### PR TITLE
Extract shared validation into mycelium.validation namespace

### DIFF
--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -1,7 +1,6 @@
 (ns mycelium.cell
   "Cell registry for Mycelium. Cells are registered via `defmethod cell-spec`."
-  (:require [clojure.set]
-            [malli.core :as m]))
+  (:require [mycelium.validation :as v]))
 
 (defmulti cell-spec
   "Multimethod-backed cell registry. Dispatches on cell-id keyword,
@@ -19,28 +18,6 @@
     (remove-method cell-spec k))
   (reset! cell-overrides {}))
 
-(defn- validate-schema! [schema label]
-  (try
-    (m/schema schema)
-    (catch Exception e
-      (throw (ex-info (str "Invalid Malli schema for " label ": " (ex-message e))
-                      {:label label :schema schema}
-                      e)))))
-
-(defn- validate-output-schema!
-  "Validates an output schema which may be a single schema (vector) or per-transition map.
-   If a map, validates each value as a Malli schema."
-  [output-schema label]
-  (cond
-    (vector? output-schema)
-    (validate-schema! output-schema label)
-
-    (map? output-schema)
-    (doseq [[k v] output-schema]
-      (validate-schema! v (str label " transition " k)))
-
-    :else
-    (validate-schema! output-schema label)))
 
 (defn get-cell
   "Returns the cell spec for the given id, or nil if not found."
@@ -67,9 +44,9 @@
     (throw (ex-info (str "Cell " cell-id " not found in registry")
                     {:id cell-id})))
   (when (:input schema)
-    (validate-schema! (:input schema) (str cell-id " :input")))
+    (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
   (when (:output schema)
-    (validate-output-schema! (:output schema) (str cell-id " :output")))
+    (v/validate-output-schema! (:output schema) (str cell-id " :output")))
   (swap! cell-overrides update cell-id merge {:schema schema})
   schema)
 
@@ -84,9 +61,9 @@
                     {:id cell-id})))
   (when schema
     (when (:input schema)
-      (validate-schema! (:input schema) (str cell-id " :input")))
+      (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
     (when (:output schema)
-      (validate-output-schema! (:output schema) (str cell-id " :output"))))
+      (v/validate-output-schema! (:output schema) (str cell-id " :output"))))
   (let [overrides (cond-> {}
                     schema   (assoc :schema schema)
                     requires (assoc :requires requires))]

--- a/src/mycelium/validation.clj
+++ b/src/mycelium/validation.clj
@@ -1,0 +1,104 @@
+(ns mycelium.validation
+  "Shared validation functions for workflow and manifest validation.
+   Provides schema well-formedness checks, edge target validation,
+   BFS reachability, and dispatch coverage verification."
+  (:require [clojure.set :as set]
+            [malli.core :as m]))
+
+;; ===== Schema well-formedness =====
+
+(defn validate-malli-schema!
+  "Validates that a Malli schema definition is well-formed.
+   Returns nil on success, throws on invalid schema.
+   `label` is included in the error message for diagnostics."
+  [schema label]
+  (try
+    (m/schema schema)
+    nil
+    (catch Exception e
+      (throw (ex-info (str "Invalid Malli schema for " label ": " (ex-message e))
+                      {:label label :schema schema}
+                      e)))))
+
+(defn validate-output-schema!
+  "Validates an output schema which may be a single schema (vector/keyword)
+   or a per-transition map. If a map, validates each value as a Malli schema."
+  [output-schema label]
+  (cond
+    (vector? output-schema)
+    (validate-malli-schema! output-schema label)
+
+    (map? output-schema)
+    (doseq [[k v] output-schema]
+      (validate-malli-schema! v (str label " transition " k)))
+
+    :else
+    (validate-malli-schema! output-schema label)))
+
+;; ===== Edge target validation =====
+
+(defn validate-edge-targets!
+  "Checks all edge targets reference valid cell names or terminal states (:end/:error/:halt).
+   `edges-map` is {cell-name -> edge-def}, `cell-names` is a set of valid cell names."
+  [edges-map cell-names]
+  (let [valid-names (into #{:end :error :halt} cell-names)]
+    (doseq [[from edge-def] edges-map
+            target (if (keyword? edge-def) [edge-def] (vals edge-def))]
+      (when-not (contains? valid-names target)
+        (throw (ex-info (str "Invalid edge target " target " from " from
+                             ". Valid targets: " valid-names)
+                        {:from from :target target :valid valid-names}))))))
+
+;; ===== Reachability =====
+
+(defn validate-reachability!
+  "BFS from :start, checks all cells in `cell-names` are reachable via `edges-map`."
+  [edges-map cell-names]
+  (let [adjacency (into {}
+                        (map (fn [[from edge-def]]
+                               [from (if (keyword? edge-def)
+                                       #{edge-def}
+                                       (set (vals edge-def)))]))
+                        edges-map)
+        reachable (loop [queue   (conj clojure.lang.PersistentQueue/EMPTY :start)
+                         visited #{}]
+                    (if (empty? queue)
+                      visited
+                      (let [node  (peek queue)
+                            queue (pop queue)]
+                        (if (visited node)
+                          (recur queue visited)
+                          (recur (into queue (get adjacency node #{}))
+                                 (conj visited node))))))
+        unreachable (set/difference (set cell-names) reachable)]
+    (when (seq unreachable)
+      (throw (ex-info (str "Unreachable cells: " unreachable)
+                      {:unreachable unreachable})))))
+
+;; ===== Dispatch coverage =====
+
+(defn validate-dispatch-coverage!
+  "For each cell with map edges, checks dispatch labels match edge keys exactly.
+   Dispatches are vectors of [label pred] pairs; labels must match edge keys.
+   Cells with unconditional edges (keyword) need no dispatch entry."
+  [edges-map dispatches-map]
+  (doseq [[cell-name edge-def] edges-map]
+    (when (map? edge-def)
+      (let [edge-keys     (set (keys edge-def))
+            dispatch-vec  (get dispatches-map cell-name)
+            dispatch-keys (when dispatch-vec (set (map first dispatch-vec)))]
+        (when-not dispatch-vec
+          (throw (ex-info (str "Cell " cell-name " has map edges but no dispatch defined")
+                          {:cell-name cell-name :edge-keys edge-keys})))
+        (let [missing (set/difference edge-keys dispatch-keys)]
+          (when (seq missing)
+            (throw (ex-info (str "Cell " cell-name " has edge(s) " missing
+                                 " with no dispatch predicates")
+                            {:cell-name cell-name :missing missing
+                             :edge-keys edge-keys :dispatch-keys dispatch-keys}))))
+        (let [extra (set/difference dispatch-keys edge-keys)]
+          (when (seq extra)
+            (throw (ex-info (str "Cell " cell-name " has dispatch(es) " extra
+                                 " that don't match any edge")
+                            {:cell-name cell-name :extra extra
+                             :edge-keys edge-keys :dispatch-keys dispatch-keys}))))))))

--- a/test/mycelium/validation_test.clj
+++ b/test/mycelium/validation_test.clj
@@ -1,0 +1,121 @@
+(ns mycelium.validation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [mycelium.validation :as v]))
+
+;; ===== Schema validation =====
+
+(deftest validate-malli-schema-valid-test
+  (testing "Valid Malli schemas pass without throwing"
+    (is (nil? (v/validate-malli-schema! [:map [:x :int]] "test")))
+    (is (nil? (v/validate-malli-schema! [:map {:closed true} [:x :int]] "test")))
+    (is (nil? (v/validate-malli-schema! :string "test")))
+    (is (nil? (v/validate-malli-schema! :int "test")))))
+
+(deftest validate-malli-schema-invalid-test
+  (testing "Invalid Malli schema throws with label in message"
+    (is (thrown-with-msg? Exception #"test-label"
+          (v/validate-malli-schema! [:not-a-real-type] "test-label")))))
+
+(deftest validate-output-schema-vector-test
+  (testing "Vector output schema validates as single Malli schema"
+    (is (nil? (v/validate-output-schema! [:map [:y :int]] "test")))
+    (is (thrown? Exception
+          (v/validate-output-schema! [:not-real] "test")))))
+
+(deftest validate-output-schema-map-test
+  (testing "Map output schema validates each transition's schema"
+    (is (nil? (v/validate-output-schema!
+               {:found [:map [:profile :map]]
+                :not-found [:map [:error :string]]}
+               "test")))
+    (is (thrown-with-msg? Exception #"transition :bad"
+          (v/validate-output-schema!
+           {:good [:map [:x :int]]
+            :bad  [:not-real]}
+           "test")))))
+
+(deftest validate-output-schema-keyword-test
+  (testing "Keyword output schema (e.g. :map) validates as Malli schema"
+    (is (nil? (v/validate-output-schema! :map "test")))))
+
+;; ===== Edge target validation =====
+
+(deftest validate-edge-targets-valid-test
+  (testing "Valid edge targets pass"
+    (is (nil? (v/validate-edge-targets!
+               {:start {:success :step-b, :failure :error}
+                :step-b :end}
+               #{:start :step-b})))))
+
+(deftest validate-edge-targets-invalid-test
+  (testing "Invalid edge target throws"
+    (is (thrown-with-msg? Exception #"[Ii]nvalid edge target"
+          (v/validate-edge-targets!
+           {:start {:success :nonexistent, :failure :error}}
+           #{:start})))))
+
+(deftest validate-edge-targets-terminal-states-test
+  (testing "Terminal states :end/:error/:halt are always valid targets"
+    (is (nil? (v/validate-edge-targets!
+               {:start {:a :end, :b :error, :c :halt}}
+               #{:start})))))
+
+;; ===== Reachability =====
+
+(deftest validate-reachability-all-reachable-test
+  (testing "All cells reachable from :start passes"
+    (is (nil? (v/validate-reachability!
+               {:start {:a :step-b, :b :step-c}
+                :step-b :end
+                :step-c :end}
+               #{:start :step-b :step-c})))))
+
+(deftest validate-reachability-unreachable-test
+  (testing "Unreachable cell throws"
+    (is (thrown-with-msg? Exception #"[Uu]nreachable"
+          (v/validate-reachability!
+           {:start :end}
+           #{:start :orphan})))))
+
+(deftest validate-reachability-deep-chain-test
+  (testing "Deep chain reachability works"
+    (is (nil? (v/validate-reachability!
+               {:start :a, :a :b, :b :c, :c :end}
+               #{:start :a :b :c})))))
+
+;; ===== Dispatch coverage =====
+
+(deftest validate-dispatch-coverage-valid-test
+  (testing "Dispatch labels exactly match edge keys"
+    (is (nil? (v/validate-dispatch-coverage!
+               {:start {:success :step-b, :failure :error}}
+               {:start [[:success (fn [d] (:ok d))]
+                        [:failure (fn [d] (not (:ok d)))]]})))))
+
+(deftest validate-dispatch-coverage-missing-test
+  (testing "Missing dispatch label throws"
+    (is (thrown-with-msg? Exception #"[Dd]ispatch"
+          (v/validate-dispatch-coverage!
+           {:start {:success :step-b, :failure :error}}
+           {:start [[:success (fn [d] (:ok d))]]})))))
+
+(deftest validate-dispatch-coverage-extra-test
+  (testing "Extra dispatch label throws"
+    (is (thrown-with-msg? Exception #"[Dd]ispatch"
+          (v/validate-dispatch-coverage!
+           {:start {:success :end}}
+           {:start [[:success (fn [d] (:ok d))]
+                    [:extra (fn [_] true)]]})))))
+
+(deftest validate-dispatch-coverage-no-dispatch-for-map-edges-test
+  (testing "Map edges with no dispatch entry throws"
+    (is (thrown-with-msg? Exception #"[Dd]ispatch"
+          (v/validate-dispatch-coverage!
+           {:start {:success :end, :failure :error}}
+           {})))))
+
+(deftest validate-dispatch-coverage-keyword-edges-skip-test
+  (testing "Unconditional (keyword) edges don't need dispatch entries"
+    (is (nil? (v/validate-dispatch-coverage!
+               {:start :end}
+               {})))))


### PR DESCRIPTION
Consolidate duplicated validation logic from cell.clj, workflow.clj, and manifest.clj into a single mycelium.validation namespace.