### PR TITLE
Use ordered vectors for dispatch predicates instead of maps

### DIFF
--- a/examples/user_onboarding/resources/workflows/dashboard.edn
+++ b/examples/user_onboarding/resources/workflows/dashboard.edn
@@ -73,11 +73,11 @@
   :render-error     {:done :end}}
 
  :dispatches
- {:start            {:success (fn [data] (:auth-token data))
-                     :failure (fn [data] (:error-type data))}
-  :validate-session {:authorized   (fn [data] (:session-valid data))
-                     :unauthorized (fn [data] (not (:session-valid data)))}
-  :fetch-profile    {:found     (fn [data] (:profile data))
-                     :not-found (fn [data] (:error-type data))}
-  :render-dashboard {:done (fn [_] true)}
-  :render-error     {:done (fn [_] true)}}}
+ {:start            [[:success (fn [data] (:auth-token data))]
+                     [:failure (fn [data] (:error-type data))]]
+  :validate-session [[:authorized   (fn [data] (:session-valid data))]
+                     [:unauthorized (fn [data] (not (:session-valid data)))]]
+  :fetch-profile    [[:found     (fn [data] (:profile data))]
+                     [:not-found (fn [data] (:error-type data))]]
+  :render-dashboard [[:done (fn [_] true)]]
+  :render-error     [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/resources/workflows/home.edn
+++ b/examples/user_onboarding/resources/workflows/home.edn
@@ -70,11 +70,11 @@
   :render-login     {:done :end}}
 
  :dispatches
- {:start            {:success (fn [data] (:auth-token data))
-                     :failure (fn [data] (not (:auth-token data)))}
-  :validate-session {:authorized   (fn [data] (:session-valid data))
-                     :unauthorized (fn [data] (not (:session-valid data)))}
-  :fetch-profile    {:found     (fn [data] (:profile data))
-                     :not-found (fn [data] (:error-type data))}
-  :render-dashboard {:done (fn [_] true)}
-  :render-login     {:done (fn [_] true)}}}
+ {:start            [[:success (fn [data] (:auth-token data))]
+                     [:failure (fn [data] (not (:auth-token data)))]]
+  :validate-session [[:authorized   (fn [data] (:session-valid data))]
+                     [:unauthorized (fn [data] (not (:session-valid data)))]]
+  :fetch-profile    [[:found     (fn [data] (:profile data))]
+                     [:not-found (fn [data] (:error-type data))]]
+  :render-dashboard [[:done (fn [_] true)]]
+  :render-login     [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/resources/workflows/login-page.edn
+++ b/examples/user_onboarding/resources/workflows/login-page.edn
@@ -14,4 +14,4 @@
  {:start {:done :end}}
 
  :dispatches
- {:start {:done (fn [_] true)}}}
+ {:start [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/resources/workflows/login-submit.edn
+++ b/examples/user_onboarding/resources/workflows/login-submit.edn
@@ -76,11 +76,11 @@
   :render-error     {:done :end}}
 
  :dispatches
- {:start            {:success (fn [data] (:auth-token data))
-                     :failure (fn [data] (:error-type data))}
-  :validate-session {:authorized   (fn [data] (:session-valid data))
-                     :unauthorized (fn [data] (not (:session-valid data)))}
-  :fetch-profile    {:found     (fn [data] (:profile data))
-                     :not-found (fn [data] (:error-type data))}
-  :render-dashboard {:done (fn [_] true)}
-  :render-error     {:done (fn [_] true)}}}
+ {:start            [[:success (fn [data] (:auth-token data))]
+                     [:failure (fn [data] (:error-type data))]]
+  :validate-session [[:authorized   (fn [data] (:session-valid data))]
+                     [:unauthorized (fn [data] (not (:session-valid data)))]]
+  :fetch-profile    [[:found     (fn [data] (:profile data))]
+                     [:not-found (fn [data] (:error-type data))]]
+  :render-dashboard [[:done (fn [_] true)]]
+  :render-error     [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/resources/workflows/user-list.edn
+++ b/examples/user_onboarding/resources/workflows/user-list.edn
@@ -30,5 +30,5 @@
   :render-list {:done :end}}
 
  :dispatches
- {:start       {:done (fn [_] true)}
-  :render-list {:done (fn [_] true)}}}
+ {:start       [[:done (fn [_] true)]]
+  :render-list [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/resources/workflows/user-onboarding.edn
+++ b/examples/user_onboarding/resources/workflows/user-onboarding.edn
@@ -70,10 +70,10 @@
   :render-home      {:done :end}}
 
  :dispatches
- {:start            {:success (fn [data] (:auth-token data))
-                     :failure (fn [data] (:error-type data))}
-  :validate-session {:authorized   (fn [data] (:session-valid data))
-                     :unauthorized (fn [data] (not (:session-valid data)))}
-  :fetch-profile    {:found     (fn [data] (:profile data))
-                     :not-found (fn [data] (:error-type data))}
-  :render-home      {:done (fn [_] true)}}}
+ {:start            [[:success (fn [data] (:auth-token data))]
+                     [:failure (fn [data] (:error-type data))]]
+  :validate-session [[:authorized   (fn [data] (:session-valid data))]
+                     [:unauthorized (fn [data] (not (:session-valid data)))]]
+  :fetch-profile    [[:found     (fn [data] (:profile data))]
+                     [:not-found (fn [data] (:error-type data))]]
+  :render-home      [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/resources/workflows/user-profile.edn
+++ b/examples/user_onboarding/resources/workflows/user-profile.edn
@@ -44,7 +44,7 @@
   :render-error   {:done :end}}
 
  :dispatches
- {:start          {:found     (fn [data] (:profile data))
-                   :not-found (fn [data] (:error-type data))}
-  :render-profile {:done (fn [_] true)}
-  :render-error   {:done (fn [_] true)}}}
+ {:start          [[:found     (fn [data] (:profile data))]
+                   [:not-found (fn [data] (:error-type data))]]
+  :render-profile [[:done (fn [_] true)]]
+  :render-error   [[:done (fn [_] true)]]}}

--- a/examples/user_onboarding/test/app/cells/auth_test.clj
+++ b/examples/user_onboarding/test/app/cells/auth_test.clj
@@ -18,8 +18,8 @@
 
 (deftest parse-request-success-test
   (testing "parse-request extracts credentials from string-keyed body"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (:error-type d))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (:error-type d))]]
           result (dev/test-cell :auth/parse-request
                   {:input {:http-request {:headers {"content-type" "application/json"}
                                           :body    {"username" "alice"
@@ -33,8 +33,8 @@
 
 (deftest parse-request-keyword-keys-test
   (testing "parse-request extracts credentials from keyword-keyed body (Muuntaja)"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (:error-type d))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (:error-type d))]]
           result (dev/test-cell :auth/parse-request
                   {:input {:http-request {:headers {"content-type" "application/json"}
                                           :body    {:username "bob"
@@ -47,8 +47,8 @@
 
 (deftest parse-request-failure-test
   (testing "parse-request fails with missing credentials and sets error context"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (:error-type d))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (:error-type d))]]
           result (dev/test-cell :auth/parse-request
                   {:input {:http-request {:headers {}
                                           :body    {}}}
@@ -63,8 +63,8 @@
     (with-redefs [db/get-session (fn [_ds token]
                                    (when (= token "tok_abc123")
                                      {:user_id "alice" :valid 1}))]
-      (let [dispatches {:authorized   (fn [d] (:session-valid d))
-                        :unauthorized (fn [d] (not (:session-valid d)))}
+      (let [dispatches [[:authorized   (fn [d] (:session-valid d))]
+                        [:unauthorized (fn [d] (not (:session-valid d)))]]
             result (dev/test-cell :auth/validate-session
                     {:input {:user-id "alice" :auth-token "tok_abc123"}
                      :resources {:db :mock-ds}
@@ -77,8 +77,8 @@
 (deftest validate-session-unauthorized-test
   (testing "validate-session rejects invalid token with error context"
     (with-redefs [db/get-session (fn [_ds _token] nil)]
-      (let [dispatches {:authorized   (fn [d] (:session-valid d))
-                        :unauthorized (fn [d] (not (:session-valid d)))}
+      (let [dispatches [[:authorized   (fn [d] (:session-valid d))]
+                        [:unauthorized (fn [d] (not (:session-valid d)))]]
             result (dev/test-cell :auth/validate-session
                     {:input {:user-id "alice" :auth-token "bad_token"}
                      :resources {:db :mock-ds}
@@ -92,8 +92,8 @@
   (testing "validate-session rejects expired token"
     (with-redefs [db/get-session (fn [_ds _token]
                                    {:user_id "alice" :valid 0})]
-      (let [dispatches {:authorized   (fn [d] (:session-valid d))
-                        :unauthorized (fn [d] (not (:session-valid d)))}
+      (let [dispatches [[:authorized   (fn [d] (:session-valid d))]
+                        [:unauthorized (fn [d] (not (:session-valid d)))]]
             result (dev/test-cell :auth/validate-session
                     {:input {:user-id "alice" :auth-token "tok_expired"}
                      :resources {:db :mock-ds}
@@ -104,8 +104,8 @@
 
 (deftest extract-session-success-test
   (testing "extract-session reads token from query params"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (:error-type d))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (:error-type d))]]
           result (dev/test-cell :auth/extract-session
                   {:input {:http-request {:query-params {:token "tok_abc123"}}}
                    :resources {}
@@ -116,8 +116,8 @@
 
 (deftest extract-session-failure-test
   (testing "extract-session fails when no token in query params"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (:error-type d))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (:error-type d))]]
           result (dev/test-cell :auth/extract-session
                   {:input {:http-request {:query-params {}}}
                    :resources {}
@@ -127,8 +127,8 @@
 
 (deftest extract-cookie-session-success-test
   (testing "extract-cookie-session reads token from cookie"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (not (:auth-token d)))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (not (:auth-token d)))]]
           result (dev/test-cell :auth/extract-cookie-session
                   {:input {:http-request {:cookies {"session-token" {:value "tok_abc123"}}}}
                    :resources {}
@@ -139,8 +139,8 @@
 
 (deftest extract-cookie-session-failure-test
   (testing "extract-cookie-session fails when no session cookie"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (not (:auth-token d)))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (not (:auth-token d)))]]
           result (dev/test-cell :auth/extract-cookie-session
                   {:input {:http-request {:cookies {}}}
                    :resources {}
@@ -151,8 +151,8 @@
 
 (deftest parse-request-test-transitions-test
   (testing "test-transitions covers both parse-request dispatches"
-    (let [dispatches {:success (fn [d] (:auth-token d))
-                      :failure (fn [d] (:error-type d))}
+    (let [dispatches [[:success (fn [d] (:auth-token d))]
+                      [:failure (fn [d] (:error-type d))]]
           results (dev/test-transitions :auth/parse-request
                     {:success {:input {:http-request {:headers {} :body {"username" "alice" "token" "tok_abc"}}}
                                :dispatches dispatches}
@@ -166,8 +166,8 @@
     (with-redefs [db/get-session (fn [_ds token]
                                    (when (= token "tok_valid")
                                      {:user_id "alice" :valid 1}))]
-      (let [dispatches {:authorized   (fn [d] (:session-valid d))
-                        :unauthorized (fn [d] (not (:session-valid d)))}
+      (let [dispatches [[:authorized   (fn [d] (:session-valid d))]
+                        [:unauthorized (fn [d] (not (:session-valid d)))]]
             results (dev/test-transitions :auth/validate-session
                       {:authorized   {:input {:user-id "alice" :auth-token "tok_valid"}
                                       :resources {:db :mock-ds}

--- a/examples/user_onboarding/test/app/cells/user_test.clj
+++ b/examples/user_onboarding/test/app/cells/user_test.clj
@@ -17,8 +17,8 @@
     (with-redefs [db/get-user (fn [_ds user-id]
                                 (when (= user-id "alice")
                                   {:id "alice" :name "Alice Smith" :email "alice@example.com"}))]
-      (let [dispatches {:found     (fn [d] (:profile d))
-                        :not-found (fn [d] (:error-type d))}
+      (let [dispatches [[:found     (fn [d] (:profile d))]
+                        [:not-found (fn [d] (:error-type d))]]
             result (dev/test-cell :user/fetch-profile
                     {:input {:user-id "alice" :session-valid true}
                      :resources {:db :mock-ds}
@@ -31,8 +31,8 @@
 (deftest fetch-profile-not-found-test
   (testing "fetch-profile returns not-found with error context"
     (with-redefs [db/get-user (fn [_ds _user-id] nil)]
-      (let [dispatches {:found     (fn [d] (:profile d))
-                        :not-found (fn [d] (:error-type d))}
+      (let [dispatches [[:found     (fn [d] (:profile d))]
+                        [:not-found (fn [d] (:error-type d))]]
             result (dev/test-cell :user/fetch-profile
                     {:input {:user-id "nobody" :session-valid true}
                      :resources {:db :mock-ds}
@@ -46,7 +46,7 @@
     (with-redefs [db/get-all-users (fn [_ds]
                                      [{:id "alice" :name "Alice Smith" :email "alice@example.com"}
                                       {:id "bob" :name "Bob Jones" :email "bob@example.com"}])]
-      (let [dispatches {:done (fn [_] true)}
+      (let [dispatches [[:done (fn [_] true)]]
             result (dev/test-cell :user/fetch-all-users
                     {:input {}
                      :resources {:db :mock-ds}
@@ -60,8 +60,8 @@
     (with-redefs [db/get-user (fn [_ds user-id]
                                 (when (= user-id "alice")
                                   {:id "alice" :name "Alice Smith" :email "alice@example.com"}))]
-      (let [dispatches {:found     (fn [d] (:profile d))
-                        :not-found (fn [d] (:error-type d))}
+      (let [dispatches [[:found     (fn [d] (:profile d))]
+                        [:not-found (fn [d] (:error-type d))]]
             result (dev/test-cell :user/fetch-profile-by-id
                     {:input {:http-request {:path-params {:id "alice"}}}
                      :resources {:db :mock-ds}
@@ -74,8 +74,8 @@
 (deftest fetch-profile-by-id-not-found-test
   (testing "fetch-profile-by-id returns not-found with error context"
     (with-redefs [db/get-user (fn [_ds _user-id] nil)]
-      (let [dispatches {:found     (fn [d] (:profile d))
-                        :not-found (fn [d] (:error-type d))}
+      (let [dispatches [[:found     (fn [d] (:profile d))]
+                        [:not-found (fn [d] (:error-type d))]]
             result (dev/test-cell :user/fetch-profile-by-id
                     {:input {:http-request {:path-params {:id "nobody"}}}
                      :resources {:db :mock-ds}
@@ -90,8 +90,8 @@
     (with-redefs [db/get-user (fn [_ds user-id]
                                 (when (= user-id "alice")
                                   {:id "alice" :name "Alice Smith" :email "alice@example.com"}))]
-      (let [dispatches {:found     (fn [d] (:profile d))
-                        :not-found (fn [d] (:error-type d))}
+      (let [dispatches [[:found     (fn [d] (:profile d))]
+                        [:not-found (fn [d] (:error-type d))]]
             results (dev/test-transitions :user/fetch-profile
                       {:found     {:input {:user-id "alice" :session-valid true}
                                    :resources {:db :mock-ds}
@@ -107,8 +107,8 @@
     (with-redefs [db/get-user (fn [_ds user-id]
                                 (when (= user-id "alice")
                                   {:id "alice" :name "Alice Smith" :email "alice@example.com"}))]
-      (let [dispatches {:found     (fn [d] (:profile d))
-                        :not-found (fn [d] (:error-type d))}
+      (let [dispatches [[:found     (fn [d] (:profile d))]
+                        [:not-found (fn [d] (:error-type d))]]
             results (dev/test-transitions :user/fetch-profile-by-id
                       {:found     {:input {:http-request {:path-params {:id "alice"}}}
                                    :resources {:db :mock-ds}

--- a/src/mycelium/compose.clj
+++ b/src/mycelium/compose.clj
@@ -6,9 +6,9 @@
 
 (def workflow-cell-dispatches
   "Default dispatch predicates for composed workflow cells.
-   Routes :success when no error, :failure when :mycelium/error is present."
-  {:success (fn [data] (not (:mycelium/error data)))
-   :failure (fn [data] (some? (:mycelium/error data)))})
+   Ordered vector — :success checked first, :failure as fallback."
+  [[:success (fn [data] (not (:mycelium/error data)))]
+   [:failure (fn [data] (some? (:mycelium/error data)))]])
 
 (defn workflow->cell
   "Wraps a workflow definition as a cell spec.

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -11,7 +11,7 @@
    Options:
      :input               - input data map
      :resources           - resources map (default {})
-     :dispatches          - {label → pred-fn} for dispatch-aware output validation
+     :dispatches          - [[label pred-fn] ...] for dispatch-aware output validation
      :expected-dispatch   - if set, verifies the matched dispatch label
    Returns:
      {:pass? bool :errors [...] :output {...} :duration-ms n :matched-dispatch kw-or-nil}"

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -50,15 +50,15 @@
 ;; ===== Dispatch validation =====
 
 (defn- validate-dispatch-coverage!
-  "For each cell with map edges, checks dispatch keys match edge keys exactly.
-   Unconditional edges (keyword) need no dispatch."
+  "For each cell with map edges, checks dispatch labels match edge keys exactly.
+   Dispatches are vectors of [label pred] pairs. Unconditional edges (keyword) need no dispatch."
   [edges dispatches]
   (doseq [[cell-name edge-def] edges]
     (when (map? edge-def)
       (let [edge-keys     (set (keys edge-def))
-            dispatch-map  (get dispatches cell-name)
-            dispatch-keys (when dispatch-map (set (keys dispatch-map)))]
-        (when-not dispatch-map
+            dispatch-vec  (get dispatches cell-name)
+            dispatch-keys (when dispatch-vec (set (map first dispatch-vec)))]
+        (when-not dispatch-vec
           (throw (ex-info (str "Cell " cell-name " has map edges but no dispatch defined")
                           {:cell-name cell-name :edge-keys edge-keys})))
         (let [missing (cset/difference edge-keys dispatch-keys)]
@@ -187,11 +187,11 @@
                                          (sort-by first output-ex)))
                           (str "Example output:\n  " (pr-str output-ex)))
         dispatch-section (when dispatches
-                           (str "Dispatch predicates determine routing based on your return data:\n"
+                           (str "Dispatch predicates (checked in order, first match wins):\n"
                                 (str/join "\n"
                                           (map (fn [[label _]]
                                                  (str "  " (pr-str label) " — predicate evaluates your output"))
-                                               (sort dispatches)))
+                                               dispatches))
                                 "\n"))
         prompt      (str "## Cell: " id "\n"
                          (when doc (str "\n## Purpose\n" doc "\n"))

--- a/test/mycelium/compose_test.clj
+++ b/test/mycelium/compose_test.clj
@@ -20,7 +20,7 @@
 
     (let [child-workflow {:cells {:start :comp/step1}
                           :edges {:start {:done :end}}
-                          :dispatches {:start {:done (constantly true)}}}
+                          :dispatches {:start [[:done (constantly true)]]}}
           cell-spec (compose/workflow->cell :comp/child child-workflow
                                            {:input [:map [:x :int]]
                                             :output [:map [:y :int]]})]
@@ -42,7 +42,7 @@
 
     (let [child-workflow {:cells {:start :comp/doubler}
                           :edges {:start {:done :end}}
-                          :dispatches {:start {:done (constantly true)}}}]
+                          :dispatches {:start [[:done (constantly true)]]}}]
       ;; Register the child workflow as a cell
       (compose/register-workflow-cell! :comp/child-wf child-workflow
                                        {:input [:map [:x :int]]
@@ -61,9 +61,9 @@
                              :child :comp/child-wf}
                      :edges {:start {:next :child}
                              :child {:success :end, :failure :error}}
-                     :dispatches {:start {:next (constantly true)}
-                                  :child {:success (fn [d] (not (:mycelium/error d)))
-                                          :failure (fn [d] (some? (:mycelium/error d)))}}})
+                     :dispatches {:start [[:next (constantly true)]]
+                                  :child [[:success (fn [d] (not (:mycelium/error d)))]
+                                          [:failure (fn [d] (some? (:mycelium/error d)))]]}})
             result (fsm/run parent {} {:data {:raw 21}})]
         (is (= 42 (:doubled result)))))))
 
@@ -80,7 +80,7 @@
 
     (let [child-workflow {:cells {:start :comp/failing-cell}
                           :edges {:start {:done :end}}
-                          :dispatches {:start {:done (constantly true)}}}]
+                          :dispatches {:start [[:done (constantly true)]]}}]
       (compose/register-workflow-cell! :comp/failing-wf child-workflow
                                        {:input [:map [:x :int]]
                                         :output [:map [:y :int]]})
@@ -97,9 +97,9 @@
                              :handle :comp/error-handler}
                      :edges {:start  {:success :end, :failure :handle}
                              :handle {:done :end}}
-                     :dispatches {:start  {:success (fn [d] (not (:mycelium/error d)))
-                                           :failure (fn [d] (some? (:mycelium/error d)))}
-                                  :handle {:done (constantly true)}}})
+                     :dispatches {:start  [[:success (fn [d] (not (:mycelium/error d)))]
+                                           [:failure (fn [d] (some? (:mycelium/error d)))]]
+                                  :handle [[:done (constantly true)]]}})
             result (fsm/run parent {} {:data {:x 1}})]
         (is (= true (:error-handled result)))))))
 
@@ -117,7 +117,7 @@
     ;; Grandchild workflow
     (let [grandchild-wf {:cells {:start :comp/adder}
                          :edges {:start {:done :end}}
-                         :dispatches {:start {:done (constantly true)}}}]
+                         :dispatches {:start [[:done (constantly true)]]}}]
       (compose/register-workflow-cell! :comp/grandchild grandchild-wf
                                        {:input [:map [:n :int]]
                                         :output [:map [:n :int]]})
@@ -125,8 +125,8 @@
       ;; Child workflow containing grandchild
       (let [child-wf {:cells {:start :comp/grandchild}
                       :edges {:start {:success :end, :failure :error}}
-                      :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
-                                           :failure (fn [d] (some? (:mycelium/error d)))}}}]
+                      :dispatches {:start [[:success (fn [d] (not (:mycelium/error d)))]
+                                           [:failure (fn [d] (some? (:mycelium/error d)))]]}}]
         (compose/register-workflow-cell! :comp/child-nested child-wf
                                          {:input [:map [:n :int]]
                                           :output [:map [:n :int]]})
@@ -135,8 +135,8 @@
         (let [parent (wf/compile-workflow
                       {:cells {:start :comp/child-nested}
                        :edges {:start {:success :end, :failure :error}}
-                       :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
-                                            :failure (fn [d] (some? (:mycelium/error d)))}}})
+                       :dispatches {:start [[:success (fn [d] (not (:mycelium/error d)))]
+                                            [:failure (fn [d] (some? (:mycelium/error d)))]]}})
               result (fsm/run parent {} {:data {:n 0}})]
           (is (= 10 (:n result))))))))
 
@@ -152,7 +152,7 @@
 
     (let [child-wf {:cells {:start :comp/traced}
                     :edges {:start {:done :end}}
-                    :dispatches {:start {:done (constantly true)}}}]
+                    :dispatches {:start [[:done (constantly true)]]}}]
       (compose/register-workflow-cell! :comp/traced-wf child-wf
                                        {:input [:map [:x :int]]
                                         :output [:map [:x :int]]})
@@ -160,8 +160,8 @@
       (let [parent (wf/compile-workflow
                     {:cells {:start :comp/traced-wf}
                      :edges {:start {:success :end, :failure :error}}
-                     :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
-                                          :failure (fn [d] (some? (:mycelium/error d)))}}})
+                     :dispatches {:start [[:success (fn [d] (not (:mycelium/error d)))]
+                                          [:failure (fn [d] (some? (:mycelium/error d)))]]}})
             result (fsm/run parent {} {:data {:x 1}})]
         (is (vector? (:mycelium/child-trace result)))))))
 
@@ -179,7 +179,7 @@
 
     (let [child-wf {:cells {:start :comp/resource-user}
                     :edges {:start {:done :end}}
-                    :dispatches {:start {:done (constantly true)}}}]
+                    :dispatches {:start [[:done (constantly true)]]}}]
       (compose/register-workflow-cell! :comp/resource-wf child-wf
                                        {:input [:map [:x :int]]
                                         :output [:map [:from-config :string]]})
@@ -187,8 +187,8 @@
       (let [parent    (wf/compile-workflow
                        {:cells {:start :comp/resource-wf}
                         :edges {:start {:success :end, :failure :error}}
-                        :dispatches {:start {:success (fn [d] (not (:mycelium/error d)))
-                                             :failure (fn [d] (some? (:mycelium/error d)))}}})
+                        :dispatches {:start [[:success (fn [d] (not (:mycelium/error d)))]
+                                             [:failure (fn [d] (some? (:mycelium/error d)))]]}})
             resources {:config {:value "from-parent"}}
             result    (fsm/run parent resources {:data {:x 1}})]
         (is (= "from-parent" (:from-config result)))))))
@@ -207,7 +207,7 @@
     (let [compile-count (atom 0)
           child-wf      {:cells {:start :comp/counter-cell}
                          :edges {:start {:done :end}}
-                         :dispatches {:start {:done (constantly true)}}}]
+                         :dispatches {:start [[:done (constantly true)]]}}]
       (with-redefs [wf/compile-workflow (let [orig wf/compile-workflow]
                                           (fn [& args]
                                             (swap! compile-count inc)
@@ -235,13 +235,16 @@
 
     (let [child-wf {:cells {:start :comp/simple}
                     :edges {:start {:done :end}}
-                    :dispatches {:start {:done (constantly true)}}}
+                    :dispatches {:start [[:done (constantly true)]]}}
           spec (compose/workflow->cell :comp/def-disp child-wf
                                       {:input [:map] :output [:map [:done :boolean]]})]
-      (is (map? (:default-dispatches spec)))
-      (is (contains? (:default-dispatches spec) :success))
-      (is (contains? (:default-dispatches spec) :failure))
+      (is (vector? (:default-dispatches spec)))
+      (let [labels (set (map first (:default-dispatches spec)))]
+        (is (contains? labels :success))
+        (is (contains? labels :failure)))
       ;; :success dispatch should return truthy for data without :mycelium/error
-      (is ((:success (:default-dispatches spec)) {:done true}))
-      ;; :failure dispatch should return truthy for data with :mycelium/error
-      (is ((:failure (:default-dispatches spec)) {:mycelium/error "boom"})))))
+      (let [success-pred (second (first (filter #(= :success (first %)) (:default-dispatches spec))))
+            failure-pred (second (first (filter #(= :failure (first %)) (:default-dispatches spec))))]
+        (is (success-pred {:done true}))
+        ;; :failure dispatch should return truthy for data with :mycelium/error
+        (is (failure-pred {:mycelium/error "boom"}))))))

--- a/test/mycelium/core_test.clj
+++ b/test/mycelium/core_test.clj
@@ -19,7 +19,7 @@
     (let [result (mycelium/run-workflow
                   {:cells {:start :core/adder}
                    :edges {:start {:done :end}}
-                   :dispatches {:start {:done (constantly true)}}}
+                   :dispatches {:start [[:done (constantly true)]]}}
                   {}
                   {:x 42})]
       (is (= 142 (:result result))))))

--- a/test/mycelium/dev_test.clj
+++ b/test/mycelium/dev_test.clj
@@ -80,8 +80,8 @@
        :schema      {:input [:map [:id :string]]
                      :output {:found     [:map [:profile [:map [:name :string]]]]
                               :not-found [:map [:error-message :string]]}}})
-    (let [dispatches {:found     (fn [d] (:profile d))
-                      :not-found (fn [d] (:error-message d))}
+    (let [dispatches [[:found     (fn [d] (:profile d))]
+                      [:not-found (fn [d] (:error-message d))]]
           result (dev/test-cell :dev/dispatch-cell
                                 {:input {:id "alice"}
                                  :dispatches dispatches})]
@@ -97,8 +97,8 @@
        :schema      {:input [:map [:id :string]]
                      :output {:found     [:map [:profile [:map [:name :string]]]]
                               :not-found [:map [:error-message :string]]}}})
-    (let [dispatches {:found     (fn [d] (:profile d))
-                      :not-found (fn [d] (:error-message d))}
+    (let [dispatches [[:found     (fn [d] (:profile d))]
+                      [:not-found (fn [d] (:error-message d))]]
           result (dev/test-cell :dev/dispatch-cell2
                                 {:input {:id "nobody"}
                                  :dispatches dispatches})]
@@ -114,8 +114,8 @@
        :schema      {:input [:map [:id :string]]
                      :output {:found     [:map [:profile [:map [:name :string]]]]
                               :not-found [:map [:error-message :string]]}}})
-    (let [dispatches {:found     (fn [d] (:profile d))
-                      :not-found (fn [d] (:error-message d))}]
+    (let [dispatches [[:found     (fn [d] (:profile d))]
+                      [:not-found (fn [d] (:error-message d))]]]
       ;; Correct expectation
       (let [result (dev/test-cell :dev/exp-dispatch
                                   {:input {:id "alice"}
@@ -139,8 +139,8 @@
        :schema      {:input [:map [:id :string]]
                      :output {:found     [:map [:profile [:map [:name :string]]]]
                               :not-found [:map [:error-message :string]]}}})
-    (let [dispatches {:found     (fn [d] (:profile d))
-                      :not-found (fn [d] (:error-message d))}
+    (let [dispatches [[:found     (fn [d] (:profile d))]
+                      [:not-found (fn [d] (:error-message d))]]
           result (dev/test-cell :dev/pt-cell
                                 {:input {:id "alice"}
                                  :dispatches dispatches})]
@@ -159,8 +159,8 @@
        :schema      {:input [:map [:id :string]]
                      :output {:found     [:map [:profile [:map [:name :string]]]]
                               :not-found [:map [:error-message :string]]}}})
-    (let [dispatches {:found     (fn [d] (:profile d))
-                      :not-found (fn [d] (:error-message d))}
+    (let [dispatches [[:found     (fn [d] (:profile d))]
+                      [:not-found (fn [d] (:error-message d))]]
           results (dev/test-transitions :dev/multi-cell
                     {:found     {:input {:id "alice"}
                                  :dispatches dispatches}

--- a/test/mycelium/integration_test.clj
+++ b/test/mycelium/integration_test.clj
@@ -29,8 +29,8 @@
                              :step2 :int/step-2}
                      :edges {:start {:next :step2}
                              :step2 {:done :end}}
-                     :dispatches {:start {:next (constantly true)}
-                                  :step2 {:done (constantly true)}}})
+                     :dispatches {:start [[:next (constantly true)]]
+                                  :step2 [[:done (constantly true)]]}})
           result   (fsm/run compiled {} {:data {:x 10}})]
       (is (= 11 (:a result)))
       (is (= 22 (:b result))))))
@@ -66,10 +66,10 @@
                      :edges {:start {:high :high, :low :low}
                              :high  {:done :end}
                              :low   {:done :end}}
-                     :dispatches {:start {:high (fn [d] (> (:value d) 5))
-                                          :low  (fn [d] (<= (:value d) 5))}
-                                  :high {:done (constantly true)}
-                                  :low  {:done (constantly true)}}})]
+                     :dispatches {:start [[:high (fn [d] (> (:value d) 5))]
+                                          [:low  (fn [d] (<= (:value d) 5))]]
+                                  :high [[:done (constantly true)]]
+                                  :low  [[:done (constantly true)]]}})]
       (is (= "high" (:result (fsm/run compiled {} {:data {:value 10}}))))
       (is (= "low"  (:result (fsm/run compiled {} {:data {:value 2}})))))))
 
@@ -87,7 +87,7 @@
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/strict-cell}
                      :edges {:start {:ok :end}}
-                     :dispatches {:start {:ok (constantly true)}}})]
+                     :dispatches {:start [[:ok (constantly true)]]}})]
       (is (thrown? Exception
             (fsm/run compiled {} {:data {:name 42}}))))))
 
@@ -106,7 +106,7 @@
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/bad-output-cell}
                      :edges {:start {:ok :end}}
-                     :dispatches {:start {:ok (constantly true)}}})]
+                     :dispatches {:start [[:ok (constantly true)]]}})]
       (is (thrown? Exception
             (fsm/run compiled {} {:data {:x 1}}))))))
 
@@ -125,7 +125,7 @@
           compiled   (wf/compile-workflow
                       {:cells {:start :int/will-fail}
                        :edges {:start {:ok :end}}
-                       :dispatches {:start {:ok (constantly true)}}}
+                       :dispatches {:start [[:ok (constantly true)]]}}
                       {:on-error (fn [_ fsm-state]
                                    (reset! error-data (:data fsm-state))
                                    (:data fsm-state))})]
@@ -148,7 +148,7 @@
     (let [compiled  (wf/compile-workflow
                      {:cells {:start :int/uses-resource}
                       :edges {:start {:ok :end}}
-                      :dispatches {:start {:ok (constantly true)}}})
+                      :dispatches {:start [[:ok (constantly true)]]}})
           resources {:config {:api-key "secret-123"}}
           result    (fsm/run compiled resources {:data {:x 1}})]
       (is (= "secret-123" (:config-val result))))))
@@ -167,8 +167,8 @@
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/incrementer}
                      :edges {:start {:again :start, :done :end}}
-                     :dispatches {:start {:again (fn [d] (< (:count d) 5))
-                                          :done  (fn [d] (>= (:count d) 5))}}})
+                     :dispatches {:start [[:again (fn [d] (< (:count d) 5))]
+                                          [:done  (fn [d] (>= (:count d) 5))]]}})
           result   (fsm/run compiled {} {:data {:count 0}})]
       (is (= 5 (:count result))))))
 
@@ -189,6 +189,6 @@
     (let [compiled (wf/compile-workflow
                     {:cells {:start :int/async-cell}
                      :edges {:start {:ok :end}}
-                     :dispatches {:start {:ok (constantly true)}}})
+                     :dispatches {:start [[:ok (constantly true)]]}})
           result   (fsm/run compiled {} {:data {:x 7}})]
       (is (= 21 (:y result))))))

--- a/test/mycelium/manifest_test.clj
+++ b/test/mycelium/manifest_test.clj
@@ -22,9 +22,9 @@
             :requires [:db]}}
    :edges {:start   {:success :process, :failure :error}
            :process {:done :end}}
-   :dispatches {:start   {:success (fn [data] (:y data))
-                           :failure (fn [data] (not (:y data)))}
-                :process {:done (constantly true)}}})
+   :dispatches {:start   [[:success (fn [data] (:y data))]
+                           [:failure (fn [data] (not (:y data)))]]
+                :process [[:done (constantly true)]]}})
 
 ;; ===== 1. Valid manifest passes validation =====
 
@@ -115,9 +115,9 @@
    :edges {:start  {:found     :render
                     :not-found :error}
            :render {:done :end}}
-   :dispatches {:start  {:found     (fn [d] (:profile d))
-                          :not-found (fn [d] (:error-message d))}
-                :render {:done (constantly true)}}})
+   :dispatches {:start  [[:found     (fn [d] (:profile d))]
+                          [:not-found (fn [d] (:error-message d))]]
+                :render [[:done (constantly true)]]}})
 
 (deftest per-transition-manifest-validates-test
   (testing "Manifest with per-transition output passes validation"
@@ -147,18 +147,18 @@
 (deftest missing-dispatch-for-edge-test
   (testing "Missing dispatch predicate for a map edge label is rejected"
     (let [bad (assoc valid-manifest :dispatches
-                     {:start {:success (fn [d] (:y d))}  ;; missing :failure
-                      :process {:done (constantly true)}})]
+                     {:start [[:success (fn [d] (:y d))]]  ;; missing :failure
+                      :process [[:done (constantly true)]]})]
       (is (thrown-with-msg? Exception #"[Dd]ispatch"
             (manifest/validate-manifest bad))))))
 
 (deftest extra-dispatch-for-edge-test
   (testing "Extra dispatch key not in edges is rejected"
     (let [bad (assoc valid-manifest :dispatches
-                     {:start {:success (fn [d] (:y d))
-                              :failure (fn [d] (not (:y d)))
-                              :extra   (fn [d] d)}
-                      :process {:done (constantly true)}})]
+                     {:start [[:success (fn [d] (:y d))]
+                              [:failure (fn [d] (not (:y d)))]
+                              [:extra   (fn [d] d)]]
+                      :process [[:done (constantly true)]]})]
       (is (thrown-with-msg? Exception #"[Dd]ispatch"
             (manifest/validate-manifest bad))))))
 

--- a/test/mycelium/orchestrate_test.clj
+++ b/test/mycelium/orchestrate_test.clj
@@ -22,9 +22,9 @@
             :requires [:db]}}
    :edges {:start   {:next :process}
            :process {:done :end, :error :error}}
-   :dispatches {:start   {:next (constantly true)}
-                :process {:done  (fn [d] (:z d))
-                          :error (fn [d] (not (:z d)))}}})
+   :dispatches {:start   [[:next (constantly true)]]
+                :process [[:done  (fn [d] (:z d))]
+                          [:error (fn [d] (not (:z d)))]]}})
 
 ;; ===== 1. cell-briefs returns brief for every cell =====
 


### PR DESCRIPTION
Maestro uses vectors [[target pred] ...] for dispatches because order determines priority when multiple predicates match. Maps create ambiguity for more than two dispatches. 
