### PR TITLE
Add TodoMVC example with HTMX on Mycelium

### DIFF
--- a/examples/todomvc/.gitignore
+++ b/examples/todomvc/.gitignore
@@ -1,0 +1,20 @@
+kit.git-config.edn
+.DS_Store
+.nrepl-port
+hs_err_pid*.log
+.cpcache/
+target
+log/
+.shadow-cljs/
+node_modules/
+modules/
+
+# IntelliJ
+*.iml
+.idea/
+*.bak
+
+# clj-kondo
+.clj-kondo/.cache/
+.calva/output-window/
+.lsp/.cache/

--- a/examples/todomvc/Dockerfile
+++ b/examples/todomvc/Dockerfile
@@ -1,0 +1,15 @@
+# syntax = docker/dockerfile:1.2
+FROM clojure:openjdk-17 AS build
+
+WORKDIR /
+COPY . /
+
+RUN clj -Sforce -T:build all
+
+FROM azul/zulu-openjdk-alpine:17
+
+COPY --from=build /target/todomvc-standalone.jar /todomvc/todomvc-standalone.jar
+
+EXPOSE $PORT
+
+ENTRYPOINT exec java $JAVA_OPTS -jar /todomvc/todomvc-standalone.jar

--- a/examples/todomvc/Makefile
+++ b/examples/todomvc/Makefile
@@ -1,0 +1,14 @@
+clean:
+	rm -rf target
+
+run:
+	clj -M:dev
+
+repl:
+	clj -M:dev:nrepl
+
+test:
+	clj -M:test
+
+uberjar:
+	clj -T:build all

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -1,0 +1,37 @@
+# todomvc
+
+Start a [REPL](#repls) in your editor or terminal of choice.
+
+Start the server with:
+
+```clojure
+(go)
+```
+
+The default API is available under http://localhost:3000/api
+
+System configuration is available under `resources/system.edn`.
+
+To reload changes:
+
+```clojure
+(reset)
+```
+
+## REPLs
+
+### Cursive
+
+Configure a [REPL following the Cursive documentation](https://cursive-ide.com/userguide/repl.html). Using the default "Run with IntelliJ project classpath" option will let you select an alias from the ["Clojure deps" aliases selection](https://cursive-ide.com/userguide/deps.html#refreshing-deps-dependencies).
+
+### CIDER
+
+Use the `cider` alias for CIDER nREPL support (run `clj -M:dev:cider`). See the [CIDER docs](https://docs.cider.mx/cider/basics/up_and_running.html) for more help.
+
+Note that this alias runs nREPL during development. To run nREPL in production (typically when the system starts), use the kit-nrepl library through the +nrepl profile as described in [the documentation](https://kit-clj.github.io/docs/profiles.html#profiles).
+
+### Command Line
+
+Run `clj -M:dev:nrepl` or `make repl`.
+
+Note that, just like with [CIDER](#cider), this alias runs nREPL during development. To run nREPL in production (typically when the system starts), use the kit-nrepl library through the +nrepl profile as described in [the documentation](https://kit-clj.github.io/docs/profiles.html#profiles).

--- a/examples/todomvc/bb.edn
+++ b/examples/todomvc/bb.edn
@@ -1,0 +1,27 @@
+{:min-bb-version "0.8.156"
+ :deps  {failjure/failjure {:mvn/version "2.3.0"}}
+ :tasks {:requires ([babashka.fs :as fs]
+                    [babashka.tasks :refer [shell]])
+
+         run       {:doc  "starts the app"
+                    :task (if (fs/windows?)
+                            (clojure {:dir "."} "-M:dev")
+                            (shell {:dir "."} "clj -M:dev"))}
+
+         nrepl     {:doc  "starts the nREPL"
+                    :task (clojure {:dir "."} "-M:dev:nrepl")}
+
+         cider     {:doc  "starts the cider"
+                    :task (clojure {:dir "."} "-M:dev:cider")}
+
+         test      {:doc  "runs tests"
+                    :task (clojure {:dir "."} "-M:test")}
+
+         uberjar   {:doc  "builds the uberjar"
+                    :task (clojure {:dir "."} "-T:build all")}
+
+         format    {:doc  "Formats codebase"
+                    :task (try
+                            (shell {:dir "src"} "cljstyle fix")
+                            (catch Exception _
+                              (clojure {:dir "src"} "-M:dev -m cljstyle.main fix")))}}}

--- a/examples/todomvc/build.clj
+++ b/examples/todomvc/build.clj
@@ -1,0 +1,41 @@
+(ns build
+  (:require [clojure.string :as string]
+            [clojure.tools.build.api :as b]))
+
+(def lib 'mycelium/todomvc)
+(def main-cls (string/join "." (filter some? [(namespace lib) (name lib) "core"])))
+(def version (format "0.0.1-SNAPSHOT"))
+(def target-dir "target")
+(def class-dir (str target-dir "/" "classes"))
+(def uber-file (format "%s/%s-standalone.jar" target-dir (name lib)))
+(def basis (b/create-basis {:project "deps.edn"}))
+
+(defn clean
+  "Delete the build target directory"
+  [_]
+  (println (str "Cleaning " target-dir))
+  (b/delete {:path target-dir}))
+
+(defn prep [_]
+  (println "Writing Pom...")
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src/clj"]})
+  (b/copy-dir {:src-dirs ["src/clj" "resources" "env/prod/resources" "env/prod/clj"]
+               :target-dir class-dir}))
+
+(defn uber [_]
+  (println "Compiling Clojure...")
+  (b/compile-clj {:basis basis
+                  :src-dirs ["src/clj" "resources" "env/prod/resources" "env/prod/clj"]
+                  :class-dir class-dir})
+  (println "Making uberjar...")
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :main main-cls
+           :basis basis}))
+
+(defn all [_]
+  (do (clean nil) (prep nil) (uber nil)))

--- a/examples/todomvc/deps.edn
+++ b/examples/todomvc/deps.edn
@@ -1,0 +1,73 @@
+{:paths   ["src/clj"
+           "resources"]
+
+ :deps    {org.clojure/clojure             {:mvn/version "1.12.4"}
+
+           ;; Routing
+           metosin/reitit                  {:mvn/version "0.10.0"}
+
+           ;; Ring
+           metosin/ring-http-response      {:mvn/version "0.9.5"}
+           ring/ring-core                  {:mvn/version "1.15.3"}
+           ring/ring-defaults              {:mvn/version "0.7.0"}
+
+           ;; Logging
+           ch.qos.logback/logback-classic  {:mvn/version "1.5.32"}
+
+           ;; Data coercion
+           luminus-transit/luminus-transit {:mvn/version "0.1.6"
+                                            :exclusions [com.cognitect/transit-clj]}
+           metosin/muuntaja                {:mvn/version "0.6.11"}
+
+           ;; kit Libs
+           io.github.kit-clj/kit-core {:mvn/version "1.0.10"}
+           io.github.kit-clj/kit-undertow {:mvn/version "1.0.10"}
+
+           ;; Mycelium
+           io.github.yogthos/mycelium {:local/root "../.."}
+
+           ;; Templating
+           selmer/selmer {:mvn/version "1.12.61"}
+
+           ;; DB
+           com.github.seancorfield/next.jdbc {:mvn/version "1.3.939"}
+           org.xerial/sqlite-jdbc            {:mvn/version "3.47.1.0"}
+           migratus/migratus                 {:mvn/version "1.5.6"}
+           }
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.12"}}
+                   :ns-default build}
+
+
+           :dev  {:extra-deps  {com.lambdaisland/classpath      {:mvn/version "0.6.58"}
+                                criterium/criterium             {:mvn/version "0.4.6"}
+                                expound/expound                 {:mvn/version "0.9.0"}
+                                integrant/repl                  {:mvn/version "0.5.0"}
+                                mvxcvi/cljstyle                 {:mvn/version "0.17.642"}
+                                pjstadig/humane-test-output     {:mvn/version "0.11.0"}
+                                ring/ring-devel                 {:mvn/version "1.15.3"}
+                                ring/ring-mock                  {:mvn/version "0.6.2"}
+                                io.github.kit-clj/kit-generator {:mvn/version "0.2.9"}
+                                org.clojure/tools.namespace     {:mvn/version "1.5.1"}
+                                }
+                  :extra-paths ["env/dev/clj" "env/dev/resources" "test/clj"]}
+           :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.5.1"}}
+                   :main-opts  ["-m" "nrepl.cmdline" "-i"]}
+           :cider {:extra-deps {nrepl/nrepl       {:mvn/version "1.5.1"}
+                                cider/cider-nrepl {:mvn/version "0.58.0"}}
+                   :main-opts  ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]" "-i"]}
+
+           :test {:extra-deps  {lambdaisland/kaocha                   {:mvn/version "1.91.1392"}
+                                criterium/criterium                  {:mvn/version "0.4.6"}
+                                expound/expound                      {:mvn/version "0.9.0"}
+                                integrant/repl                       {:mvn/version "0.5.0"}
+                                pjstadig/humane-test-output          {:mvn/version "0.11.0"}
+                                ring/ring-devel                      {:mvn/version "1.15.3"}
+                                ring/ring-mock                       {:mvn/version "0.6.2"}
+                                io.github.kit-clj/kit-generator      {:mvn/version "0.2.9"}
+                                org.clojure/tools.namespace          {:mvn/version "1.5.0"}
+                                peridot/peridot                      {:mvn/version "0.5.4"}
+                                org.clj-commons/byte-streams         {:mvn/version "0.3.4"}
+                                com.lambdaisland/classpath           {:mvn/version "0.6.58"}}
+                  :extra-paths ["env/dev/clj" "env/dev/resources" "env/test/resources" "test/clj"]
+                  :main-opts   ["-m" "kaocha.runner"]}}
+ }

--- a/examples/todomvc/env/dev/clj/mycelium/todomvc/dev_middleware.clj
+++ b/examples/todomvc/env/dev/clj/mycelium/todomvc/dev_middleware.clj
@@ -1,0 +1,5 @@
+(ns mycelium.todomvc.dev-middleware)
+
+(defn wrap-dev [handler _opts]
+  (-> handler
+      ))

--- a/examples/todomvc/env/dev/clj/mycelium/todomvc/env.clj
+++ b/examples/todomvc/env/dev/clj/mycelium/todomvc/env.clj
@@ -1,0 +1,14 @@
+(ns mycelium.todomvc.env
+  (:require
+    [clojure.tools.logging :as log]
+    [mycelium.todomvc.dev-middleware :refer [wrap-dev]]))
+
+(def defaults
+  {:init       (fn []
+                 (log/info "\n-=[todomvc starting using the development or test profile]=-"))
+   :start      (fn []
+                 (log/info "\n-=[todomvc started successfully using the development or test profile]=-"))
+   :stop       (fn []
+                 (log/info "\n-=[todomvc has shut down successfully]=-"))
+   :middleware wrap-dev
+   :opts       {:profile       :dev}})

--- a/examples/todomvc/env/dev/clj/user.clj
+++ b/examples/todomvc/env/dev/clj/user.clj
@@ -1,0 +1,51 @@
+(ns user
+  "Userspace functions you can run by default in your local REPL."
+  (:require
+    [clojure.pprint]
+    [clojure.spec.alpha :as s]
+    [clojure.tools.namespace.repl :as repl]
+    [criterium.core :as c]                                  ;; benchmarking
+    [expound.alpha :as expound]
+    [integrant.core :as ig]
+    [integrant.repl :refer [clear go halt prep init reset reset-all]]
+    [integrant.repl.state :as state]
+    [kit.api :as kit]
+    [lambdaisland.classpath :as licp]
+    [mycelium.todomvc.core :refer [start-app]]))
+
+(alter-var-root #'s/*explain-out* (constantly expound/printer))
+
+(add-tap (bound-fn* clojure.pprint/pprint))
+
+(defn dev-prep!
+  []
+  (integrant.repl/set-prep! (fn []
+                              (-> (mycelium.todomvc.config/system-config {:profile :dev})
+                                  (ig/expand)))))
+
+(defn test-prep!
+  []
+  (integrant.repl/set-prep! (fn []
+                              (-> (mycelium.todomvc.config/system-config {:profile :test})
+                                  (ig/expand)))))
+
+;; Can change this to test-prep! if want to run tests as the test profile in your repl
+;; You can run tests in the dev profile, too, but there are some differences between
+;; the two profiles.
+(dev-prep!)
+
+(repl/set-refresh-dirs "src/clj")
+
+(def refresh repl/refresh)
+
+
+
+(defn update-deps
+  "Refresh classpath to pick up deps.edn changes."
+  []
+  (licp/update-classpath! {:aliases [:dev :test]}))
+
+(comment
+  (go)
+  (reset)
+  (update-deps))

--- a/examples/todomvc/env/dev/resources/logback.xml
+++ b/examples/todomvc/env/dev/resources/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="10 seconds">
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>log/mycelium.todomvc.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>log/mycelium.todomvc.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- keep 30 days of history -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <logger name="org.eclipse.aether" level="warn" />
+    <logger name="io.methvin.watcher" level="warn" />
+    <logger name="org.eclipse.jgit" level="warn" />
+    <logger name="com.zaxxer.hikari" level="warn" />
+    <logger name="org.apache.http" level="warn" />
+    <logger name="org.xnio.nio" level="warn" />
+    <logger name="io.undertow" level="warn" />
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/examples/todomvc/env/prod/clj/mycelium/todomvc/env.clj
+++ b/examples/todomvc/env/prod/clj/mycelium/todomvc/env.clj
@@ -1,0 +1,12 @@
+(ns mycelium.todomvc.env
+  (:require [clojure.tools.logging :as log]))
+
+(def defaults
+  {:init       (fn []
+                 (log/info "\n-=[todomvc starting]=-"))
+   :start      (fn []
+                 (log/info "\n-=[todomvc started successfully]=-"))
+   :stop       (fn []
+                 (log/info "\n-=[todomvc has shut down successfully]=-"))
+   :middleware (fn [handler _] handler)
+   :opts       {:profile :prod}})

--- a/examples/todomvc/env/prod/resources/logback.xml
+++ b/examples/todomvc/env/prod/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5relative %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="com.zaxxer.hikari" level="error" />
+    <logger name="org.apache.http" level="error" />
+    <logger name="org.xnio.nio" level="error" />
+    <logger name="io.undertow" level="error" />
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/todomvc/env/test/resources/logback.xml
+++ b/examples/todomvc/env/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5relative %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="com.zaxxer.hikari" level="error" />
+    <logger name="org.apache.http" level="error" />
+    <logger name="org.xnio.nio" level="error" />
+    <logger name="io.undertow" level="error" />
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/todomvc/kit.edn
+++ b/examples/todomvc/kit.edn
@@ -1,0 +1,8 @@
+{:full-name "mycelium/todomvc"
+ :ns-name   "mycelium.todomvc"
+ :sanitized "mycelium/todomvc"
+ :name      "todomvc"
+ :modules   {:root         "modules"
+             :repositories [{:url  "https://github.com/kit-clj/modules.git"
+                             :tag  "master"
+                             :name "kit-modules"}]}}

--- a/examples/todomvc/resources/fragments/fetch-render-list.edn
+++ b/examples/todomvc/resources/fragments/fetch-render-list.edn
@@ -1,0 +1,43 @@
+{:id    :fetch-render-list
+ :doc   "Fetch filtered todos + stats, render the list fragment"
+
+ :entry :fetch-list
+ :exits [:done]
+
+ :cells
+ {:fetch-list
+  {:id       :todo/list
+   :doc      "Fetch filtered list of todos"
+   :schema   {:input  [:map [:filter :string]]
+              :output [:map [:todos [:vector :map]]]}
+   :on-error nil
+   :requires [:db]}
+
+  :fetch-stats
+  {:id       :todo/count-stats
+   :doc      "Fetch todo count statistics"
+   :schema   {:input  [:map]
+              :output [:map [:stats [:map
+                              [:active :int]
+                              [:completed :int]
+                              [:total :int]]]]}
+   :on-error nil
+   :requires [:db]}
+
+  :render-list
+  {:id       :ui/render-todo-list
+   :doc      "Render the todo list fragment"
+   :schema   {:input  [:map
+                [:todos [:vector :map]]
+                [:stats [:map [:active :int] [:completed :int] [:total :int]]]
+                [:filter :string]]
+              :output [:map [:html :string]]}
+   :on-error nil
+   :requires []}}
+
+ :edges
+ {:fetch-list  :fetch-stats
+  :fetch-stats :render-list
+  :render-list :_exit/done}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/migrations/20240101000000-create-todos.down.sql
+++ b/examples/todomvc/resources/migrations/20240101000000-create-todos.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS todos;

--- a/examples/todomvc/resources/migrations/20240101000000-create-todos.up.sql
+++ b/examples/todomvc/resources/migrations/20240101000000-create-todos.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS todos (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  title      TEXT NOT NULL,
+  completed  INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/examples/todomvc/resources/system.edn
+++ b/examples/todomvc/resources/system.edn
@@ -1,0 +1,58 @@
+{:todomvc/db
+ {:jdbc-url "jdbc:sqlite:todomvc.db"}
+
+ :todomvc/migrations
+ {:db #ig/ref :todomvc/db}
+
+ :system/env
+ #profile {:dev  :dev
+           :test :test
+           :prod :prod}
+ 
+ 
+ 
+ 
+
+ :server/http
+ {:port    #long #or [#env PORT 3000]
+  :host    #or [#env HTTP_HOST "0.0.0.0"]
+  :handler #ig/ref :handler/ring}
+
+ :handler/ring
+ {:router                #ig/ref :router/core
+  :api-path              "/api"
+  :cookie-secret         #or [#env COOKIE_SECRET "KYLWZSYQHCLRMCYB"]
+  ;; from ring.middleware.defaults. anti-forgery `false` by default because services may not require it
+  :site-defaults-config  {:params    {:urlencoded true
+                                      :multipart  true
+                                      :nested     true
+                                      :keywordize true}
+                          :cookies   true
+                          :session   {:flash true
+                                      :cookie-name "mycelium.todomvc"
+                                      :cookie-attrs {:max-age     86400
+                                                     :http-only   true
+                                                     :same-site   :strict}}
+                          :security  {:anti-forgery   false
+                                      :xss-protection {:enable? true, :mode :block}
+                                      :frame-options  :sameorigin
+                                      :content-type-options :nosniff}
+                          :static    {:resources "public"}
+                          :responses {:not-modified-responses true
+                                      :absolute-redirects     true
+                                      :content-types          true
+                                      :default-charset        "utf-8"}}}
+
+ :reitit.routes/api
+ {:base-path "/api"
+  :env       #ig/ref :system/env}
+
+ :reitit.routes/pages
+ {:db #ig/ref :todomvc/db}
+
+ :router/routes
+ {:routes #ig/refset :reitit/routes}
+
+ :router/core
+ {:routes #ig/ref :router/routes
+  :env #ig/ref :system/env} }

--- a/examples/todomvc/resources/templates/base.html
+++ b/examples/todomvc/resources/templates/base.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TodoMVC — Mycelium</title>
+  <link rel="stylesheet" href="https://unpkg.com/todomvc-common@1.0.5/base.css">
+  <link rel="stylesheet" href="https://unpkg.com/todomvc-app-css@2.4.3/index.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/examples/todomvc/resources/templates/partials/todo-list.html
+++ b/examples/todomvc/resources/templates/partials/todo-list.html
@@ -1,0 +1,38 @@
+{% if stats.total > 0 %}
+<section class="main">
+  <input id="toggle-all" class="toggle-all" type="checkbox"
+         hx-post="/todos/toggle-all?filter={{filter}}" hx-target="#todo-container" hx-swap="innerHTML"
+         {% if stats.active = 0 %}checked{% endif %}>
+  <label for="toggle-all">Mark all as complete</label>
+  <ul class="todo-list">
+    {% for todo in todos %}
+    <li class="{% if todo.completed = 1 %}completed{% endif %}" id="todo-{{todo.id}}">
+      <div class="view">
+        <input class="toggle" type="checkbox"
+               hx-patch="/todos/{{todo.id}}/toggle?filter={{filter}}" hx-target="#todo-container" hx-swap="innerHTML"
+               {% if todo.completed = 1 %}checked{% endif %}>
+        <label hx-get="/todos/{{todo.id}}/edit?filter={{filter}}" hx-trigger="dblclick"
+               hx-target="#todo-{{todo.id}}" hx-swap="innerHTML">{{todo.title}}</label>
+        <button class="destroy"
+                hx-delete="/todos/{{todo.id}}?filter={{filter}}" hx-target="#todo-container" hx-swap="innerHTML"></button>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+<footer class="footer">
+  <span class="todo-count"><strong>{{stats.active}}</strong> {% if stats.active = 1 %}item{% else %}items{% endif %} left</span>
+  <ul class="filters">
+    <li><a href="/?filter=all" class="{% if filter = "all" %}selected{% endif %}"
+           hx-get="/?filter=all" hx-target="#todo-container" hx-swap="innerHTML" hx-push-url="true">All</a></li>
+    <li><a href="/?filter=active" class="{% if filter = "active" %}selected{% endif %}"
+           hx-get="/?filter=active" hx-target="#todo-container" hx-swap="innerHTML" hx-push-url="true">Active</a></li>
+    <li><a href="/?filter=completed" class="{% if filter = "completed" %}selected{% endif %}"
+           hx-get="/?filter=completed" hx-target="#todo-container" hx-swap="innerHTML" hx-push-url="true">Completed</a></li>
+  </ul>
+  {% if stats.completed > 0 %}
+  <button class="clear-completed"
+          hx-post="/todos/clear-completed?filter={{filter}}" hx-target="#todo-container" hx-swap="innerHTML">Clear completed</button>
+  {% endif %}
+</footer>
+{% endif %}

--- a/examples/todomvc/resources/templates/todo-page.html
+++ b/examples/todomvc/resources/templates/todo-page.html
@@ -1,0 +1,19 @@
+{% extends "templates/base.html" %}
+{% block content %}
+<section class="todoapp">
+  <header class="header">
+    <h1>todos</h1>
+    <form hx-post="/todos" hx-target="#todo-container" hx-swap="innerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset()">
+      <input class="new-todo" name="title" placeholder="What needs to be done?" autofocus>
+    </form>
+  </header>
+  <div id="todo-container">
+    {% include "templates/partials/todo-list.html" %}
+  </div>
+</section>
+<footer class="info">
+  <p>Double-click to edit a todo</p>
+  <p>Built with <a href="https://github.com/yogthos/mycelium">Mycelium</a> + HTMX</p>
+</footer>
+{% endblock %}

--- a/examples/todomvc/resources/workflows/todo-add.edn
+++ b/examples/todomvc/resources/workflows/todo-add.edn
@@ -1,0 +1,32 @@
+{:id :todo-add
+ :doc "Add a new todo, then fetch + render list"
+
+ :input-schema [:map [:http-request :map]]
+
+ :fragments
+ {:tail {:ref   "fragments/fetch-render-list.edn"
+         :as    :fetch-list
+         :exits {:done :end}}}
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:title :string] [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :create
+  {:id       :todo/create
+   :doc      "Create a new todo"
+   :schema   {:input  [:map [:title :string]]
+              :output [:map [:created-id :int]]}
+   :on-error nil
+   :requires [:db]}}
+
+ :edges
+ {:start  :create
+  :create :fetch-list}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/workflows/todo-clear.edn
+++ b/examples/todomvc/resources/workflows/todo-clear.edn
@@ -1,0 +1,32 @@
+{:id :todo-clear
+ :doc "Clear completed todos, then fetch + render list"
+
+ :input-schema [:map [:http-request :map]]
+
+ :fragments
+ {:tail {:ref   "fragments/fetch-render-list.edn"
+         :as    :fetch-list
+         :exits {:done :end}}}
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :clear
+  {:id       :todo/clear-completed
+   :doc      "Delete all completed todos"
+   :schema   {:input  [:map]
+              :output [:map]}
+   :on-error nil
+   :requires [:db]}}
+
+ :edges
+ {:start :clear
+  :clear :fetch-list}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/workflows/todo-delete.edn
+++ b/examples/todomvc/resources/workflows/todo-delete.edn
@@ -1,0 +1,32 @@
+{:id :todo-delete
+ :doc "Delete a todo, then fetch + render list"
+
+ :input-schema [:map [:http-request :map]]
+
+ :fragments
+ {:tail {:ref   "fragments/fetch-render-list.edn"
+         :as    :fetch-list
+         :exits {:done :end}}}
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:todo-id :int] [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :delete
+  {:id       :todo/delete
+   :doc      "Delete the todo"
+   :schema   {:input  [:map [:todo-id :int]]
+              :output [:map]}
+   :on-error nil
+   :requires [:db]}}
+
+ :edges
+ {:start  :delete
+  :delete :fetch-list}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/workflows/todo-page.edn
+++ b/examples/todomvc/resources/workflows/todo-page.edn
@@ -1,0 +1,54 @@
+{:id :todo-page
+ :doc "Full page render: parse request, fetch todos + stats, render page"
+
+ :input-schema [:map [:http-request :map]]
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :fetch-list
+  {:id       :todo/list
+   :doc      "Fetch filtered list of todos"
+   :schema   {:input  [:map [:filter :string]]
+              :output [:map [:todos [:vector :map]]]}
+   :on-error nil
+   :requires [:db]}
+
+  :fetch-stats
+  {:id       :todo/count-stats
+   :doc      "Fetch todo count statistics"
+   :schema   {:input  [:map]
+              :output [:map [:stats [:map
+                              [:active :int]
+                              [:completed :int]
+                              [:total :int]]]]}
+   :on-error nil
+   :requires [:db]}
+
+  :render-page
+  {:id       :ui/render-todo-page
+   :doc      "Render the full TodoMVC page"
+   :schema   {:input  [:map
+                [:todos [:vector :map]]
+                [:stats [:map [:active :int] [:completed :int] [:total :int]]]
+                [:filter :string]]
+              :output [:map [:html :string]]}
+   :on-error nil
+   :requires []}}
+
+ :joins
+ {:fetch-data {:cells    [:fetch-list :fetch-stats]
+               :strategy :parallel}}
+
+ :edges
+ {:start      :fetch-data
+  :fetch-data {:done :render-page}
+  :render-page :end}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/workflows/todo-toggle-all.edn
+++ b/examples/todomvc/resources/workflows/todo-toggle-all.edn
@@ -1,0 +1,32 @@
+{:id :todo-toggle-all
+ :doc "Toggle all todos, then fetch + render list"
+
+ :input-schema [:map [:http-request :map]]
+
+ :fragments
+ {:tail {:ref   "fragments/fetch-render-list.edn"
+         :as    :fetch-list
+         :exits {:done :end}}}
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :toggle-all
+  {:id       :todo/toggle-all
+   :doc      "Toggle all todos"
+   :schema   {:input  [:map]
+              :output [:map]}
+   :on-error nil
+   :requires [:db]}}
+
+ :edges
+ {:start      :toggle-all
+  :toggle-all :fetch-list}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/workflows/todo-toggle.edn
+++ b/examples/todomvc/resources/workflows/todo-toggle.edn
@@ -1,0 +1,32 @@
+{:id :todo-toggle
+ :doc "Toggle a todo, then fetch + render list"
+
+ :input-schema [:map [:http-request :map]]
+
+ :fragments
+ {:tail {:ref   "fragments/fetch-render-list.edn"
+         :as    :fetch-list
+         :exits {:done :end}}}
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:todo-id :int] [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :toggle
+  {:id       :todo/toggle
+   :doc      "Toggle todo completed status"
+   :schema   {:input  [:map [:todo-id :int]]
+              :output [:map]}
+   :on-error nil
+   :requires [:db]}}
+
+ :edges
+ {:start  :toggle
+  :toggle :fetch-list}
+
+ :dispatches {}}

--- a/examples/todomvc/resources/workflows/todo-update.edn
+++ b/examples/todomvc/resources/workflows/todo-update.edn
@@ -1,0 +1,32 @@
+{:id :todo-update
+ :doc "Update a todo title, then fetch + render list"
+
+ :input-schema [:map [:http-request :map]]
+
+ :fragments
+ {:tail {:ref   "fragments/fetch-render-list.edn"
+         :as    :fetch-list
+         :exits {:done :end}}}
+
+ :cells
+ {:start
+  {:id       :request/parse-todo
+   :doc      "Parse request parameters"
+   :schema   {:input  [:map [:http-request :map]]
+              :output [:map [:todo-id :int] [:title :string] [:filter :string]]}
+   :on-error nil
+   :requires []}
+
+  :update-title
+  {:id       :todo/update-title
+   :doc      "Update the todo title"
+   :schema   {:input  [:map [:todo-id :int] [:title :string]]
+              :output [:map]}
+   :on-error nil
+   :requires [:db]}}
+
+ :edges
+ {:start        :update-title
+  :update-title :fetch-list}
+
+ :dispatches {}}

--- a/examples/todomvc/src/clj/mycelium/todomvc/cells/request.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/cells/request.clj
@@ -1,0 +1,33 @@
+(ns mycelium.todomvc.cells.request
+  (:require [mycelium.cell :as cell]
+            [clojure.string :as str]))
+
+(defmethod cell/cell-spec :request/parse-todo [_]
+  {:id      :request/parse-todo
+   :doc     "Extract todo-related params from an HTTP request"
+   :handler (fn [_resources data]
+              (let [req         (:http-request data)
+                    path-params (or (:path-params req) {})
+                    form-params (or (:form-params req) (:params req) {})
+                    query-params (or (:query-params req) {})
+                    headers     (or (:headers req) {})
+                    ;; Parse todo-id from path params (support both string and keyword keys)
+                    raw-id      (or (get path-params :id)
+                                    (get path-params "id"))
+                    todo-id     (when raw-id
+                                  (try (Long/parseLong (str raw-id))
+                                       (catch Exception _ nil)))
+                    ;; Extract title from form params
+                    raw-title   (or (get form-params :title)
+                                    (get form-params "title"))
+                    title       (when raw-title (str/trim (str raw-title)))
+                    ;; Extract filter from query params
+                    filter-val  (or (get query-params :filter)
+                                    (get query-params "filter")
+                                    "all")
+                    ;; Check if HTMX request
+                    htmx?       (some? (or (get headers "hx-request")
+                                           (get headers "HX-Request")))]
+                (cond-> (assoc data :filter filter-val :htmx? htmx?)
+                  todo-id (assoc :todo-id todo-id)
+                  (and title (not (str/blank? title))) (assoc :title title))))})

--- a/examples/todomvc/src/clj/mycelium/todomvc/cells/todo.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/cells/todo.clj
@@ -1,0 +1,57 @@
+(ns mycelium.todomvc.cells.todo
+  (:require [mycelium.cell :as cell]
+            [mycelium.todomvc.db :as db]))
+
+(defmethod cell/cell-spec :todo/list [_]
+  {:id      :todo/list
+   :doc     "Fetch filtered list of todos"
+   :handler (fn [{:keys [db]} data]
+              (assoc data :todos (db/list-todos db (or (:filter data) "all"))))})
+
+(defmethod cell/cell-spec :todo/count-stats [_]
+  {:id      :todo/count-stats
+   :doc     "Fetch todo count statistics"
+   :handler (fn [{:keys [db]} data]
+              (assoc data :stats (db/count-stats db)))})
+
+(defmethod cell/cell-spec :todo/create [_]
+  {:id      :todo/create
+   :doc     "Create a new todo"
+   :handler (fn [{:keys [db]} data]
+              (let [{:keys [id]} (db/create-todo! db (:title data))]
+                (assoc data :created-id id)))})
+
+(defmethod cell/cell-spec :todo/toggle [_]
+  {:id      :todo/toggle
+   :doc     "Toggle a todo's completed status"
+   :handler (fn [{:keys [db]} data]
+              (db/toggle-todo! db (:todo-id data))
+              data)})
+
+(defmethod cell/cell-spec :todo/update-title [_]
+  {:id      :todo/update-title
+   :doc     "Update a todo's title"
+   :handler (fn [{:keys [db]} data]
+              (db/update-todo-title! db (:todo-id data) (:title data))
+              data)})
+
+(defmethod cell/cell-spec :todo/delete [_]
+  {:id      :todo/delete
+   :doc     "Delete a todo"
+   :handler (fn [{:keys [db]} data]
+              (db/delete-todo! db (:todo-id data))
+              data)})
+
+(defmethod cell/cell-spec :todo/toggle-all [_]
+  {:id      :todo/toggle-all
+   :doc     "Toggle all todos"
+   :handler (fn [{:keys [db]} data]
+              (db/toggle-all! db)
+              data)})
+
+(defmethod cell/cell-spec :todo/clear-completed [_]
+  {:id      :todo/clear-completed
+   :doc     "Delete all completed todos"
+   :handler (fn [{:keys [db]} data]
+              (db/clear-completed! db)
+              data)})

--- a/examples/todomvc/src/clj/mycelium/todomvc/cells/ui.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/cells/ui.clj
@@ -1,0 +1,23 @@
+(ns mycelium.todomvc.cells.ui
+  (:require [mycelium.cell :as cell]
+            [selmer.parser :as selmer]))
+
+(defmethod cell/cell-spec :ui/render-todo-page [_]
+  {:id      :ui/render-todo-page
+   :doc     "Render the full TodoMVC page"
+   :handler (fn [_resources data]
+              (assoc data :html
+                     (selmer/render-file "templates/todo-page.html"
+                                         {:todos  (:todos data)
+                                          :stats  (:stats data)
+                                          :filter (or (:filter data) "all")})))})
+
+(defmethod cell/cell-spec :ui/render-todo-list [_]
+  {:id      :ui/render-todo-list
+   :doc     "Render the todo list fragment for HTMX swaps"
+   :handler (fn [_resources data]
+              (assoc data :html
+                     (selmer/render-file "templates/partials/todo-list.html"
+                                         {:todos  (:todos data)
+                                          :stats  (:stats data)
+                                          :filter (or (:filter data) "all")})))})

--- a/examples/todomvc/src/clj/mycelium/todomvc/config.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/config.clj
@@ -1,0 +1,9 @@
+(ns mycelium.todomvc.config
+  (:require
+    [kit.config :as config]))
+
+(def ^:const system-filename "system.edn")
+
+(defn system-config
+  [options]
+  (config/read-config system-filename options))

--- a/examples/todomvc/src/clj/mycelium/todomvc/core.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/core.clj
@@ -1,0 +1,42 @@
+(ns mycelium.todomvc.core
+  (:require
+   [clojure.tools.logging :as log]
+   [integrant.core :as ig]
+   [mycelium.todomvc.config :as config]
+   [mycelium.todomvc.env :refer [defaults]]
+
+    ;; Edges
+   [kit.edge.server.undertow]
+   [mycelium.todomvc.web.handler]
+
+    ;; Routes
+   [mycelium.todomvc.web.routes.api]
+   [mycelium.todomvc.web.routes.pages]
+
+    ;; System components
+   [mycelium.todomvc.system])
+  (:gen-class))
+
+;; log uncaught exceptions in threads
+(Thread/setDefaultUncaughtExceptionHandler
+ (fn [thread ex]
+   (log/error {:what :uncaught-exception
+               :exception ex
+               :where (str "Uncaught exception on" (.getName thread))})))
+
+(defonce system (atom nil))
+
+(defn stop-app []
+  ((or (:stop defaults) (fn [])))
+  (some-> (deref system) (ig/halt!)))
+
+(defn start-app [& [params]]
+  ((or (:start params) (:start defaults) (fn [])))
+  (->> (config/system-config (or (:opts params) (:opts defaults) {}))
+       (ig/expand)
+       (ig/init)
+       (reset! system)))
+
+(defn -main [& _]
+  (start-app)
+  (.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] (stop-app) (shutdown-agents)))))

--- a/examples/todomvc/src/clj/mycelium/todomvc/db.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/db.clj
@@ -1,0 +1,75 @@
+(ns mycelium.todomvc.db
+  (:require [next.jdbc :as jdbc]
+            [next.jdbc.result-set :as rs]))
+
+(def ^:private query-opts {:builder-fn rs/as-unqualified-lower-maps})
+
+(defn list-todos
+  "Returns todos filtered by status. filter is \"all\", \"active\", or \"completed\"."
+  [ds filter-str]
+  (case filter-str
+    "active"    (jdbc/execute! ds
+                  ["SELECT id, title, completed, created_at FROM todos WHERE completed = 0 ORDER BY id"]
+                  query-opts)
+    "completed" (jdbc/execute! ds
+                  ["SELECT id, title, completed, created_at FROM todos WHERE completed = 1 ORDER BY id"]
+                  query-opts)
+    ;; default: all
+    (jdbc/execute! ds
+      ["SELECT id, title, completed, created_at FROM todos ORDER BY id"]
+      query-opts)))
+
+(defn count-stats
+  "Returns {:active n :completed n :total n}."
+  [ds]
+  (let [rows (jdbc/execute! ds
+               ["SELECT completed, COUNT(*) as cnt FROM todos GROUP BY completed"]
+               query-opts)
+        by-status (into {} (map (fn [r] [(:completed r) (:cnt r)])) rows)
+        active    (get by-status 0 0)
+        completed (get by-status 1 0)]
+    {:active    active
+     :completed completed
+     :total     (+ active completed)}))
+
+(defn create-todo!
+  "Inserts a new todo. Returns {:id n}."
+  [ds title]
+  (jdbc/with-transaction [tx ds]
+    (jdbc/execute-one! tx
+      ["INSERT INTO todos (title) VALUES (?)" title])
+    (let [result (jdbc/execute-one! tx
+                   ["SELECT last_insert_rowid() as id"]
+                   query-opts)]
+      {:id (:id result)})))
+
+(defn toggle-todo!
+  "Flips the completed status of a todo."
+  [ds id]
+  (jdbc/execute-one! ds
+    ["UPDATE todos SET completed = CASE WHEN completed = 0 THEN 1 ELSE 0 END WHERE id = ?" id]))
+
+(defn update-todo-title!
+  "Updates the title of a todo."
+  [ds id title]
+  (jdbc/execute-one! ds
+    ["UPDATE todos SET title = ? WHERE id = ?" title id]))
+
+(defn delete-todo!
+  "Deletes a todo by id."
+  [ds id]
+  (jdbc/execute-one! ds
+    ["DELETE FROM todos WHERE id = ?" id]))
+
+(defn toggle-all!
+  "If any are incomplete, mark all complete. Otherwise mark all incomplete."
+  [ds]
+  (let [stats (count-stats ds)]
+    (if (pos? (:active stats))
+      (jdbc/execute-one! ds ["UPDATE todos SET completed = 1"])
+      (jdbc/execute-one! ds ["UPDATE todos SET completed = 0"]))))
+
+(defn clear-completed!
+  "Deletes all completed todos."
+  [ds]
+  (jdbc/execute-one! ds ["DELETE FROM todos WHERE completed = 1"]))

--- a/examples/todomvc/src/clj/mycelium/todomvc/system.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/system.clj
@@ -1,0 +1,17 @@
+(ns mycelium.todomvc.system
+  (:require [integrant.core :as ig]
+            [next.jdbc :as jdbc]
+            [migratus.core :as migratus]))
+
+(defmethod ig/init-key :todomvc/db
+  [_ {:keys [jdbc-url]}]
+  (let [ds (jdbc/get-datasource {:jdbcUrl jdbc-url})]
+    (jdbc/execute-one! ds ["SELECT 1"])
+    ds))
+
+(defmethod ig/init-key :todomvc/migrations
+  [_ {:keys [db]}]
+  (migratus/migrate {:store         :database
+                     :migration-dir "migrations"
+                     :db            {:datasource db}})
+  :migrated)

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/controllers/health.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/controllers/health.clj
@@ -1,0 +1,13 @@
+(ns mycelium.todomvc.web.controllers.health
+  (:require
+    [ring.util.http-response :as http-response])
+  (:import
+    [java.util Date]))
+
+(defn healthcheck!
+  [req]
+  (http-response/ok
+    {:time     (str (Date. (System/currentTimeMillis)))
+     :up-since (str (Date. (.getStartTime (java.lang.management.ManagementFactory/getRuntimeMXBean))))
+     :app      {:status  "up"
+                :message ""}}))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/handler.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/handler.clj
@@ -1,0 +1,46 @@
+(ns mycelium.todomvc.web.handler
+  (:require
+    [mycelium.todomvc.web.middleware.core :as middleware]
+    [integrant.core :as ig]
+    [ring.util.http-response :as http-response]
+    [reitit.ring :as ring]
+    [reitit.swagger-ui :as swagger-ui]))
+
+(defmethod ig/init-key :handler/ring
+  [_ {:keys [router api-path] :as opts}]
+  (ring/ring-handler
+   (router)
+    (ring/routes
+     ;; Handle trailing slash in routes - add it + redirect to it
+     ;; https://github.com/metosin/reitit/blob/master/doc/ring/slash_handler.md
+     (ring/redirect-trailing-slash-handler)
+     (ring/create-resource-handler {:path "/"})
+     (when (some? api-path)
+       (swagger-ui/create-swagger-ui-handler {:path api-path
+                                              :url  (str api-path "/swagger.json")}))
+     (ring/create-default-handler
+      {:not-found
+       (constantly (-> {:status 404, :body "Page not found"}
+                       (http-response/content-type "text/plain")))
+       :method-not-allowed
+       (constantly (-> {:status 405, :body "Not allowed"}
+                       (http-response/content-type "text/plain")))
+       :not-acceptable
+       (constantly (-> {:status 406, :body "Not acceptable"}
+                       (http-response/content-type "text/plain")))}))
+    {:middleware [(middleware/wrap-base opts)]}))
+
+(defmethod ig/init-key :router/routes
+  [_ {:keys [routes]}]
+  (mapv (fn [route]
+          (if (fn? route)
+            (route)
+            route))
+        routes))
+
+(defmethod ig/init-key :router/core
+  [_ {:keys [routes env] :as opts}]
+  (let [router-opts {:conflicts nil}]
+    (if (= env :dev)
+      #(ring/router ["" opts routes] router-opts)
+      (constantly (ring/router ["" opts routes] router-opts)))))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/middleware/core.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/middleware/core.clj
@@ -1,0 +1,14 @@
+(ns mycelium.todomvc.web.middleware.core
+  (:require
+    [mycelium.todomvc.env :as env]
+    [ring.middleware.defaults :as defaults]
+    [ring.middleware.session.cookie :as cookie]))
+
+(defn wrap-base
+  [{:keys [metrics site-defaults-config cookie-secret] :as opts}]
+  (let [cookie-store (cookie/cookie-store {:key (.getBytes ^String cookie-secret)})]
+    (fn [handler]
+      (cond-> ((:middleware env/defaults) handler opts)
+              true (defaults/wrap-defaults
+                     (assoc-in site-defaults-config [:session :store] cookie-store))
+              ))))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/middleware/exception.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/middleware/exception.clj
@@ -1,0 +1,31 @@
+(ns mycelium.todomvc.web.middleware.exception
+  (:require
+    [clojure.tools.logging :as log]
+    [reitit.ring.middleware.exception :as exception]))
+
+(defn handler [message status exception request]
+  (when (>= status 500)
+    ;; You can optionally use this to report error to an external service
+    (log/error exception))
+  {:status status
+   :body   {:message   message
+            :exception (.getClass exception)
+            :data      (ex-data exception)
+            :uri       (:uri request)}})
+
+(def wrap-exception
+  (exception/create-exception-middleware
+    (merge
+      exception/default-handlers
+      {:system.exception/internal     (partial handler "internal exception" 500)
+       :system.exception/business     (partial handler "bad request" 400)
+       :system.exception/not-found    (partial handler "not found" 404)
+       :system.exception/unauthorized (partial handler "unauthorized" 401)
+       :system.exception/forbidden    (partial handler "forbidden" 403)
+
+       ;; override the default handler
+       ::exception/default            (partial handler "default" 500)
+
+       ;; print stack-traces for all exceptions
+       ::exception/wrap               (fn [handler e request]
+                                        (handler e request))})))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/middleware/formats.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/middleware/formats.clj
@@ -1,0 +1,14 @@
+(ns mycelium.todomvc.web.middleware.formats
+  (:require
+    [luminus-transit.time :as time]
+    [muuntaja.core :as m]))
+
+(def instance
+  (m/create
+    (-> m/default-options
+        (update-in
+          [:formats "application/transit+json" :decoder-opts]
+          (partial merge time/time-deserialization-handlers))
+        (update-in
+          [:formats "application/transit+json" :encoder-opts]
+          (partial merge time/time-serialization-handlers)))))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/routes/api.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/routes/api.clj
@@ -1,0 +1,52 @@
+(ns mycelium.todomvc.web.routes.api
+  (:require
+    [mycelium.todomvc.web.controllers.health :as health]
+    [mycelium.todomvc.web.middleware.exception :as exception]
+    [mycelium.todomvc.web.middleware.formats :as formats]
+    [integrant.core :as ig]
+    [reitit.coercion.malli :as malli]
+    [reitit.ring.coercion :as coercion]
+    [reitit.ring.middleware.muuntaja :as muuntaja]
+    [reitit.ring.middleware.parameters :as parameters]
+    [reitit.swagger :as swagger]))
+
+(def route-data
+  {:coercion   malli/coercion
+   :muuntaja   formats/instance
+   :swagger    {:id ::api}
+   :middleware [;; query-params & form-params
+                parameters/parameters-middleware
+                  ;; content-negotiation
+                muuntaja/format-negotiate-middleware
+                  ;; encoding response body
+                muuntaja/format-response-middleware
+                  ;; exception handling
+                coercion/coerce-exceptions-middleware
+                  ;; decoding request body
+                muuntaja/format-request-middleware
+                  ;; coercing response bodys
+                coercion/coerce-response-middleware
+                  ;; coercing request parameters
+                coercion/coerce-request-middleware
+                  ;; exception handling
+                exception/wrap-exception]})
+
+;; Routes
+(defn api-routes [_opts]
+  [["/swagger.json"
+    {:get {:no-doc  true
+           :swagger {:info {:title "mycelium.todomvc API"}}
+           :handler (swagger/create-swagger-handler)}}]
+   ["/health"
+    ;; note that use of the var is necessary
+    ;; for reitit to reload routes without
+    ;; restarting the system
+    {:get #'health/healthcheck!}]])
+
+(derive :reitit.routes/api :reitit/routes)
+
+(defmethod ig/init-key :reitit.routes/api
+  [_ {:keys [base-path]
+      :or   {base-path ""}
+      :as   opts}]
+  (fn [] [base-path route-data (api-routes opts)]))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/routes/pages.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/routes/pages.clj
@@ -1,0 +1,35 @@
+(ns mycelium.todomvc.web.routes.pages
+  (:require [integrant.core :as ig]
+            [mycelium.todomvc.workflows.todo :as wf]
+            [reitit.ring.middleware.parameters :as parameters]))
+
+(defn- html-response [result]
+  {:status  200
+   :headers {"Content-Type" "text/html; charset=utf-8"}
+   :body    (:html result)})
+
+(defn- run-and-respond [runner-fn db request]
+  (html-response (runner-fn db request)))
+
+(defn page-routes [db]
+  [["/"
+    {:get {:handler (fn [req] (run-and-respond wf/run-page db req))}}]
+   ["/todos"
+    {:post {:handler (fn [req] (run-and-respond wf/run-add db req))}}]
+   ["/todos/toggle-all"
+    {:post {:handler (fn [req] (run-and-respond wf/run-toggle-all db req))}}]
+   ["/todos/clear-completed"
+    {:post {:handler (fn [req] (run-and-respond wf/run-clear db req))}}]
+   ["/todos/:id/toggle"
+    {:patch {:handler (fn [req] (run-and-respond wf/run-toggle db req))}}]
+   ["/todos/:id"
+    {:delete  {:handler (fn [req] (run-and-respond wf/run-delete db req))}
+     :put     {:handler (fn [req] (run-and-respond wf/run-update db req))}}]])
+
+(derive :reitit.routes/pages :reitit/routes)
+
+(defmethod ig/init-key :reitit.routes/pages
+  [_ {:keys [db]}]
+  (fn []
+    ["" {:middleware [parameters/parameters-middleware]}
+     (page-routes db)]))

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/routes/utils.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/routes/utils.clj
@@ -1,0 +1,11 @@
+(ns mycelium.todomvc.web.routes.utils)
+
+(def route-data-path [:reitit.core/match :data])
+
+(defn route-data
+  [req]
+  (get-in req route-data-path))
+
+(defn route-data-key
+  [req k]
+  (get-in req (conj route-data-path k)))

--- a/examples/todomvc/src/clj/mycelium/todomvc/workflows/todo.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/workflows/todo.clj
@@ -1,0 +1,46 @@
+(ns mycelium.todomvc.workflows.todo
+  (:require [mycelium.manifest :as manifest]
+            [mycelium.core :as myc]
+            [clojure.java.io :as io]
+            ;; Cell registrations
+            [mycelium.todomvc.cells.request]
+            [mycelium.todomvc.cells.todo]
+            [mycelium.todomvc.cells.ui]))
+
+(defn- load-and-compile [filename]
+  (let [manifest-data (manifest/load-manifest
+                        (str (io/resource (str "workflows/" filename))))
+        workflow-def  (manifest/manifest->workflow manifest-data)]
+    (myc/pre-compile workflow-def)))
+
+(def compiled-page       (load-and-compile "todo-page.edn"))
+(def compiled-add        (load-and-compile "todo-add.edn"))
+(def compiled-toggle     (load-and-compile "todo-toggle.edn"))
+(def compiled-delete     (load-and-compile "todo-delete.edn"))
+(def compiled-update     (load-and-compile "todo-update.edn"))
+(def compiled-toggle-all (load-and-compile "todo-toggle-all.edn"))
+(def compiled-clear      (load-and-compile "todo-clear.edn"))
+
+(defn- run [compiled db request]
+  (myc/run-compiled compiled {:db db} {:http-request request}))
+
+(defn run-page [db request]
+  (run compiled-page db request))
+
+(defn run-add [db request]
+  (run compiled-add db request))
+
+(defn run-toggle [db request]
+  (run compiled-toggle db request))
+
+(defn run-delete [db request]
+  (run compiled-delete db request))
+
+(defn run-update [db request]
+  (run compiled-update db request))
+
+(defn run-toggle-all [db request]
+  (run compiled-toggle-all db request))
+
+(defn run-clear [db request]
+  (run compiled-clear db request))

--- a/examples/todomvc/test/clj/mycelium/todomvc/cells/todo_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/cells/todo_test.clj
@@ -1,0 +1,104 @@
+(ns mycelium.todomvc.cells.todo-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.dev :as dev]
+            [mycelium.cell :as cell]
+            [mycelium.todomvc.db :as db]
+            [mycelium.todomvc.cells.todo]
+            [next.jdbc :as jdbc]
+            [migratus.core :as migratus])
+  (:import [java.io File]))
+
+(def ^:dynamic *ds* nil)
+
+(defn create-test-db []
+  (let [f   (File/createTempFile "todomvc-cell-test-" ".db")
+        _   (.deleteOnExit f)
+        url (str "jdbc:sqlite:" (.getAbsolutePath f))
+        ds  (jdbc/get-datasource {:jdbcUrl url})]
+    (migratus/migrate {:store         :database
+                       :migration-dir "migrations"
+                       :db            {:datasource ds}})
+    ds))
+
+(use-fixtures :each
+  (fn [f]
+    (when-not (cell/get-cell :todo/list)
+      (require 'mycelium.todomvc.cells.todo :reload))
+    (binding [*ds* (create-test-db)]
+      (f))))
+
+(deftest todo-list-cell-test
+  (testing ":todo/list returns todos"
+    (db/create-todo! *ds* "Test item")
+    (let [result (dev/test-cell :todo/list
+                  {:input     {:filter "all"}
+                   :resources {:db *ds*}})]
+      (is (:pass? result))
+      (is (= 1 (count (get-in result [:output :todos]))))
+      (is (= "Test item" (:title (first (get-in result [:output :todos]))))))))
+
+(deftest todo-count-stats-cell-test
+  (testing ":todo/count-stats returns stats"
+    (db/create-todo! *ds* "A")
+    (let [{:keys [id]} (db/create-todo! *ds* "B")]
+      (db/toggle-todo! *ds* id))
+    (let [result (dev/test-cell :todo/count-stats
+                  {:input     {}
+                   :resources {:db *ds*}})]
+      (is (:pass? result))
+      (is (= {:active 1 :completed 1 :total 2}
+             (get-in result [:output :stats]))))))
+
+(deftest todo-create-cell-test
+  (testing ":todo/create inserts a new todo"
+    (let [result (dev/test-cell :todo/create
+                  {:input     {:title "New todo"}
+                   :resources {:db *ds*}})]
+      (is (:pass? result))
+      (is (pos-int? (get-in result [:output :created-id])))
+      (is (= 1 (count (db/list-todos *ds* "all")))))))
+
+(deftest todo-toggle-cell-test
+  (testing ":todo/toggle flips completed"
+    (let [{:keys [id]} (db/create-todo! *ds* "Task")
+          result (dev/test-cell :todo/toggle
+                  {:input     {:todo-id id}
+                   :resources {:db *ds*}})]
+      (is (:pass? result))
+      (is (= 1 (:completed (first (db/list-todos *ds* "all"))))))))
+
+(deftest todo-update-title-cell-test
+  (testing ":todo/update-title changes the title"
+    (let [{:keys [id]} (db/create-todo! *ds* "Old")]
+      (dev/test-cell :todo/update-title
+        {:input     {:todo-id id :title "New"}
+         :resources {:db *ds*}})
+      (is (= "New" (:title (first (db/list-todos *ds* "all"))))))))
+
+(deftest todo-delete-cell-test
+  (testing ":todo/delete removes the todo"
+    (let [{:keys [id]} (db/create-todo! *ds* "Bye")]
+      (dev/test-cell :todo/delete
+        {:input     {:todo-id id}
+         :resources {:db *ds*}})
+      (is (= [] (db/list-todos *ds* "all"))))))
+
+(deftest todo-toggle-all-cell-test
+  (testing ":todo/toggle-all marks all complete"
+    (db/create-todo! *ds* "A")
+    (db/create-todo! *ds* "B")
+    (dev/test-cell :todo/toggle-all
+      {:input     {}
+       :resources {:db *ds*}})
+    (is (every? #(= 1 (:completed %)) (db/list-todos *ds* "all")))))
+
+(deftest todo-clear-completed-cell-test
+  (testing ":todo/clear-completed removes completed todos"
+    (db/create-todo! *ds* "Keep")
+    (let [{:keys [id]} (db/create-todo! *ds* "Remove")]
+      (db/toggle-todo! *ds* id)
+      (dev/test-cell :todo/clear-completed
+        {:input     {}
+         :resources {:db *ds*}})
+      (is (= 1 (count (db/list-todos *ds* "all"))))
+      (is (= "Keep" (:title (first (db/list-todos *ds* "all"))))))))

--- a/examples/todomvc/test/clj/mycelium/todomvc/cells/ui_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/cells/ui_test.clj
@@ -1,0 +1,50 @@
+(ns mycelium.todomvc.cells.ui-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.dev :as dev]
+            [mycelium.cell :as cell]
+            [mycelium.todomvc.cells.ui]))
+
+(use-fixtures :each
+  (fn [f]
+    (when-not (cell/get-cell :ui/render-todo-page)
+      (require 'mycelium.todomvc.cells.ui :reload))
+    (f)))
+
+(deftest render-todo-page-test
+  (testing ":ui/render-todo-page renders full page HTML"
+    (let [result (dev/test-cell :ui/render-todo-page
+                  {:input {:todos  [{:id 1 :title "Buy milk" :completed 0}]
+                           :stats  {:active 1 :completed 0 :total 1}
+                           :filter "all"}})]
+      (is (:pass? result))
+      (let [html (get-in result [:output :html])]
+        (is (string? html))
+        (is (re-find #"Buy milk" html))
+        (is (re-find #"todoapp" html))
+        (is (re-find #"htmx" html))))))
+
+(deftest render-todo-list-test
+  (testing ":ui/render-todo-list renders the list fragment"
+    (let [result (dev/test-cell :ui/render-todo-list
+                  {:input {:todos  [{:id 1 :title "Test" :completed 1}
+                                    {:id 2 :title "Active" :completed 0}]
+                           :stats  {:active 1 :completed 1 :total 2}
+                           :filter "all"}})]
+      (is (:pass? result))
+      (let [html (get-in result [:output :html])]
+        (is (string? html))
+        (is (re-find #"Test" html))
+        (is (re-find #"Active" html))
+        (is (re-find #"1.*item" html))))))
+
+(deftest render-empty-list-test
+  (testing ":ui/render-todo-list with no todos renders no list"
+    (let [result (dev/test-cell :ui/render-todo-list
+                  {:input {:todos  []
+                           :stats  {:active 0 :completed 0 :total 0}
+                           :filter "all"}})]
+      (is (:pass? result))
+      (let [html (get-in result [:output :html])]
+        (is (string? html))
+        ;; No main section when total is 0
+        (is (not (re-find #"todo-list" html)))))))

--- a/examples/todomvc/test/clj/mycelium/todomvc/core_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/core_test.clj
@@ -1,0 +1,6 @@
+(ns mycelium.todomvc.core-test
+  (:require [clojure.test :refer :all]))
+
+(deftest sanity-test
+  (is (= 1 1)))
+

--- a/examples/todomvc/test/clj/mycelium/todomvc/db_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/db_test.clj
@@ -1,0 +1,95 @@
+(ns mycelium.todomvc.db-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.todomvc.db :as db]
+            [next.jdbc :as jdbc]
+            [migratus.core :as migratus])
+  (:import [java.io File]))
+
+(def ^:dynamic *ds* nil)
+
+(defn create-test-db []
+  (let [f   (File/createTempFile "todomvc-test-" ".db")
+        _   (.deleteOnExit f)
+        url (str "jdbc:sqlite:" (.getAbsolutePath f))
+        ds  (jdbc/get-datasource {:jdbcUrl url})]
+    (migratus/migrate {:store         :database
+                       :migration-dir "migrations"
+                       :db            {:datasource ds}})
+    ds))
+
+(use-fixtures :each
+  (fn [f]
+    (binding [*ds* (create-test-db)]
+      (f))))
+
+(deftest list-todos-empty-test
+  (testing "empty table returns empty list"
+    (is (= [] (db/list-todos *ds* "all")))))
+
+(deftest create-and-list-test
+  (testing "create todo and list it"
+    (let [{:keys [id]} (db/create-todo! *ds* "Buy milk")]
+      (is (pos-int? id))
+      (let [todos (db/list-todos *ds* "all")]
+        (is (= 1 (count todos)))
+        (is (= "Buy milk" (:title (first todos))))
+        (is (= 0 (:completed (first todos))))))))
+
+(deftest filter-active-completed-test
+  (testing "filtering by active/completed"
+    (db/create-todo! *ds* "Active task")
+    (let [{:keys [id]} (db/create-todo! *ds* "Done task")]
+      (db/toggle-todo! *ds* id)
+      (is (= 1 (count (db/list-todos *ds* "active"))))
+      (is (= "Active task" (:title (first (db/list-todos *ds* "active")))))
+      (is (= 1 (count (db/list-todos *ds* "completed"))))
+      (is (= "Done task" (:title (first (db/list-todos *ds* "completed")))))
+      (is (= 2 (count (db/list-todos *ds* "all")))))))
+
+(deftest count-stats-test
+  (testing "count-stats returns correct counts"
+    (is (= {:active 0 :completed 0 :total 0} (db/count-stats *ds*)))
+    (db/create-todo! *ds* "A")
+    (let [{:keys [id]} (db/create-todo! *ds* "B")]
+      (db/toggle-todo! *ds* id)
+      (is (= {:active 1 :completed 1 :total 2} (db/count-stats *ds*))))))
+
+(deftest toggle-todo-test
+  (testing "toggle flips completed status"
+    (let [{:keys [id]} (db/create-todo! *ds* "Task")]
+      (db/toggle-todo! *ds* id)
+      (is (= 1 (:completed (first (db/list-todos *ds* "all")))))
+      (db/toggle-todo! *ds* id)
+      (is (= 0 (:completed (first (db/list-todos *ds* "all"))))))))
+
+(deftest update-todo-title-test
+  (testing "update-todo-title! changes the title"
+    (let [{:keys [id]} (db/create-todo! *ds* "Old title")]
+      (db/update-todo-title! *ds* id "New title")
+      (is (= "New title" (:title (first (db/list-todos *ds* "all"))))))))
+
+(deftest delete-todo-test
+  (testing "delete-todo! removes the todo"
+    (let [{:keys [id]} (db/create-todo! *ds* "To delete")]
+      (db/delete-todo! *ds* id)
+      (is (= [] (db/list-todos *ds* "all"))))))
+
+(deftest toggle-all-test
+  (testing "toggle-all marks all complete when some are active"
+    (db/create-todo! *ds* "A")
+    (db/create-todo! *ds* "B")
+    (db/toggle-all! *ds*)
+    (is (every? #(= 1 (:completed %)) (db/list-todos *ds* "all"))))
+  (testing "toggle-all marks all incomplete when all are complete"
+    (db/toggle-all! *ds*)
+    (is (every? #(= 0 (:completed %)) (db/list-todos *ds* "all")))))
+
+(deftest clear-completed-test
+  (testing "clear-completed! removes only completed todos"
+    (db/create-todo! *ds* "Keep")
+    (let [{:keys [id]} (db/create-todo! *ds* "Remove")]
+      (db/toggle-todo! *ds* id)
+      (db/clear-completed! *ds*)
+      (let [remaining (db/list-todos *ds* "all")]
+        (is (= 1 (count remaining)))
+        (is (= "Keep" (:title (first remaining))))))))

--- a/examples/todomvc/test/clj/mycelium/todomvc/test_utils.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/test_utils.clj
@@ -1,0 +1,32 @@
+(ns mycelium.todomvc.test-utils
+  (:require
+    [mycelium.todomvc.core :as core]
+    [peridot.core :as p]
+    [byte-streams :as bs]
+    [integrant.repl.state :as state]))
+
+(defn system-state
+  []
+  (or @core/system state/system))
+
+(defn system-fixture
+  []
+  (fn [f]
+    (when (nil? (system-state))
+      (core/start-app {:opts {:profile :test}}))
+    (f)
+    (core/stop-app)))
+
+(defn get-response [ctx]
+  (-> ctx
+      :response
+      (update :body (fnil bs/to-string ""))))
+
+(defn GET [app path params headers]
+  (-> (p/session app)
+      (p/request path
+                 :request-method :get
+                 :content-type "application/edn"
+                 :headers headers
+                 :params params)
+      (get-response)))

--- a/examples/todomvc/test/clj/mycelium/todomvc/web/request_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/web/request_test.clj
@@ -1,0 +1,13 @@
+(ns mycelium.todomvc.web.request-test
+  (:require  [clojure.test :refer [deftest testing is use-fixtures]]
+             [mycelium.todomvc.test-utils :refer [system-state system-fixture GET]]))
+
+(use-fixtures :once (system-fixture))
+
+(deftest health-request-test []
+  (testing "happy path"
+    (let [handler (:handler/ring (system-state))
+          params {}
+          headers {}
+          response (GET handler "/api/health" params headers)]
+      (is (= 200 (:status response))))))

--- a/examples/todomvc/test/clj/mycelium/todomvc/web/routes_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/web/routes_test.clj
@@ -1,0 +1,90 @@
+(ns mycelium.todomvc.web.routes-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.todomvc.web.routes.pages :as pages]
+            [mycelium.todomvc.db :as db]
+            [reitit.ring :as ring]
+            [ring.middleware.params :as params]
+            [ring.mock.request :as mock]
+            [next.jdbc :as jdbc]
+            [migratus.core :as migratus])
+  (:import [java.io File]))
+
+(def ^:dynamic *ds* nil)
+(def ^:dynamic *app* nil)
+
+(defn create-test-db []
+  (let [f   (File/createTempFile "todomvc-route-test-" ".db")
+        _   (.deleteOnExit f)
+        url (str "jdbc:sqlite:" (.getAbsolutePath f))
+        ds  (jdbc/get-datasource {:jdbcUrl url})]
+    (migratus/migrate {:store         :database
+                       :migration-dir "migrations"
+                       :db            {:datasource ds}})
+    ds))
+
+(use-fixtures :each
+  (fn [f]
+    (let [ds (create-test-db)]
+      (binding [*ds* ds
+                *app* (ring/ring-handler
+                        (ring/router
+                          ["" {:middleware [params/wrap-params]}
+                           (pages/page-routes ds)]
+                          {:conflicts nil})
+                        (ring/create-default-handler))]
+        (f)))))
+
+(deftest get-page-test
+  (testing "GET / returns full page HTML"
+    (let [resp (*app* (mock/request :get "/"))]
+      (is (= 200 (:status resp)))
+      (is (re-find #"todoapp" (:body resp))))))
+
+(deftest post-add-test
+  (testing "POST /todos creates a todo and returns list fragment"
+    (let [resp (*app* (-> (mock/request :post "/todos")
+                          (mock/content-type "application/x-www-form-urlencoded")
+                          (mock/body "title=New+task")))]
+      (is (= 200 (:status resp)))
+      (is (re-find #"New task" (:body resp)))
+      (is (= 1 (count (db/list-todos *ds* "all")))))))
+
+(deftest patch-toggle-test
+  (testing "PATCH /todos/:id/toggle toggles and returns list"
+    (let [{:keys [id]} (db/create-todo! *ds* "Toggle")]
+      (let [resp (*app* (mock/request :patch (str "/todos/" id "/toggle")))]
+        (is (= 200 (:status resp)))
+        (is (= 1 (:completed (first (db/list-todos *ds* "all")))))))))
+
+(deftest delete-test
+  (testing "DELETE /todos/:id removes todo"
+    (let [{:keys [id]} (db/create-todo! *ds* "Remove")]
+      (let [resp (*app* (mock/request :delete (str "/todos/" id)))]
+        (is (= 200 (:status resp)))
+        (is (= 0 (count (db/list-todos *ds* "all"))))))))
+
+(deftest put-update-test
+  (testing "PUT /todos/:id updates title"
+    (let [{:keys [id]} (db/create-todo! *ds* "Old")]
+      (let [resp (*app* (-> (mock/request :put (str "/todos/" id))
+                            (mock/content-type "application/x-www-form-urlencoded")
+                            (mock/body "title=New")))]
+        (is (= 200 (:status resp)))
+        (is (= "New" (:title (first (db/list-todos *ds* "all")))))))))
+
+(deftest post-toggle-all-test
+  (testing "POST /todos/toggle-all toggles all"
+    (db/create-todo! *ds* "A")
+    (db/create-todo! *ds* "B")
+    (let [resp (*app* (mock/request :post "/todos/toggle-all"))]
+      (is (= 200 (:status resp)))
+      (is (every? #(= 1 (:completed %)) (db/list-todos *ds* "all"))))))
+
+(deftest post-clear-completed-test
+  (testing "POST /todos/clear-completed removes completed"
+    (db/create-todo! *ds* "Keep")
+    (let [{:keys [id]} (db/create-todo! *ds* "Remove")]
+      (db/toggle-todo! *ds* id)
+      (let [resp (*app* (mock/request :post "/todos/clear-completed"))]
+        (is (= 200 (:status resp)))
+        (is (= 1 (count (db/list-todos *ds* "all"))))))))

--- a/examples/todomvc/test/clj/mycelium/todomvc/workflows/todo_test.clj
+++ b/examples/todomvc/test/clj/mycelium/todomvc/workflows/todo_test.clj
@@ -1,0 +1,84 @@
+(ns mycelium.todomvc.workflows.todo-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.todomvc.workflows.todo :as wf]
+            [mycelium.todomvc.db :as db]
+            [next.jdbc :as jdbc]
+            [migratus.core :as migratus])
+  (:import [java.io File]))
+
+(def ^:dynamic *ds* nil)
+
+(defn create-test-db []
+  (let [f   (File/createTempFile "todomvc-wf-test-" ".db")
+        _   (.deleteOnExit f)
+        url (str "jdbc:sqlite:" (.getAbsolutePath f))
+        ds  (jdbc/get-datasource {:jdbcUrl url})]
+    (migratus/migrate {:store         :database
+                       :migration-dir "migrations"
+                       :db            {:datasource ds}})
+    ds))
+
+(use-fixtures :each
+  (fn [f]
+    (binding [*ds* (create-test-db)]
+      (f))))
+
+(deftest page-workflow-test
+  (testing "page workflow renders full HTML with no todos"
+    (let [result (wf/run-page *ds* {:query-params {"filter" "all"}})]
+      (is (string? (:html result)))
+      (is (re-find #"todoapp" (:html result)))))
+  (testing "page workflow renders todos"
+    (db/create-todo! *ds* "Test item")
+    (let [result (wf/run-page *ds* {:query-params {"filter" "all"}})]
+      (is (re-find #"Test item" (:html result))))))
+
+(deftest add-workflow-test
+  (testing "add workflow creates todo and returns list fragment"
+    (let [result (wf/run-add *ds* {:form-params {"title" "New task"}
+                                    :query-params {"filter" "all"}})]
+      (is (string? (:html result)))
+      (is (re-find #"New task" (:html result)))
+      (is (= 1 (count (db/list-todos *ds* "all")))))))
+
+(deftest toggle-workflow-test
+  (testing "toggle workflow flips todo and returns list fragment"
+    (let [{:keys [id]} (db/create-todo! *ds* "Toggle me")]
+      (let [result (wf/run-toggle *ds* {:path-params {:id (str id)}
+                                         :query-params {"filter" "all"}})]
+        (is (string? (:html result)))
+        (is (= 1 (:completed (first (db/list-todos *ds* "all")))))))))
+
+(deftest delete-workflow-test
+  (testing "delete workflow removes todo and returns list fragment"
+    (let [{:keys [id]} (db/create-todo! *ds* "Delete me")]
+      (let [result (wf/run-delete *ds* {:path-params {:id (str id)}
+                                         :query-params {"filter" "all"}})]
+        (is (string? (:html result)))
+        (is (= 0 (count (db/list-todos *ds* "all"))))))))
+
+(deftest update-workflow-test
+  (testing "update workflow changes title and returns list fragment"
+    (let [{:keys [id]} (db/create-todo! *ds* "Old title")]
+      (let [result (wf/run-update *ds* {:path-params  {:id (str id)}
+                                         :form-params  {"title" "New title"}
+                                         :query-params {"filter" "all"}})]
+        (is (string? (:html result)))
+        (is (re-find #"New title" (:html result)))))))
+
+(deftest toggle-all-workflow-test
+  (testing "toggle-all workflow marks all complete and returns list fragment"
+    (db/create-todo! *ds* "A")
+    (db/create-todo! *ds* "B")
+    (let [result (wf/run-toggle-all *ds* {:query-params {"filter" "all"}})]
+      (is (string? (:html result)))
+      (is (every? #(= 1 (:completed %)) (db/list-todos *ds* "all"))))))
+
+(deftest clear-workflow-test
+  (testing "clear workflow removes completed todos and returns list fragment"
+    (db/create-todo! *ds* "Keep")
+    (let [{:keys [id]} (db/create-todo! *ds* "Remove")]
+      (db/toggle-todo! *ds* id)
+      (let [result (wf/run-clear *ds* {:query-params {"filter" "all"}})]
+        (is (string? (:html result)))
+        (is (= 1 (count (db/list-todos *ds* "all"))))))))

--- a/examples/todomvc/tests.edn
+++ b/examples/todomvc/tests.edn
@@ -1,0 +1,8 @@
+#kaocha/v1
+{:tests [{:id          :unit
+          :test-paths  ["test/clj"]
+          :source-paths ["src/clj"]
+          :ns-patterns  [".*-test$"]}]
+ :reporter [kaocha.report/dots]
+ :color?   true
+ :randomize? true}


### PR DESCRIPTION
Server-side TodoMVC using HTMX and Selmer templates running on Mycelium workflows. Exercises cells, manifests, fragments, joins, and pre-compiled workflows in a real CRUD application.

- SQLite DB layer with next.jdbc + migratus migrations
- 8 cells: request parsing, 6 todo operations, 2 UI renderers
- 7 workflow manifests: page (with join), 6 mutations (with fragment)
- Reusable fetch-render-list fragment shared across all mutations
- HTMX fragment swaps for all interactions (add/toggle/delete/edit/filter)
- Integrant system wiring for DB, migrations, and page routes
- Tests  for DB, cell, workflow integration, and HTTP route