### PR TITLE
Upgrade Maestro

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
          io.github.yogthos/maestro {:git/url "https://github.com/yogthos/maestro"
-                                    :git/sha "b2256aa24ac60adb4921618c9bf6de4f33c54320"}
+                                    :git/sha "663480b4da9e982635836a063176f52f6686357a"}
          metosin/malli       {:mvn/version "0.17.0"}}
  :aliases
  {:dev  {:extra-paths ["dev" "test" "examples"]

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -61,6 +61,18 @@
    (let [compiled (compile-workflow workflow-def opts)]
      (fsm/run compiled resources {:data initial-data}))))
 
+(defn run-workflow-async
+  "Like run-workflow but returns a future. Deref to get the final data map."
+  ([workflow-def]
+   (run-workflow-async workflow-def {} {} {}))
+  ([workflow-def resources]
+   (run-workflow-async workflow-def resources {} {}))
+  ([workflow-def resources initial-data]
+   (run-workflow-async workflow-def resources initial-data {}))
+  ([workflow-def resources initial-data opts]
+   (let [compiled (compile-workflow workflow-def opts)]
+     (fsm/run-async compiled resources {:data initial-data}))))
+
 ;; --- Dev tools ---
 
 (def test-transitions
@@ -72,3 +84,8 @@
   "Enumerates all paths from :start to terminal states.
    See mycelium.dev/enumerate-paths."
   dev/enumerate-paths)
+
+(def analyze-workflow
+  "Runs Maestro's static analysis on a workflow definition.
+   See mycelium.dev/analyze-workflow."
+  dev/analyze-workflow)

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -114,11 +114,14 @@
                                      [state-id (:current-state-id fsm-state)]))
                 data       (:data fsm-state)
                 error      (validate-output cell data transition)
+                ;; Extract duration-ms from the latest Maestro trace segment
+                duration-ms (some-> (:trace fsm-state) last :duration-ms)
                 trace-entry (cond-> {:cell       (get state->names state-id)
                                      :cell-id    (:id cell)
                                      :transition transition
                                      :data       (dissoc data :mycelium/trace)}
-                              error (assoc :error error))]
+                              duration-ms (assoc :duration-ms duration-ms)
+                              error       (assoc :error error))]
             (if error
               (-> fsm-state
                   (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -247,5 +247,11 @@
                             (when-let [on-end (:on-end opts)]
                               {::fsm/end {:handler on-end}}))
                :opts {:pre  pre
-                      :post post}}]
+                      :post post}}
+         ;; Static analysis: catch structural issues Maestro can detect
+         analysis (fsm/analyze spec)]
+     (when (seq (:no-path-to-end analysis))
+       (let [names (mapv #(get state->names % %) (:no-path-to-end analysis))]
+         (throw (ex-info (str "States with no path to end: " names)
+                         {:no-path-to-end names :analysis analysis}))))
      (fsm/compile spec))))

--- a/test/mycelium/core_test.clj
+++ b/test/mycelium/core_test.clj
@@ -1,7 +1,8 @@
 (ns mycelium.core-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [mycelium.cell :as cell]
-            [mycelium.core :as mycelium]))
+            [mycelium.core :as mycelium]
+            [mycelium.dev :as dev]))
 
 (use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
 
@@ -33,4 +34,134 @@
     (is (fn? mycelium/workflow->cell))
     (is (fn? mycelium/load-manifest))
     (is (fn? mycelium/cell-brief))
-    (is (fn? mycelium/run-workflow))))
+    (is (fn? mycelium/run-workflow))
+    (is (fn? mycelium/run-workflow-async))
+    (is (fn? mycelium/analyze-workflow))))
+
+;; ===== 3. run-workflow-async returns a future =====
+
+(deftest run-workflow-async-test
+  (testing "run-workflow-async returns a future that resolves to the final data"
+    (defmethod cell/cell-spec :core/async-adder [_]
+      {:id      :core/async-adder
+       :handler (fn [_ data] (assoc data :result (+ (:x data) 200)))
+       :schema  {:input [:map [:x :int]]
+                 :output [:map [:result :int]]}})
+
+    (let [fut (mycelium/run-workflow-async
+               {:cells {:start :core/async-adder}
+                :edges {:start {:done :end}}
+                :dispatches {:start [[:done (constantly true)]]}}
+               {}
+               {:x 42})]
+      (is (future? fut))
+      (let [result (deref fut 5000 :timeout)]
+        (is (not= :timeout result))
+        (is (= 242 (:result result)))))))
+
+;; ===== 4. run-workflow-async with branching takes correct path =====
+
+(deftest run-workflow-async-branching-test
+  (testing "run-workflow-async resolves correct branch"
+    (defmethod cell/cell-spec :core/async-router [_]
+      {:id      :core/async-router
+       :handler (fn [_ data] data)
+       :schema  {:input [:map [:value :int]] :output [:map]}})
+    (defmethod cell/cell-spec :core/async-high [_]
+      {:id      :core/async-high
+       :handler (fn [_ data] (assoc data :path "high"))
+       :schema  {:input [:map [:value :int]] :output [:map [:path :string]]}})
+    (defmethod cell/cell-spec :core/async-low [_]
+      {:id      :core/async-low
+       :handler (fn [_ data] (assoc data :path "low"))
+       :schema  {:input [:map [:value :int]] :output [:map [:path :string]]}})
+
+    (let [wf-def {:cells {:start :core/async-router
+                          :high  :core/async-high
+                          :low   :core/async-low}
+                  :edges {:start {:high :high, :low :low}
+                          :high  {:done :end}
+                          :low   {:done :end}}
+                  :dispatches {:start [[:high (fn [d] (> (:value d) 5))]
+                                       [:low  (fn [d] (<= (:value d) 5))]]
+                               :high [[:done (constantly true)]]
+                               :low  [[:done (constantly true)]]}}
+          fut-high (mycelium/run-workflow-async wf-def {} {:value 10})
+          fut-low  (mycelium/run-workflow-async wf-def {} {:value 2})]
+      (is (= "high" (:path (deref fut-high 5000 :timeout))))
+      (is (= "low"  (:path (deref fut-low 5000 :timeout)))))))
+
+;; ===== 5. run-workflow-async with resources =====
+
+(deftest run-workflow-async-resources-test
+  (testing "run-workflow-async passes resources through to handlers"
+    (defmethod cell/cell-spec :core/async-res [_]
+      {:id      :core/async-res
+       :handler (fn [{:keys [multiplier]} data]
+                  (assoc data :result (* (:x data) multiplier)))
+       :schema  {:input [:map [:x :int]] :output [:map [:result :int]]}})
+
+    (let [fut (mycelium/run-workflow-async
+               {:cells {:start :core/async-res}
+                :edges {:start {:done :end}}
+                :dispatches {:start [[:done (constantly true)]]}}
+               {:multiplier 7}
+               {:x 6})]
+      (is (= 42 (:result (deref fut 5000 :timeout)))))))
+
+;; ===== 6. run-workflow-async propagates errors =====
+
+(deftest run-workflow-async-error-propagation-test
+  (testing "run-workflow-async propagates schema errors when deref'd"
+    (defmethod cell/cell-spec :core/async-bad [_]
+      {:id      :core/async-bad
+       :handler (fn [_ data] (assoc data :y "not-an-int"))
+       :schema  {:input [:map [:x :int]] :output [:map [:y :int]]}})
+
+    (let [fut (mycelium/run-workflow-async
+               {:cells {:start :core/async-bad}
+                :edges {:start {:ok :end}}
+                :dispatches {:start [[:ok (constantly true)]]}}
+               {}
+               {:x 1})]
+      ;; Deref should throw (Maestro hits error state with no handler)
+      (is (thrown? Exception (deref fut 5000 :timeout))))))
+
+;; ===== 7. run-workflow-async includes trace with duration-ms =====
+
+(deftest run-workflow-async-trace-test
+  (testing "run-workflow-async result includes trace with duration-ms"
+    (defmethod cell/cell-spec :core/async-traced [_]
+      {:id      :core/async-traced
+       :handler (fn [_ data] (assoc data :a 1))
+       :schema  {:input [:map [:x :int]] :output [:map [:a :int]]}})
+
+    (let [fut (mycelium/run-workflow-async
+               {:cells {:start :core/async-traced}
+                :edges {:start {:done :end}}
+                :dispatches {:start [[:done (constantly true)]]}}
+               {}
+               {:x 10})
+          result (deref fut 5000 :timeout)
+          trace  (:mycelium/trace result)]
+      (is (= 1 (count trace)))
+      (is (= :start (:cell (first trace))))
+      (is (number? (:duration-ms (first trace)))))))
+
+;; ===== 8. analyze-workflow exposed in core =====
+
+(deftest analyze-workflow-test
+  (testing "analyze-workflow returns analysis with cell names"
+    (defmethod cell/cell-spec :core/analyze-a [_]
+      {:id      :core/analyze-a
+       :handler (fn [_ data] (assoc data :a 1))
+       :schema  {:input [:map] :output [:map [:a :int]]}})
+
+    (let [analysis (mycelium/analyze-workflow
+                    {:cells {:start :core/analyze-a}
+                     :edges {:start {:done :end}}
+                     :dispatches {:start [[:done (constantly true)]]}})]
+      (is (contains? (:reachable analysis) :start))
+      (is (empty? (:unreachable analysis)))
+      (is (empty? (:no-path-to-end analysis)))
+      (is (empty? (:cycles analysis))))))


### PR DESCRIPTION
- Enrich mycelium trace entries with :duration-ms from Maestro trace segments
- Add compile-time static analysis via fsm/analyze (rejects no-path-to-end)
- Expose run-workflow-async in core.clj (future-based async execution)
- Add analyze-workflow in dev.clj (static analysis with cell name resolution)
