### PR TITLE
Expose workflow trace for agent diagnostics

### DIFF
--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -270,6 +270,11 @@
                            cells)
          ;; Build state->edge-targets for post-interceptor transition lookup
          state->edge-targets (build-edge-targets edges)
+         ;; Build state->names for human-readable trace entries
+         state->names (into {}
+                            (map (fn [[cell-name _]]
+                                   [(resolve-state-id cell-name) cell-name]))
+                            cells)
          ;; Build Maestro FSM states
          fsm-states (into {}
                           (map (fn [[cell-name cell-id]]
@@ -286,7 +291,7 @@
                           cells)
          ;; Build interceptors — compose custom pre/post with schema interceptors
          schema-pre  (schema/make-pre-interceptor state->cell)
-         schema-post (schema/make-post-interceptor state->cell state->edge-targets)
+         schema-post (schema/make-post-interceptor state->cell state->edge-targets state->names)
          pre  (if-let [custom-pre (:pre opts)]
                 (fn [fsm-state resources]
                   (-> (schema-pre fsm-state resources)

--- a/test/mycelium/integration_test.clj
+++ b/test/mycelium/integration_test.clj
@@ -192,3 +192,158 @@
                      :dispatches {:start [[:ok (constantly true)]]}})
           result   (fsm/run compiled {} {:data {:x 7}})]
       (is (= 21 (:y result))))))
+
+;; ===== 9. Linear workflow trace contains entries in order =====
+
+(deftest linear-workflow-trace-test
+  (testing "Linear workflow result contains :mycelium/trace with entries in order"
+    (defmethod cell/cell-spec :int/trace-a [_]
+      {:id      :int/trace-a
+       :handler (fn [_ data] (assoc data :a 1))
+       :schema  {:input [:map [:x :int]] :output [:map [:a :int]]}})
+
+    (defmethod cell/cell-spec :int/trace-b [_]
+      {:id      :int/trace-b
+       :handler (fn [_ data] (assoc data :b 2))
+       :schema  {:input [:map [:a :int]] :output [:map [:b :int]]}})
+
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start :int/trace-a
+                             :step2 :int/trace-b}
+                     :edges {:start {:next :step2}
+                             :step2 {:done :end}}
+                     :dispatches {:start [[:next (constantly true)]]
+                                  :step2 [[:done (constantly true)]]}})
+          result   (fsm/run compiled {} {:data {:x 10}})
+          trace    (:mycelium/trace result)]
+      (is (= 2 (count trace)))
+      (is (= :start (:cell (first trace))))
+      (is (= :int/trace-a (:cell-id (first trace))))
+      (is (= :next (:transition (first trace))))
+      (is (= :step2 (:cell (second trace))))
+      (is (= :int/trace-b (:cell-id (second trace))))
+      (is (= :done (:transition (second trace)))))))
+
+;; ===== 10. Branching workflow trace shows correct path =====
+
+(deftest branching-workflow-trace-test
+  (testing "Branching workflow trace shows only the path taken"
+    (defmethod cell/cell-spec :int/trace-router [_]
+      {:id      :int/trace-router
+       :handler (fn [_ data] data)
+       :schema  {:input [:map [:value :int]] :output [:map]}})
+
+    (defmethod cell/cell-spec :int/trace-high [_]
+      {:id      :int/trace-high
+       :handler (fn [_ data] (assoc data :path "high"))
+       :schema  {:input [:map [:value :int]] :output [:map [:path :string]]}})
+
+    (defmethod cell/cell-spec :int/trace-low [_]
+      {:id      :int/trace-low
+       :handler (fn [_ data] (assoc data :path "low"))
+       :schema  {:input [:map [:value :int]] :output [:map [:path :string]]}})
+
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start :int/trace-router
+                             :high  :int/trace-high
+                             :low   :int/trace-low}
+                     :edges {:start {:high :high, :low :low}
+                             :high  {:done :end}
+                             :low   {:done :end}}
+                     :dispatches {:start [[:high (fn [d] (> (:value d) 5))]
+                                          [:low  (fn [d] (<= (:value d) 5))]]
+                                  :high [[:done (constantly true)]]
+                                  :low  [[:done (constantly true)]]}})
+          result-high (fsm/run compiled {} {:data {:value 10}})
+          result-low  (fsm/run compiled {} {:data {:value 2}})]
+      ;; High path: start → high
+      (is (= [:start :high] (mapv :cell (:mycelium/trace result-high))))
+      (is (= :high (:transition (first (:mycelium/trace result-high)))))
+      ;; Low path: start → low
+      (is (= [:start :low] (mapv :cell (:mycelium/trace result-low))))
+      (is (= :low (:transition (first (:mycelium/trace result-low))))))))
+
+;; ===== 11. Looping workflow trace shows each iteration =====
+
+(deftest looping-workflow-trace-test
+  (testing "Looping workflow trace shows each iteration"
+    (defmethod cell/cell-spec :int/trace-inc [_]
+      {:id      :int/trace-inc
+       :handler (fn [_ data] (assoc data :count (inc (:count data))))
+       :schema  {:input [:map [:count :int]] :output [:map [:count :int]]}})
+
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start :int/trace-inc}
+                     :edges {:start {:again :start, :done :end}}
+                     :dispatches {:start [[:again (fn [d] (< (:count d) 3))]
+                                          [:done  (fn [d] (>= (:count d) 3))]]}})
+          result   (fsm/run compiled {} {:data {:count 0}})
+          trace    (:mycelium/trace result)]
+      (is (= 3 (count trace)))
+      (is (every? #(= :start (:cell %)) trace))
+      (is (= [:again :again :done] (mapv :transition trace)))
+      ;; Data snapshots show progression
+      (is (= [1 2 3] (mapv #(get-in % [:data :count]) trace))))))
+
+;; ===== 12. Error case trace shows failing step =====
+
+(deftest error-trace-test
+  (testing "Error case trace shows the failing step with :error details"
+    (defmethod cell/cell-spec :int/trace-ok [_]
+      {:id      :int/trace-ok
+       :handler (fn [_ data] (assoc data :a 1))
+       :schema  {:input [:map [:x :int]] :output [:map [:a :int]]}})
+
+    (defmethod cell/cell-spec :int/trace-bad [_]
+      {:id      :int/trace-bad
+       :handler (fn [_ data]
+                  ;; Returns wrong type — schema violation
+                  (assoc data :b "not-an-int"))
+       :schema  {:input [:map [:a :int]] :output [:map [:b :int]]}})
+
+    (let [error-data (atom nil)
+          compiled   (wf/compile-workflow
+                      {:cells {:start :int/trace-ok
+                               :step2 :int/trace-bad}
+                       :edges {:start {:next :step2}
+                               :step2 {:done :end}}
+                       :dispatches {:start [[:next (constantly true)]]
+                                    :step2 [[:done (constantly true)]]}}
+                      {:on-error (fn [_ fsm-state]
+                                   (reset! error-data (:data fsm-state))
+                                   (:data fsm-state))})]
+      (fsm/run compiled {} {:data {:x 1}})
+      (let [trace (:mycelium/trace @error-data)]
+        ;; Both steps appear in trace
+        (is (= 2 (count trace)))
+        (is (= :start (:cell (first trace))))
+        (is (nil? (:error (first trace))))
+        (is (= :step2 (:cell (second trace))))
+        (is (some? (:error (second trace))))))))
+
+;; ===== 13. Trace data snapshots don't contain :mycelium/trace =====
+
+(deftest trace-no-nesting-test
+  (testing "Trace :data snapshots don't contain :mycelium/trace (no recursive nesting)"
+    (defmethod cell/cell-spec :int/nest-a [_]
+      {:id      :int/nest-a
+       :handler (fn [_ data] (assoc data :a 1))
+       :schema  {:input [:map [:x :int]] :output [:map [:a :int]]}})
+
+    (defmethod cell/cell-spec :int/nest-b [_]
+      {:id      :int/nest-b
+       :handler (fn [_ data] (assoc data :b 2))
+       :schema  {:input [:map [:a :int]] :output [:map [:b :int]]}})
+
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start :int/nest-a
+                             :step2 :int/nest-b}
+                     :edges {:start {:next :step2}
+                             :step2 {:done :end}}
+                     :dispatches {:start [[:next (constantly true)]]
+                                  :step2 [[:done (constantly true)]]}})
+          result   (fsm/run compiled {} {:data {:x 10}})
+          trace    (:mycelium/trace result)]
+      (doseq [entry trace]
+        (is (not (contains? (:data entry) :mycelium/trace))
+            (str "Trace entry for " (:cell entry) " should not contain :mycelium/trace in :data"))))))


### PR DESCRIPTION
Post-interceptor now appends `:mycelium/trace` entries with cell name, cell id, transition taken, and data snapshot after each step. On schema errors the trace entry includes `:error` details. Child workflow traces flow through to parent results automatically via compose.