### PR TITLE
Decouple transition logic from cell handlers

### DIFF
--- a/examples/user_onboarding/README.md
+++ b/examples/user_onboarding/README.md
@@ -63,7 +63,7 @@ graph LR
     err -->|done| stop
 ```
 
-Each box is a **cell** — an isolated unit with a defined handler, input/output schema, and declared transitions. The manifests (`resources/workflows/*.edn`) are the single source of truth for schemas and wiring.
+Each box is a **cell** — an isolated unit with a defined handler and input/output schema. The manifests (`resources/workflows/*.edn`) are the single source of truth for schemas, edges, and dispatch predicates.
 
 ## Project Structure
 
@@ -113,8 +113,8 @@ user_onboarding/
 
 ## How It Works
 
-1. **Cells** (`src/app/cells/`) define handlers and transitions via `defcell` — no schemas here.
-2. **Manifests** (`resources/workflows/*.edn`) declare schemas, edges, and wiring for each cell.
+1. **Cells** (`src/app/cells/`) define handlers via `defmethod cell/cell-spec` — pure data transformations, no routing logic.
+2. **Manifests** (`resources/workflows/*.edn`) declare schemas, edges, and dispatch predicates for each cell.
 3. **Workflow loaders** (`src/app/workflows/`) load manifests and call `manifest->workflow`, which attaches schemas to registered cells and produces compilable workflow definitions.
 4. **Routes** (`src/app/routes.clj`) bridge HTTP requests into workflows. JSON API routes use Muuntaja for content negotiation. HTML routes use a generic `html-handler` that maps workflow results to Ring responses.
 5. **Integrant** (`src/app/core.clj`) manages the system lifecycle: database, migrations, handler, and Jetty server.

--- a/examples/user_onboarding/resources/workflows/dashboard.edn
+++ b/examples/user_onboarding/resources/workflows/dashboard.edn
@@ -13,8 +13,7 @@
                        :failure [:map
                                   [:error-type :keyword]
                                   [:error-message :string]]}}
-   :requires []
-   :transitions #{:success :failure}}
+   :requires []}
 
   :validate-session
   {:id       :auth/validate-session
@@ -28,8 +27,7 @@
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
                                        [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:authorized :unauthorized}}
+   :requires [:db]}
 
   :fetch-profile
   {:id       :user/fetch-profile
@@ -42,8 +40,7 @@
                        :not-found [:map
                                     [:error-type :keyword]
                                     [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:found :not-found}}
+   :requires [:db]}
 
   :render-dashboard
   {:id       :ui/render-dashboard
@@ -54,8 +51,7 @@
                           [:email :string]]]]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}
+   :requires []}
 
   :render-error
   {:id       :ui/render-error
@@ -64,8 +60,7 @@
               :output [:map
                         [:html :string]
                         [:error-status :int]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
  {:start            {:success :validate-session
@@ -75,4 +70,14 @@
   :fetch-profile    {:found     :render-dashboard
                      :not-found :render-error}
   :render-dashboard {:done :end}
-  :render-error     {:done :end}}}
+  :render-error     {:done :end}}
+
+ :dispatches
+ {:start            {:success (fn [data] (:auth-token data))
+                     :failure (fn [data] (:error-type data))}
+  :validate-session {:authorized   (fn [data] (:session-valid data))
+                     :unauthorized (fn [data] (not (:session-valid data)))}
+  :fetch-profile    {:found     (fn [data] (:profile data))
+                     :not-found (fn [data] (:error-type data))}
+  :render-dashboard {:done (fn [_] true)}
+  :render-error     {:done (fn [_] true)}}}

--- a/examples/user_onboarding/resources/workflows/home.edn
+++ b/examples/user_onboarding/resources/workflows/home.edn
@@ -11,8 +11,7 @@
               :output {:success [:map
                                   [:auth-token :string]]
                        :failure [:map]}}
-   :requires []
-   :transitions #{:success :failure}}
+   :requires []}
 
   :validate-session
   {:id       :auth/validate-session
@@ -26,8 +25,7 @@
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
                                        [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:authorized :unauthorized}}
+   :requires [:db]}
 
   :fetch-profile
   {:id       :user/fetch-profile
@@ -40,8 +38,7 @@
                        :not-found [:map
                                     [:error-type :keyword]
                                     [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:found :not-found}}
+   :requires [:db]}
 
   :render-dashboard
   {:id       :ui/render-dashboard
@@ -52,8 +49,7 @@
                           [:email :string]]]]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}
+   :requires []}
 
   :render-login
   {:id       :ui/render-login-page
@@ -61,8 +57,7 @@
    :schema   {:input  [:map]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
  {:start            {:success :validate-session
@@ -72,4 +67,14 @@
   :fetch-profile    {:found     :render-dashboard
                      :not-found :render-login}
   :render-dashboard {:done :end}
-  :render-login     {:done :end}}}
+  :render-login     {:done :end}}
+
+ :dispatches
+ {:start            {:success (fn [data] (:auth-token data))
+                     :failure (fn [data] (not (:auth-token data)))}
+  :validate-session {:authorized   (fn [data] (:session-valid data))
+                     :unauthorized (fn [data] (not (:session-valid data)))}
+  :fetch-profile    {:found     (fn [data] (:profile data))
+                     :not-found (fn [data] (:error-type data))}
+  :render-dashboard {:done (fn [_] true)}
+  :render-login     {:done (fn [_] true)}}}

--- a/examples/user_onboarding/resources/workflows/login-page.edn
+++ b/examples/user_onboarding/resources/workflows/login-page.edn
@@ -8,8 +8,10 @@
    :schema   {:input  [:map]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
- {:start {:done :end}}}
+ {:start {:done :end}}
+
+ :dispatches
+ {:start {:done (fn [_] true)}}}

--- a/examples/user_onboarding/resources/workflows/login-submit.edn
+++ b/examples/user_onboarding/resources/workflows/login-submit.edn
@@ -15,8 +15,7 @@
                        :failure [:map
                                   [:error-type :keyword]
                                   [:error-message :string]]}}
-   :requires []
-   :transitions #{:success :failure}}
+   :requires []}
 
   :validate-session
   {:id       :auth/validate-session
@@ -31,8 +30,7 @@
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
                                        [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:authorized :unauthorized}}
+   :requires [:db]}
 
   :fetch-profile
   {:id       :user/fetch-profile
@@ -45,8 +43,7 @@
                        :not-found [:map
                                     [:error-type :keyword]
                                     [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:found :not-found}}
+   :requires [:db]}
 
   :render-dashboard
   {:id       :ui/render-dashboard
@@ -57,8 +54,7 @@
                           [:email :string]]]]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}
+   :requires []}
 
   :render-error
   {:id       :ui/render-error
@@ -67,8 +63,7 @@
               :output [:map
                         [:html :string]
                         [:error-status :int]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
  {:start            {:success :validate-session
@@ -78,4 +73,14 @@
   :fetch-profile    {:found     :render-dashboard
                      :not-found :render-error}
   :render-dashboard {:done :end}
-  :render-error     {:done :end}}}
+  :render-error     {:done :end}}
+
+ :dispatches
+ {:start            {:success (fn [data] (:auth-token data))
+                     :failure (fn [data] (:error-type data))}
+  :validate-session {:authorized   (fn [data] (:session-valid data))
+                     :unauthorized (fn [data] (not (:session-valid data)))}
+  :fetch-profile    {:found     (fn [data] (:profile data))
+                     :not-found (fn [data] (:error-type data))}
+  :render-dashboard {:done (fn [_] true)}
+  :render-error     {:done (fn [_] true)}}}

--- a/examples/user_onboarding/resources/workflows/user-list.edn
+++ b/examples/user_onboarding/resources/workflows/user-list.edn
@@ -11,8 +11,7 @@
                           [:id :string]
                           [:name :string]
                           [:email :string]]]]]}
-   :requires [:db]
-   :transitions #{:done}}
+   :requires [:db]}
 
   :render-list
   {:id       :ui/render-user-list
@@ -24,9 +23,12 @@
                           [:email :string]]]]]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
  {:start       {:done :render-list}
-  :render-list {:done :end}}}
+  :render-list {:done :end}}
+
+ :dispatches
+ {:start       {:done (fn [_] true)}
+  :render-list {:done (fn [_] true)}}}

--- a/examples/user_onboarding/resources/workflows/user-onboarding.edn
+++ b/examples/user_onboarding/resources/workflows/user-onboarding.edn
@@ -15,8 +15,7 @@
                        :failure [:map
                                   [:error-type :keyword]
                                   [:error-message :string]]}}
-   :requires []
-   :transitions #{:success :failure}}
+   :requires []}
 
   :validate-session
   {:id       :auth/validate-session
@@ -31,8 +30,7 @@
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
                                        [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:authorized :unauthorized}}
+   :requires [:db]}
 
   :fetch-profile
   {:id       :user/fetch-profile
@@ -47,8 +45,7 @@
                        :not-found [:map
                                     [:error-type :keyword]
                                     [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:found :not-found}}
+   :requires [:db]}
 
   :render-home
   {:id       :ui/render-home
@@ -61,8 +58,7 @@
                         [:http-response [:map
                           [:status :int]
                           [:body map?]]]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
  {:start            {:success :validate-session
@@ -71,4 +67,13 @@
                      :unauthorized :error}
   :fetch-profile    {:found     :render-home
                      :not-found :error}
-  :render-home      {:done :end}}}
+  :render-home      {:done :end}}
+
+ :dispatches
+ {:start            {:success (fn [data] (:auth-token data))
+                     :failure (fn [data] (:error-type data))}
+  :validate-session {:authorized   (fn [data] (:session-valid data))
+                     :unauthorized (fn [data] (not (:session-valid data)))}
+  :fetch-profile    {:found     (fn [data] (:profile data))
+                     :not-found (fn [data] (:error-type data))}
+  :render-home      {:done (fn [_] true)}}}

--- a/examples/user_onboarding/resources/workflows/user-profile.edn
+++ b/examples/user_onboarding/resources/workflows/user-profile.edn
@@ -14,8 +14,7 @@
                        :not-found [:map
                                     [:error-type :keyword]
                                     [:error-message :string]]}}
-   :requires [:db]
-   :transitions #{:found :not-found}}
+   :requires [:db]}
 
   :render-profile
   {:id       :ui/render-user-profile
@@ -27,8 +26,7 @@
                           [:email :string]]]]
               :output [:map
                         [:html :string]]}
-   :requires []
-   :transitions #{:done}}
+   :requires []}
 
   :render-error
   {:id       :ui/render-error
@@ -37,11 +35,16 @@
               :output [:map
                         [:html :string]
                         [:error-status :int]]}
-   :requires []
-   :transitions #{:done}}}
+   :requires []}}
 
  :edges
  {:start          {:found     :render-profile
                    :not-found :render-error}
   :render-profile {:done :end}
-  :render-error   {:done :end}}}
+  :render-error   {:done :end}}
+
+ :dispatches
+ {:start          {:found     (fn [data] (:profile data))
+                   :not-found (fn [data] (:error-type data))}
+  :render-profile {:done (fn [_] true)}
+  :render-error   {:done (fn [_] true)}}}

--- a/examples/user_onboarding/src/app/cells/auth.clj
+++ b/examples/user_onboarding/src/app/cells/auth.clj
@@ -13,12 +13,10 @@
                 (if (and user-id token)
                   (assoc data
                          :user-id    user-id
-                         :auth-token token
-                         :mycelium/transition :success)
+                         :auth-token token)
                   (assoc data
                          :error-type    :bad-request
-                         :error-message "Missing username or token"
-                         :mycelium/transition :failure))))})
+                         :error-message "Missing username or token"))))})
 
 (defmethod cell/cell-spec :auth/validate-session [_]
   {:id      :auth/validate-session
@@ -29,13 +27,11 @@
                 (if valid?
                   (assoc data
                          :user-id    (:user_id session)
-                         :session-valid true
-                         :mycelium/transition :authorized)
+                         :session-valid true)
                   (assoc data
                          :session-valid  false
                          :error-type     :unauthorized
-                         :error-message  "Invalid or expired session token"
-                         :mycelium/transition :unauthorized))))})
+                         :error-message  "Invalid or expired session token"))))})
 
 (defmethod cell/cell-spec :auth/extract-session [_]
   {:id      :auth/extract-session
@@ -44,13 +40,10 @@
               (let [qp    (get-in data [:http-request :query-params])
                     token (or (get qp :token) (get qp "token"))]
                 (if token
-                  (assoc data
-                         :auth-token token
-                         :mycelium/transition :success)
+                  (assoc data :auth-token token)
                   (assoc data
                          :error-type    :unauthorized
-                         :error-message "No session token provided"
-                         :mycelium/transition :failure))))})
+                         :error-message "No session token provided"))))})
 
 (defmethod cell/cell-spec :auth/extract-cookie-session [_]
   {:id      :auth/extract-cookie-session
@@ -58,8 +51,5 @@
    :handler (fn [_resources data]
               (let [token (get-in data [:http-request :cookies "session-token" :value])]
                 (if token
-                  (assoc data
-                         :auth-token token
-                         :mycelium/transition :success)
-                  (assoc data
-                         :mycelium/transition :failure))))})
+                  (assoc data :auth-token token)
+                  data)))})

--- a/examples/user_onboarding/src/app/cells/ui.clj
+++ b/examples/user_onboarding/src/app/cells/ui.clj
@@ -10,16 +10,13 @@
                 (assoc data
                        :http-response {:status 200
                                        :body   {:message (str "Welcome, " name "!")
-                                                :profile {:name name :email email}}}
-                       :mycelium/transition :done)))})
+                                                :profile {:name name :email email}}})))})
 
 (defmethod cell/cell-spec :ui/render-login-page [_]
   {:id      :ui/render-login-page
    :doc     "Render the login form page"
    :handler (fn [_resources data]
-              (assoc data
-                     :html (selmer/render-file "templates/login.html" {})
-                     :mycelium/transition :done))})
+              (assoc data :html (selmer/render-file "templates/login.html" {})))})
 
 (defmethod cell/cell-spec :ui/render-dashboard [_]
   {:id      :ui/render-dashboard
@@ -30,8 +27,7 @@
                        :html (selmer/render-file "templates/dashboard.html"
                                                  {:name    name
                                                   :email   email
-                                                  :user-id (:user-id data)})
-                       :mycelium/transition :done)))})
+                                                  :user-id (:user-id data)}))))})
 
 (defmethod cell/cell-spec :ui/render-error [_]
   {:id      :ui/render-error
@@ -53,8 +49,7 @@
                                                  {:status  status
                                                   :title   title
                                                   :message (:error-message data "An unexpected error occurred")})
-                       :error-status status
-                       :mycelium/transition :done)))})
+                       :error-status status)))})
 
 (defmethod cell/cell-spec :ui/render-user-list [_]
   {:id      :ui/render-user-list
@@ -62,8 +57,7 @@
    :handler (fn [_resources data]
               (assoc data
                      :html (selmer/render-file "templates/users.html"
-                                               {:users (:users data)})
-                     :mycelium/transition :done))})
+                                               {:users (:users data)})))})
 
 (defmethod cell/cell-spec :ui/render-user-profile [_]
   {:id      :ui/render-user-profile
@@ -71,5 +65,4 @@
    :handler (fn [_resources data]
               (let [profile (:profile data)]
                 (assoc data
-                       :html (selmer/render-file "templates/profile.html" profile)
-                       :mycelium/transition :done)))})
+                       :html (selmer/render-file "templates/profile.html" profile))))})

--- a/examples/user_onboarding/src/app/cells/user.clj
+++ b/examples/user_onboarding/src/app/cells/user.clj
@@ -8,22 +8,17 @@
    :handler (fn [{:keys [db]} data]
               (let [user (db/get-user db (:user-id data))]
                 (if user
-                  (assoc data
-                         :profile (select-keys user [:name :email])
-                         :mycelium/transition :found)
+                  (assoc data :profile (select-keys user [:name :email]))
                   (assoc data
                          :error-type    :not-found
-                         :error-message (str "User not found: " (:user-id data))
-                         :mycelium/transition :not-found))))})
+                         :error-message (str "User not found: " (:user-id data))))))})
 
 (defmethod cell/cell-spec :user/fetch-all-users [_]
   {:id      :user/fetch-all-users
    :doc     "Fetch all users from the database"
    :handler (fn [{:keys [db]} data]
               (let [users (db/get-all-users db)]
-                (assoc data
-                       :users (vec users)
-                       :mycelium/transition :done)))})
+                (assoc data :users (vec users))))})
 
 (defmethod cell/cell-spec :user/fetch-profile-by-id [_]
   {:id      :user/fetch-profile-by-id
@@ -32,10 +27,7 @@
               (let [user-id (get-in data [:http-request :path-params :id])
                     user    (when user-id (db/get-user db user-id))]
                 (if user
-                  (assoc data
-                         :profile user
-                         :mycelium/transition :found)
+                  (assoc data :profile user)
                   (assoc data
                          :error-type    :not-found
-                         :error-message (str "User not found: " user-id)
-                         :mycelium/transition :not-found))))})
+                         :error-message (str "User not found: " user-id)))))})

--- a/examples/user_onboarding/src/app/middleware.clj
+++ b/examples/user_onboarding/src/app/middleware.clj
@@ -4,11 +4,10 @@
 (defn logging-interceptor
   "Maestro post-interceptor that logs cell transitions."
   [fsm-state _resources]
-  (let [last-state (:last-state-id fsm-state)
-        data       (:data fsm-state)
-        transition (:mycelium/transition data)]
-    (when (and last-state transition)
-      (println (str "[workflow] " last-state " → " transition)))
+  (let [last-state    (:last-state-id fsm-state)
+        current-state (:current-state-id fsm-state)]
+    (when last-state
+      (println (str "[workflow] " last-state " → " current-state)))
     fsm-state))
 
 (def workflow-opts

--- a/test/mycelium/cell_test.clj
+++ b/test/mycelium/cell_test.clj
@@ -10,8 +10,7 @@
       {:id          :test/valid-cell
        :handler     (fn [_resources data] data)
        :schema      {:input  [:map [:x :int]]
-                     :output [:map [:y :int]]}
-       :transitions #{:success :failure}})
+                     :output [:map [:y :int]]}})
     (is (= :test/valid-cell (:id (cell/get-cell :test/valid-cell))))))
 
 (deftest defmethod-cell-test
@@ -19,14 +18,13 @@
     (defmethod cell/cell-spec :test/macro-cell [_]
       {:id          :test/macro-cell
        :doc         "A test cell"
-       :transitions #{:ok}
        :handler     (fn [_resources data]
-                      (assoc data :b (* 2 (:a data)) :mycelium/transition :ok))})
+                      (assoc data :b (* 2 (:a data))))})
     (let [spec (cell/get-cell :test/macro-cell)]
       (is (some? spec))
       (is (= :test/macro-cell (:id spec)))
       (is (nil? (:schema spec)))
-      (is (= {:b 10 :a 5 :mycelium/transition :ok}
+      (is (= {:b 10 :a 5}
              ((:handler spec) {} {:a 5}))))))
 
 (deftest defmethod-async-test
@@ -34,15 +32,14 @@
     (defmethod cell/cell-spec :test/async-cell [_]
       {:id          :test/async-cell
        :doc         "An async cell"
-       :transitions #{:done}
        :async?      true
        :handler     (fn [_resources data callback _error-callback]
-                      (callback (assoc data :y (inc (:x data)) :mycelium/transition :done)))})
+                      (callback (assoc data :y (inc (:x data)))))})
     (let [spec    (cell/get-cell :test/async-cell)
           result  (promise)]
       (is (:async? spec))
       ((:handler spec) {} {:x 41} #(deliver result %) identity)
-      (is (= {:x 41 :y 42 :mycelium/transition :done} @result)))))
+      (is (= {:x 41 :y 42} @result)))))
 
 (deftest get-cell-bang-throws-test
   (testing "get-cell! throws on missing ID"
@@ -55,8 +52,7 @@
       {:id          :test/with-schema
        :handler     (fn [_ d] d)
        :schema      {:input  [:map [:x :int]]
-                     :output [:map [:y :int]]}
-       :transitions #{:done}})
+                     :output [:map [:y :int]]}})
     (let [spec (cell/get-cell :test/with-schema)]
       (is (some? spec))
       (is (= [:map [:x :int]] (get-in spec [:schema :input])))
@@ -66,8 +62,7 @@
   (testing "Cell can be registered without schema"
     (defmethod cell/cell-spec :test/no-schema [_]
       {:id          :test/no-schema
-       :handler     (fn [_ d] d)
-       :transitions #{:done}})
+       :handler     (fn [_ d] d)})
     (let [spec (cell/get-cell :test/no-schema)]
       (is (some? spec))
       (is (nil? (:schema spec))))))
@@ -76,8 +71,7 @@
   (testing "set-cell-schema! attaches schema to existing cell"
     (defmethod cell/cell-spec :test/schema-later [_]
       {:id          :test/schema-later
-       :handler     (fn [_ d] d)
-       :transitions #{:done}})
+       :handler     (fn [_ d] d)})
     (cell/set-cell-schema! :test/schema-later
                            {:input  [:map [:x :int]]
                             :output [:map [:y :int]]})
@@ -94,8 +88,7 @@
   (testing "set-cell-schema! throws on invalid Malli schema"
     (defmethod cell/cell-spec :test/bad-schema-later [_]
       {:id          :test/bad-schema-later
-       :handler     (fn [_ d] d)
-       :transitions #{:done}})
+       :handler     (fn [_ d] d)})
     (is (thrown? Exception
           (cell/set-cell-schema! :test/bad-schema-later
                                 {:input  [:not-a-real-schema-type]
@@ -110,8 +103,7 @@
        :handler     (fn [_ d] d)
        :schema      {:input  [:map [:x :int]]
                      :output {:found     [:map [:profile :map]]
-                              :not-found [:map [:error-message :string]]}}
-       :transitions #{:found :not-found}})
+                              :not-found [:map [:error-message :string]]}}})
     (let [spec (cell/get-cell :test/map-out)]
       (is (map? (get-in spec [:schema :output])))
       (is (= #{:found :not-found} (set (keys (get-in spec [:schema :output]))))))))
@@ -122,8 +114,7 @@
   (testing "set-cell-schema! accepts map format"
     (defmethod cell/cell-spec :test/set-map-out [_]
       {:id          :test/set-map-out
-       :handler     (fn [_ d] d)
-       :transitions #{:found :not-found}})
+       :handler     (fn [_ d] d)})
     (cell/set-cell-schema! :test/set-map-out
                            {:input  [:map [:x :int]]
                             :output {:found     [:map [:profile :map]]
@@ -135,8 +126,7 @@
   (testing "Re-defining via defmethod does NOT clear overrides (they persist until clear-registry!)"
     (defmethod cell/cell-spec :test/override-persist [_]
       {:id          :test/override-persist
-       :handler     (fn [_ d] d)
-       :transitions #{:done}})
+       :handler     (fn [_ d] d)})
     (cell/set-cell-schema! :test/override-persist
                            {:input  [:map [:x :int]]
                             :output [:map [:y :int]]})
@@ -144,8 +134,7 @@
     ;; Re-define via defmethod — overrides should persist
     (defmethod cell/cell-spec :test/override-persist [_]
       {:id          :test/override-persist
-       :handler     (fn [_ d] d)
-       :transitions #{:done}})
+       :handler     (fn [_ d] d)})
     (is (some? (:schema (cell/get-cell :test/override-persist))))
     ;; clear-registry! clears overrides
     (cell/clear-registry!)
@@ -154,29 +143,29 @@
 ;; ===== set-cell-meta! tests =====
 
 (deftest set-cell-meta-test
-  (testing "set-cell-meta! sets schema, transitions, and requires on a cell"
+  (testing "set-cell-meta! sets schema and requires on a cell"
     (defmethod cell/cell-spec :test/meta-cell [_]
       {:id      :test/meta-cell
        :handler (fn [_ d] d)})
     (cell/set-cell-meta! :test/meta-cell
                          {:schema      {:input  [:map [:x :int]]
                                         :output [:map [:y :int]]}
-                          :transitions #{:done}
                           :requires    [:db]})
     (let [spec (cell/get-cell :test/meta-cell)]
       (is (= [:map [:x :int]] (get-in spec [:schema :input])))
       (is (= [:map [:y :int]] (get-in spec [:schema :output])))
-      (is (= #{:done} (:transitions spec)))
       (is (= [:db] (:requires spec))))))
 
-(deftest set-cell-meta-validates-transitions-test
-  (testing "set-cell-meta! rejects empty transitions"
-    (defmethod cell/cell-spec :test/meta-bad-trans [_]
-      {:id      :test/meta-bad-trans
+(deftest set-cell-meta-without-transitions-test
+  (testing "set-cell-meta! works without :transitions (transitions are now optional)"
+    (defmethod cell/cell-spec :test/meta-no-trans [_]
+      {:id      :test/meta-no-trans
        :handler (fn [_ d] d)})
-    (is (thrown-with-msg? Exception #"transitions"
-          (cell/set-cell-meta! :test/meta-bad-trans
-                               {:transitions #{}})))))
+    (cell/set-cell-meta! :test/meta-no-trans
+                         {:schema {:input  [:map [:x :int]]
+                                   :output [:map [:y :int]]}})
+    (let [spec (cell/get-cell :test/meta-no-trans)]
+      (is (some? (:schema spec))))))
 
 (deftest set-cell-meta-validates-schema-test
   (testing "set-cell-meta! rejects invalid Malli schema"
@@ -186,5 +175,16 @@
     (is (thrown? Exception
           (cell/set-cell-meta! :test/meta-bad-schema
                                {:schema {:input [:not-a-real-schema-type]
-                                         :output [:map [:y :int]]}
-                                :transitions #{:done}})))))
+                                         :output [:map [:y :int]]}})))))
+
+;; ===== Cell without :transitions registers fine =====
+
+(deftest cell-without-transitions-test
+  (testing "Cell can be registered without :transitions"
+    (defmethod cell/cell-spec :test/no-trans [_]
+      {:id      :test/no-trans
+       :handler (fn [_ d] d)
+       :schema  {:input [:map] :output [:map]}})
+    (let [spec (cell/get-cell :test/no-trans)]
+      (is (some? spec))
+      (is (nil? (:transitions spec))))))

--- a/test/mycelium/compose_test.clj
+++ b/test/mycelium/compose_test.clj
@@ -10,23 +10,23 @@
 ;; ===== 1. workflow->cell produces valid cell spec =====
 
 (deftest workflow-to-cell-produces-valid-spec-test
-  (testing "workflow->cell produces valid cell spec with :success/:failure transitions"
+  (testing "workflow->cell produces valid cell spec with :default-dispatches"
     (defmethod cell/cell-spec :comp/step1 [_]
       {:id          :comp/step1
        :handler     (fn [_ data]
-                      (assoc data :y (* 2 (:x data)) :mycelium/transition :done))
+                      (assoc data :y (* 2 (:x data))))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:y :int]]}
-       :transitions #{:done}})
+                     :output [:map [:y :int]]}})
 
     (let [child-workflow {:cells {:start :comp/step1}
-                          :edges {:start {:done :end}}}
+                          :edges {:start {:done :end}}
+                          :dispatches {:start {:done (constantly true)}}}
           cell-spec (compose/workflow->cell :comp/child child-workflow
                                            {:input [:map [:x :int]]
                                             :output [:map [:y :int]]})]
       (is (= :comp/child (:id cell-spec)))
       (is (fn? (:handler cell-spec)))
-      (is (= #{:success :failure} (:transitions cell-spec)))
+      (is (some? (:default-dispatches cell-spec)))
       (is (some? (:schema cell-spec))))))
 
 ;; ===== 2. Child workflow runs inside parent =====
@@ -36,13 +36,13 @@
     (defmethod cell/cell-spec :comp/doubler [_]
       {:id          :comp/doubler
        :handler     (fn [_ data]
-                      (assoc data :doubled (* 2 (:x data)) :mycelium/transition :done))
+                      (assoc data :doubled (* 2 (:x data))))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:doubled :int]]}
-       :transitions #{:done}})
+                     :output [:map [:doubled :int]]}})
 
     (let [child-workflow {:cells {:start :comp/doubler}
-                          :edges {:start {:done :end}}}]
+                          :edges {:start {:done :end}}
+                          :dispatches {:start {:done (constantly true)}}}]
       ;; Register the child workflow as a cell
       (compose/register-workflow-cell! :comp/child-wf child-workflow
                                        {:input [:map [:x :int]]
@@ -52,33 +52,35 @@
       (defmethod cell/cell-spec :comp/setup [_]
         {:id          :comp/setup
          :handler     (fn [_ data]
-                        (assoc data :x (:raw data) :mycelium/transition :next))
+                        (assoc data :x (:raw data)))
          :schema      {:input [:map [:raw :int]]
-                       :output [:map [:x :int]]}
-         :transitions #{:next}})
+                       :output [:map [:x :int]]}})
 
       (let [parent (wf/compile-workflow
                     {:cells {:start :comp/setup
                              :child :comp/child-wf}
                      :edges {:start {:next :child}
-                             :child {:success :end, :failure :error}}})
+                             :child {:success :end, :failure :error}}
+                     :dispatches {:start {:next (constantly true)}
+                                  :child {:success (fn [d] (not (:mycelium/error d)))
+                                          :failure (fn [d] (some? (:mycelium/error d)))}}})
             result (fsm/run parent {} {:data {:raw 21}})]
         (is (= 42 (:doubled result)))))))
 
-;; ===== 3. Child failure propagates as parent :failure transition =====
+;; ===== 3. Child failure propagates as parent :failure =====
 
 (deftest child-failure-propagates-test
-  (testing "Child failure propagates as parent :failure transition"
+  (testing "Child failure propagates — parent dispatch routes via :mycelium/error"
     (defmethod cell/cell-spec :comp/failing-cell [_]
       {:id          :comp/failing-cell
        :handler     (fn [_ _data]
                       (throw (Exception. "intentional failure")))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:y :int]]}
-       :transitions #{:done}})
+                     :output [:map [:y :int]]}})
 
     (let [child-workflow {:cells {:start :comp/failing-cell}
-                          :edges {:start {:done :end}}}]
+                          :edges {:start {:done :end}}
+                          :dispatches {:start {:done (constantly true)}}}]
       (compose/register-workflow-cell! :comp/failing-wf child-workflow
                                        {:input [:map [:x :int]]
                                         :output [:map [:y :int]]})
@@ -86,16 +88,18 @@
       (defmethod cell/cell-spec :comp/error-handler [_]
         {:id          :comp/error-handler
          :handler     (fn [_ data]
-                        (assoc data :error-handled true :mycelium/transition :done))
+                        (assoc data :error-handled true))
          :schema      {:input [:map]
-                       :output [:map [:error-handled :boolean]]}
-         :transitions #{:done}})
+                       :output [:map [:error-handled :boolean]]}})
 
       (let [parent (wf/compile-workflow
                     {:cells {:start  :comp/failing-wf
                              :handle :comp/error-handler}
                      :edges {:start  {:success :end, :failure :handle}
-                             :handle {:done :end}}})
+                             :handle {:done :end}}
+                     :dispatches {:start  {:success (fn [d] (not (:mycelium/error d)))
+                                           :failure (fn [d] (some? (:mycelium/error d)))}
+                                  :handle {:done (constantly true)}}})
             result (fsm/run parent {} {:data {:x 1}})]
         (is (= true (:error-handled result)))))))
 
@@ -106,21 +110,23 @@
     (defmethod cell/cell-spec :comp/adder [_]
       {:id          :comp/adder
        :handler     (fn [_ data]
-                      (assoc data :n (+ (:n data) 10) :mycelium/transition :done))
+                      (assoc data :n (+ (:n data) 10)))
        :schema      {:input [:map [:n :int]]
-                     :output [:map [:n :int]]}
-       :transitions #{:done}})
+                     :output [:map [:n :int]]}})
 
     ;; Grandchild workflow
     (let [grandchild-wf {:cells {:start :comp/adder}
-                         :edges {:start {:done :end}}}]
+                         :edges {:start {:done :end}}
+                         :dispatches {:start {:done (constantly true)}}}]
       (compose/register-workflow-cell! :comp/grandchild grandchild-wf
                                        {:input [:map [:n :int]]
                                         :output [:map [:n :int]]})
 
       ;; Child workflow containing grandchild
       (let [child-wf {:cells {:start :comp/grandchild}
-                      :edges {:start {:success :end, :failure :error}}}]
+                      :edges {:start {:success :end, :failure :error}}
+                      :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
+                                           :failure (fn [d] (some? (:mycelium/error d)))}}}]
         (compose/register-workflow-cell! :comp/child-nested child-wf
                                          {:input [:map [:n :int]]
                                           :output [:map [:n :int]]})
@@ -128,7 +134,9 @@
         ;; Parent workflow containing child
         (let [parent (wf/compile-workflow
                       {:cells {:start :comp/child-nested}
-                       :edges {:start {:success :end, :failure :error}}})
+                       :edges {:start {:success :end, :failure :error}}
+                       :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
+                                            :failure (fn [d] (some? (:mycelium/error d)))}}})
               result (fsm/run parent {} {:data {:n 0}})]
           (is (= 10 (:n result))))))))
 
@@ -138,21 +146,22 @@
   (testing "Child trace preserved in output data"
     (defmethod cell/cell-spec :comp/traced [_]
       {:id          :comp/traced
-       :handler     (fn [_ data]
-                      (assoc data :mycelium/transition :done))
+       :handler     (fn [_ data] data)
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:x :int]]}
-       :transitions #{:done}})
+                     :output [:map [:x :int]]}})
 
     (let [child-wf {:cells {:start :comp/traced}
-                    :edges {:start {:done :end}}}]
+                    :edges {:start {:done :end}}
+                    :dispatches {:start {:done (constantly true)}}}]
       (compose/register-workflow-cell! :comp/traced-wf child-wf
                                        {:input [:map [:x :int]]
                                         :output [:map [:x :int]]})
 
       (let [parent (wf/compile-workflow
                     {:cells {:start :comp/traced-wf}
-                     :edges {:start {:success :end, :failure :error}}})
+                     :edges {:start {:success :end, :failure :error}}
+                     :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
+                                          :failure (fn [d] (some? (:mycelium/error d)))}}})
             result (fsm/run parent {} {:data {:x 1}})]
         (is (vector? (:mycelium/child-trace result)))))))
 
@@ -163,21 +172,23 @@
     (defmethod cell/cell-spec :comp/resource-user [_]
       {:id          :comp/resource-user
        :handler     (fn [{:keys [config]} data]
-                      (assoc data :from-config (:value config) :mycelium/transition :done))
+                      (assoc data :from-config (:value config)))
        :schema      {:input [:map [:x :int]]
                      :output [:map [:from-config :string]]}
-       :transitions #{:done}
        :requires    [:config]})
 
     (let [child-wf {:cells {:start :comp/resource-user}
-                    :edges {:start {:done :end}}}]
+                    :edges {:start {:done :end}}
+                    :dispatches {:start {:done (constantly true)}}}]
       (compose/register-workflow-cell! :comp/resource-wf child-wf
                                        {:input [:map [:x :int]]
                                         :output [:map [:from-config :string]]})
 
       (let [parent    (wf/compile-workflow
                        {:cells {:start :comp/resource-wf}
-                        :edges {:start {:success :end, :failure :error}}})
+                        :edges {:start {:success :end, :failure :error}}
+                        :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
+                                             :failure (fn [d] (some? (:mycelium/error d)))}}})
             resources {:config {:value "from-parent"}}
             result    (fsm/run parent resources {:data {:x 1}})]
         (is (= "from-parent" (:from-config result)))))))
@@ -189,14 +200,14 @@
     (defmethod cell/cell-spec :comp/counter-cell [_]
       {:id          :comp/counter-cell
        :handler     (fn [_ data]
-                      (assoc data :n (inc (:n data)) :mycelium/transition :done))
+                      (assoc data :n (inc (:n data))))
        :schema      {:input [:map [:n :int]]
-                     :output [:map [:n :int]]}
-       :transitions #{:done}})
+                     :output [:map [:n :int]]}})
 
     (let [compile-count (atom 0)
           child-wf      {:cells {:start :comp/counter-cell}
-                         :edges {:start {:done :end}}}]
+                         :edges {:start {:done :end}}
+                         :dispatches {:start {:done (constantly true)}}}]
       (with-redefs [wf/compile-workflow (let [orig wf/compile-workflow]
                                           (fn [& args]
                                             (swap! compile-count inc)
@@ -212,3 +223,25 @@
           (handler {} {:n 10})
           (handler {} {:n 20})
           (is (= 1 @compile-count)))))))
+
+;; ===== 8. default-dispatches are provided by workflow->cell =====
+
+(deftest default-dispatches-test
+  (testing "workflow->cell provides :default-dispatches for success/failure routing"
+    (defmethod cell/cell-spec :comp/simple [_]
+      {:id :comp/simple
+       :handler (fn [_ data] (assoc data :done true))
+       :schema {:input [:map] :output [:map [:done :boolean]]}})
+
+    (let [child-wf {:cells {:start :comp/simple}
+                    :edges {:start {:done :end}}
+                    :dispatches {:start {:done (constantly true)}}}
+          spec (compose/workflow->cell :comp/def-disp child-wf
+                                      {:input [:map] :output [:map [:done :boolean]]})]
+      (is (map? (:default-dispatches spec)))
+      (is (contains? (:default-dispatches spec) :success))
+      (is (contains? (:default-dispatches spec) :failure))
+      ;; :success dispatch should return truthy for data without :mycelium/error
+      (is ((:success (:default-dispatches spec)) {:done true}))
+      ;; :failure dispatch should return truthy for data with :mycelium/error
+      (is ((:failure (:default-dispatches spec)) {:mycelium/error "boom"})))))

--- a/test/mycelium/core_test.clj
+++ b/test/mycelium/core_test.clj
@@ -12,14 +12,14 @@
     (defmethod cell/cell-spec :core/adder [_]
       {:id          :core/adder
        :handler     (fn [_ data]
-                      (assoc data :result (+ (:x data) 100) :mycelium/transition :done))
+                      (assoc data :result (+ (:x data) 100)))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:result :int]]}
-       :transitions #{:done}})
+                     :output [:map [:result :int]]}})
 
     (let [result (mycelium/run-workflow
                   {:cells {:start :core/adder}
-                   :edges {:start {:done :end}}}
+                   :edges {:start {:done :end}}
+                   :dispatches {:start {:done (constantly true)}}}
                   {}
                   {:x 42})]
       (is (= 142 (:result result))))))

--- a/test/mycelium/integration_test.clj
+++ b/test/mycelium/integration_test.clj
@@ -13,56 +13,51 @@
     (defmethod cell/cell-spec :int/step-1 [_]
       {:id          :int/step-1
        :handler     (fn [_ data]
-                      (assoc data :a (inc (:x data)) :mycelium/transition :next))
+                      (assoc data :a (inc (:x data))))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:a :int]]}
-       :transitions #{:next}})
+                     :output [:map [:a :int]]}})
 
     (defmethod cell/cell-spec :int/step-2 [_]
       {:id          :int/step-2
        :handler     (fn [_ data]
-                      (assoc data :b (* 2 (:a data)) :mycelium/transition :done))
+                      (assoc data :b (* 2 (:a data))))
        :schema      {:input [:map [:a :int]]
-                     :output [:map [:b :int]]}
-       :transitions #{:done}})
+                     :output [:map [:b :int]]}})
 
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/step-1
                              :step2 :int/step-2}
                      :edges {:start {:next :step2}
-                             :step2 {:done :end}}})
+                             :step2 {:done :end}}
+                     :dispatches {:start {:next (constantly true)}
+                                  :step2 {:done (constantly true)}}})
           result   (fsm/run compiled {} {:data {:x 10}})]
       (is (= 11 (:a result)))
-      (is (= 22 (:b result)))
-      (is (= :done (:mycelium/transition result))))))
+      (is (= 22 (:b result))))))
 
 ;; ===== 2. Branching workflow takes correct path =====
 
 (deftest branching-workflow-test
-  (testing "Branching workflow takes correct path based on data"
+  (testing "Branching workflow takes correct path based on dispatch predicates"
     (defmethod cell/cell-spec :int/router [_]
       {:id          :int/router
-       :handler     (fn [_ data]
-                      (assoc data :mycelium/transition (if (> (:value data) 5) :high :low)))
+       :handler     (fn [_ data] data)
        :schema      {:input [:map [:value :int]]
-                     :output [:map]}
-       :transitions #{:high :low}})
+                     :output [:map]}})
 
     (defmethod cell/cell-spec :int/high-path [_]
       {:id          :int/high-path
        :handler     (fn [_ data]
-                      (assoc data :result "high" :mycelium/transition :done))
+                      (assoc data :result "high"))
        :schema      {:input [:map [:value :int]]
-                     :output [:map [:result :string]]}
-       :transitions #{:done}})
+                     :output [:map [:result :string]]}})
 
     (defmethod cell/cell-spec :int/low-path [_]
       {:id          :int/low-path
        :handler     (fn [_ data]
-                      (assoc data :result "low" :mycelium/transition :done))
+                      (assoc data :result "low"))
        :schema      {:input [:map [:value :int]]
-                     :output [:map [:result :string]]}
-       :transitions #{:done}})
+                     :output [:map [:result :string]]}})
 
     (let [compiled (wf/compile-workflow
                     {:cells {:start    :int/router
@@ -70,7 +65,11 @@
                              :low      :int/low-path}
                      :edges {:start {:high :high, :low :low}
                              :high  {:done :end}
-                             :low   {:done :end}}})]
+                             :low   {:done :end}}
+                     :dispatches {:start {:high (fn [d] (> (:value d) 5))
+                                          :low  (fn [d] (<= (:value d) 5))}
+                                  :high {:done (constantly true)}
+                                  :low  {:done (constantly true)}}})]
       (is (= "high" (:result (fsm/run compiled {} {:data {:value 10}}))))
       (is (= "low"  (:result (fsm/run compiled {} {:data {:value 2}})))))))
 
@@ -81,14 +80,14 @@
     (defmethod cell/cell-spec :int/strict-cell [_]
       {:id          :int/strict-cell
        :handler     (fn [_ data]
-                      (assoc data :greeting (str "Hello " (:name data)) :mycelium/transition :ok))
+                      (assoc data :greeting (str "Hello " (:name data))))
        :schema      {:input [:map [:name :string]]
-                     :output [:map [:greeting :string]]}
-       :transitions #{:ok}})
+                     :output [:map [:greeting :string]]}})
 
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/strict-cell}
-                     :edges {:start {:ok :end}}})]
+                     :edges {:start {:ok :end}}
+                     :dispatches {:start {:ok (constantly true)}}})]
       (is (thrown? Exception
             (fsm/run compiled {} {:data {:name 42}}))))))
 
@@ -100,14 +99,14 @@
       {:id          :int/bad-output-cell
        :handler     (fn [_ data]
                       ;; Returns :y as int instead of string - schema violation
-                      (assoc data :y 42 :mycelium/transition :ok))
+                      (assoc data :y 42))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:y :string]]}
-       :transitions #{:ok}})
+                     :output [:map [:y :string]]}})
 
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/bad-output-cell}
-                     :edges {:start {:ok :end}}})]
+                     :edges {:start {:ok :end}}
+                     :dispatches {:start {:ok (constantly true)}}})]
       (is (thrown? Exception
             (fsm/run compiled {} {:data {:x 1}}))))))
 
@@ -118,15 +117,15 @@
     (defmethod cell/cell-spec :int/will-fail [_]
       {:id          :int/will-fail
        :handler     (fn [_ data]
-                      (assoc data :y 42 :mycelium/transition :ok))
+                      (assoc data :y 42))
        :schema      {:input [:map [:x :int]]
-                     :output [:map [:y :string]]}
-       :transitions #{:ok}})
+                     :output [:map [:y :string]]}})
 
     (let [error-data (atom nil)
           compiled   (wf/compile-workflow
                       {:cells {:start :int/will-fail}
-                       :edges {:start {:ok :end}}}
+                       :edges {:start {:ok :end}}
+                       :dispatches {:start {:ok (constantly true)}}}
                       {:on-error (fn [_ fsm-state]
                                    (reset! error-data (:data fsm-state))
                                    (:data fsm-state))})]
@@ -141,17 +140,15 @@
     (defmethod cell/cell-spec :int/uses-resource [_]
       {:id          :int/uses-resource
        :handler     (fn [{:keys [config]} data]
-                      (assoc data
-                             :config-val (:api-key config)
-                             :mycelium/transition :ok))
+                      (assoc data :config-val (:api-key config)))
        :schema      {:input [:map [:x :int]]
                      :output [:map [:config-val :string]]}
-       :transitions #{:ok}
        :requires    [:config]})
 
     (let [compiled  (wf/compile-workflow
                      {:cells {:start :int/uses-resource}
-                      :edges {:start {:ok :end}}})
+                      :edges {:start {:ok :end}}
+                      :dispatches {:start {:ok (constantly true)}}})
           resources {:config {:api-key "secret-123"}}
           result    (fsm/run compiled resources {:data {:x 1}})]
       (is (= "secret-123" (:config-val result))))))
@@ -159,21 +156,19 @@
 ;; ===== 7. Looping workflow with counter =====
 
 (deftest looping-workflow-test
-  (testing "Looping workflow (cycle) works with counter"
+  (testing "Looping workflow (cycle) works with counter via dispatch predicates"
     (defmethod cell/cell-spec :int/incrementer [_]
       {:id          :int/incrementer
        :handler     (fn [_ data]
-                      (let [new-count (inc (:count data))]
-                        (assoc data
-                               :count new-count
-                               :mycelium/transition (if (>= new-count 5) :done :again))))
+                      (assoc data :count (inc (:count data))))
        :schema      {:input [:map [:count :int]]
-                     :output [:map [:count :int]]}
-       :transitions #{:again :done}})
+                     :output [:map [:count :int]]}})
 
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/incrementer}
-                     :edges {:start {:again :start, :done :end}}})
+                     :edges {:start {:again :start, :done :end}}
+                     :dispatches {:start {:again (fn [d] (< (:count d) 5))
+                                          :done  (fn [d] (>= (:count d) 5))}}})
           result   (fsm/run compiled {} {:data {:count 0}})]
       (is (= 5 (:count result))))))
 
@@ -186,14 +181,14 @@
        :handler     (fn [_ data callback _error-callback]
                       (future
                         (Thread/sleep 10)
-                        (callback (assoc data :y (* (:x data) 3) :mycelium/transition :ok))))
+                        (callback (assoc data :y (* (:x data) 3)))))
        :schema      {:input [:map [:x :int]]
                      :output [:map [:y :int]]}
-       :transitions #{:ok}
        :async?      true})
 
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/async-cell}
-                     :edges {:start {:ok :end}}})
+                     :edges {:start {:ok :end}}
+                     :dispatches {:start {:ok (constantly true)}}})
           result   (fsm/run compiled {} {:data {:x 7}})]
       (is (= 21 (:y result))))))

--- a/test/mycelium/manifest_test.clj
+++ b/test/mycelium/manifest_test.clj
@@ -13,17 +13,18 @@
             :doc      "Parse input"
             :schema   {:input  [:map [:x :int]]
                        :output [:map [:y :int]]}
-            :requires []
-            :transitions #{:success :failure}}
+            :requires []}
            :process
            {:id       :test/process
             :doc      "Process data"
             :schema   {:input  [:map [:y :int]]
                        :output [:map [:z :string]]}
-            :requires [:db]
-            :transitions #{:done}}}
+            :requires [:db]}}
    :edges {:start   {:success :process, :failure :error}
-           :process {:done :end}}})
+           :process {:done :end}}
+   :dispatches {:start   {:success (fn [data] (:y data))
+                           :failure (fn [data] (not (:y data)))}
+                :process {:done (constantly true)}}})
 
 ;; ===== 1. Valid manifest passes validation =====
 
@@ -50,25 +51,27 @@
       (is (map? (get-in brief [:examples :input])))
       (is (int? (get-in brief [:examples :input :x]))))))
 
-;; ===== 4. cell-brief prompt includes contract details =====
+;; ===== 4. cell-brief prompt does NOT mention :mycelium/transition =====
 
-(deftest cell-brief-prompt-includes-contract-test
-  (testing "cell-brief prompt includes contract details (transitions, resources, schema)"
+(deftest cell-brief-prompt-no-transition-test
+  (testing "cell-brief prompt does not mention :mycelium/transition"
     (let [brief (manifest/cell-brief valid-manifest :process)]
       (is (string? (:prompt brief)))
       (is (re-find #"process" (:prompt brief)))
-      (is (re-find #":done" (:prompt brief)))
       (is (re-find #":db" (:prompt brief)))
-      (is (re-find #":z" (:prompt brief))))))
+      (is (re-find #":z" (:prompt brief)))
+      ;; Should NOT reference :mycelium/transition
+      (is (not (re-find #"mycelium/transition" (:prompt brief)))))))
 
 ;; ===== 5. manifest->workflow produces compilable workflow def =====
 
 (deftest manifest-to-workflow-produces-compilable-def-test
-  (testing "manifest->workflow produces compilable workflow def"
+  (testing "manifest->workflow produces compilable workflow def with :dispatches"
     (let [workflow-def (manifest/manifest->workflow valid-manifest)]
       (is (map? workflow-def))
       (is (contains? workflow-def :cells))
       (is (contains? workflow-def :edges))
+      (is (contains? workflow-def :dispatches))
       ;; All cell IDs should be in the registry after manifest->workflow
       (is (some? (cell/get-cell :test/parse)))
       (is (some? (cell/get-cell :test/process))))))
@@ -76,22 +79,20 @@
 ;; ===== 6. manifest->workflow applies schema to pre-registered cells =====
 
 (deftest manifest-applies-schema-to-existing-cells-test
-  (testing "manifest->workflow applies manifest metadata to pre-registered cells (without transitions)"
-    ;; Register a cell WITHOUT :transitions — manifest is the source of truth
+  (testing "manifest->workflow applies manifest metadata to pre-registered cells"
+    ;; Register a cell WITHOUT schema — manifest is the source of truth
     (defmethod cell/cell-spec :test/parse [_]
       {:id      :test/parse
-       :handler (fn [_ data] (assoc data :y 1 :mycelium/transition :success))})
+       :handler (fn [_ data] (assoc data :y 1))})
     (is (nil? (:schema (cell/get-cell :test/parse))))
-    (is (nil? (:transitions (cell/get-cell :test/parse))))
 
-    ;; Now load the manifest — should apply schema AND transitions from manifest
+    ;; Now load the manifest — should apply schema from manifest
     (manifest/manifest->workflow valid-manifest)
 
     (let [cell (cell/get-cell :test/parse)]
       (is (some? (:schema cell)))
       (is (= [:map [:x :int]] (get-in cell [:schema :input])))
-      (is (= [:map [:y :int]] (get-in cell [:schema :output])))
-      (is (= #{:success :failure} (:transitions cell))))))
+      (is (= [:map [:y :int]] (get-in cell [:schema :output]))))))
 
 ;; ===== Per-transition output schema in manifest =====
 
@@ -104,42 +105,34 @@
             :schema   {:input  [:map [:id :string]]
                        :output {:found     [:map [:profile [:map [:name :string]]]]
                                 :not-found [:map [:error-message :string]]}}
-            :requires [:db]
-            :transitions #{:found :not-found}}
+            :requires [:db]}
            :render
            {:id       :test/render
             :doc      "Render output"
             :schema   {:input  [:map [:profile [:map [:name :string]]]]
                        :output [:map [:html :string]]}
-            :requires []
-            :transitions #{:done}}}
+            :requires []}}
    :edges {:start  {:found     :render
                     :not-found :error}
-           :render {:done :end}}})
+           :render {:done :end}}
+   :dispatches {:start  {:found     (fn [d] (:profile d))
+                          :not-found (fn [d] (:error-message d))}
+                :render {:done (constantly true)}}})
 
 (deftest per-transition-manifest-validates-test
   (testing "Manifest with per-transition output passes validation"
     (let [result (manifest/validate-manifest per-transition-manifest)]
       (is (= :test/pt-workflow (:id result))))))
 
-(deftest per-transition-manifest-key-mismatch-test
-  (testing "Output map keys / transitions mismatch → rejected"
-    (let [bad (assoc-in per-transition-manifest [:cells :start :schema :output]
-                        {:found     [:map [:profile :map]]
-                         :typo      [:map [:error :string]]})]
-      (is (thrown-with-msg? Exception #"not in transitions|missing keys"
-            (manifest/validate-manifest bad))))))
-
 (deftest cell-brief-per-transition-prompt-test
   (testing "cell-brief shows per-transition schemas in prompt"
     (let [brief (manifest/cell-brief per-transition-manifest :start)]
       (is (string? (:prompt brief)))
-      ;; Should mention both transitions
-      (is (re-find #":found" (:prompt brief)))
-      (is (re-find #":not-found" (:prompt brief)))
       ;; Should mention per-transition schema details
       (is (re-find #"profile" (:prompt brief)))
-      (is (re-find #"error-message" (:prompt brief))))))
+      (is (re-find #"error-message" (:prompt brief)))
+      ;; Should NOT mention :mycelium/transition
+      (is (not (re-find #"mycelium/transition" (:prompt brief)))))))
 
 (deftest manifest-to-workflow-per-transition-test
   (testing "manifest->workflow applies per-transition schema to cells"
@@ -148,3 +141,31 @@
       (let [cell (cell/get-cell :test/lookup)]
         (is (map? (get-in cell [:schema :output])))
         (is (= #{:found :not-found} (set (keys (get-in cell [:schema :output])))))))))
+
+;; ===== Dispatch coverage validation =====
+
+(deftest missing-dispatch-for-edge-test
+  (testing "Missing dispatch predicate for a map edge label is rejected"
+    (let [bad (assoc valid-manifest :dispatches
+                     {:start {:success (fn [d] (:y d))}  ;; missing :failure
+                      :process {:done (constantly true)}})]
+      (is (thrown-with-msg? Exception #"[Dd]ispatch"
+            (manifest/validate-manifest bad))))))
+
+(deftest extra-dispatch-for-edge-test
+  (testing "Extra dispatch key not in edges is rejected"
+    (let [bad (assoc valid-manifest :dispatches
+                     {:start {:success (fn [d] (:y d))
+                              :failure (fn [d] (not (:y d)))
+                              :extra   (fn [d] d)}
+                      :process {:done (constantly true)}})]
+      (is (thrown-with-msg? Exception #"[Dd]ispatch"
+            (manifest/validate-manifest bad))))))
+
+(deftest unconditional-edge-no-dispatch-test
+  (testing "Unconditional edge (keyword target) needs no dispatch entry"
+    (let [m {:id :test/simple
+             :cells {:start {:id :test/simple-cell
+                              :schema {:input [:map] :output [:map]}}}
+             :edges {:start :end}}]
+      (is (some? (manifest/validate-manifest m))))))


### PR DESCRIPTION
Replace :mycelium/transition in handler return data with workflow-level :dispatches predicate functions that examine output data to determine routing. Handlers now compute data; the graph decides where it goes.

- Remove :mycelium/transition from all cell handlers
- Remove :transitions from cell specs and manifests
- Add :dispatches key to workflow definitions and EDN manifests
- Composed cells (workflow->cell) carry :default-dispatches as fallback
- dev/test-cell accepts :dispatches for test-time dispatch matching
