### PR TITLE
Add pipeline shorthand, schema inherit, optional dispatches, and Ring middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ mycelium/
 │   ├── workflow.clj      ;; DSL → Maestro compiler
 │   ├── compose.clj       ;; Hierarchical workflow nesting
 │   ├── manifest.clj      ;; EDN manifest loading, cell briefs
+│   ├── middleware.clj     ;; Ring middleware for workflow execution
 │   ├── dev.clj           ;; Testing harness, visualization
 │   ├── orchestrate.clj   ;; Agent orchestration helpers
 │   └── core.clj          ;; Public API

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -50,6 +50,17 @@
  :interceptors [{:id :x :scope :all :pre (fn [d] d)}]}           ;; optional
 ```
 
+### Pipeline Shorthand (Manifests)
+
+```clojure
+;; Instead of :edges + :dispatches for linear flows:
+{:id :my-pipeline
+ :pipeline [:start :process :render]
+ :cells {:start   {...} :process {...} :render {...}}}
+;; Expands to :edges {:start :process, :process :render, :render :end}
+;; Mutually exclusive with :edges, :dispatches, :fragments, :joins
+```
+
 ## Manifest Loading
 
 ```clojure
@@ -136,12 +147,30 @@ Default dispatches `:success` / `:failure` are provided automatically based on `
          :failure [:map [:error :string]]}
 ```
 
+## Ring Middleware
+
+```clojure
+(require '[mycelium.middleware :as mw])
+
+;; Create a Ring handler from a pre-compiled workflow
+(mw/workflow-handler compiled {:resources {:db db}})
+
+;; With custom input/output transforms
+(mw/workflow-handler compiled
+  {:resources {:db db}
+   :input-fn  (fn [req] {:http-request req})   ;; default
+   :output-fn mw/html-response})               ;; default
+
+;; Standard HTML response helper
+(mw/html-response result)  ;; => {:status 200 :body (:html result) ...}
+```
+
 ## Manifest Cell Required Fields
 
 ```clojure
 {:id       :namespace/name    ;; cell registry ID
  :schema   {:input  [...]     ;; Malli schema
-            :output [...]}    ;; single or per-transition
+            :output [...]}    ;; single or per-transition — or :inherit
  :on-error :cell-name}        ;; or nil — required in strict mode (default)
 ```
 

--- a/docs/workflow-fragments.md
+++ b/docs/workflow-fragments.md
@@ -169,3 +169,5 @@ Fragment validation checks:
 - Multiple fragments can be used in the same manifest as long as cell names don't collide
 - Fragments cannot contain `:joins` (keep join workflows as standalone manifests)
 - Fragment dispatch predicates in EDN use `(fn ...)` forms, same as manifests
+- `:dispatches` can be omitted from fragments (and host manifests) when all edges are unconditional keywords
+- Fragment cells support `:schema :inherit` to pull schemas from the cell registry instead of duplicating them

--- a/examples/todomvc/resources/fragments/fetch-render-list.edn
+++ b/examples/todomvc/resources/fragments/fetch-render-list.edn
@@ -38,6 +38,4 @@
  :edges
  {:fetch-list  :fetch-stats
   :fetch-stats :render-list
-  :render-list :_exit/done}
-
- :dispatches {}}
+  :render-list :_exit/done}}

--- a/examples/todomvc/resources/workflows/todo-add.edn
+++ b/examples/todomvc/resources/workflows/todo-add.edn
@@ -27,6 +27,4 @@
 
  :edges
  {:start  :create
-  :create :fetch-list}
-
- :dispatches {}}
+  :create :fetch-list}}

--- a/examples/todomvc/resources/workflows/todo-clear.edn
+++ b/examples/todomvc/resources/workflows/todo-clear.edn
@@ -27,6 +27,4 @@
 
  :edges
  {:start :clear
-  :clear :fetch-list}
-
- :dispatches {}}
+  :clear :fetch-list}}

--- a/examples/todomvc/resources/workflows/todo-delete.edn
+++ b/examples/todomvc/resources/workflows/todo-delete.edn
@@ -27,6 +27,4 @@
 
  :edges
  {:start  :delete
-  :delete :fetch-list}
-
- :dispatches {}}
+  :delete :fetch-list}}

--- a/examples/todomvc/resources/workflows/todo-page.edn
+++ b/examples/todomvc/resources/workflows/todo-page.edn
@@ -49,6 +49,4 @@
  :edges
  {:start      :fetch-data
   :fetch-data {:done :render-page}
-  :render-page :end}
-
- :dispatches {}}
+  :render-page :end}}

--- a/examples/todomvc/resources/workflows/todo-toggle-all.edn
+++ b/examples/todomvc/resources/workflows/todo-toggle-all.edn
@@ -27,6 +27,4 @@
 
  :edges
  {:start      :toggle-all
-  :toggle-all :fetch-list}
-
- :dispatches {}}
+  :toggle-all :fetch-list}}

--- a/examples/todomvc/resources/workflows/todo-toggle.edn
+++ b/examples/todomvc/resources/workflows/todo-toggle.edn
@@ -27,6 +27,4 @@
 
  :edges
  {:start  :toggle
-  :toggle :fetch-list}
-
- :dispatches {}}
+  :toggle :fetch-list}}

--- a/examples/todomvc/resources/workflows/todo-update.edn
+++ b/examples/todomvc/resources/workflows/todo-update.edn
@@ -27,6 +27,4 @@
 
  :edges
  {:start        :update-title
-  :update-title :fetch-list}
-
- :dispatches {}}
+  :update-title :fetch-list}}

--- a/examples/todomvc/src/clj/mycelium/todomvc/web/routes/pages.clj
+++ b/examples/todomvc/src/clj/mycelium/todomvc/web/routes/pages.clj
@@ -1,30 +1,26 @@
 (ns mycelium.todomvc.web.routes.pages
   (:require [integrant.core :as ig]
+            [mycelium.middleware :as mw]
             [mycelium.todomvc.workflows.todo :as wf]
             [reitit.ring.middleware.parameters :as parameters]))
 
-(defn- html-response [result]
-  {:status  200
-   :headers {"Content-Type" "text/html; charset=utf-8"}
-   :body    (:html result)})
-
-(defn- run-and-respond [runner-fn db request]
-  (html-response (runner-fn db request)))
+(defn- wf-handler [compiled db]
+  (mw/workflow-handler compiled {:resources {:db db}}))
 
 (defn page-routes [db]
   [["/"
-    {:get {:handler (fn [req] (run-and-respond wf/run-page db req))}}]
+    {:get {:handler (wf-handler wf/compiled-page db)}}]
    ["/todos"
-    {:post {:handler (fn [req] (run-and-respond wf/run-add db req))}}]
+    {:post {:handler (wf-handler wf/compiled-add db)}}]
    ["/todos/toggle-all"
-    {:post {:handler (fn [req] (run-and-respond wf/run-toggle-all db req))}}]
+    {:post {:handler (wf-handler wf/compiled-toggle-all db)}}]
    ["/todos/clear-completed"
-    {:post {:handler (fn [req] (run-and-respond wf/run-clear db req))}}]
+    {:post {:handler (wf-handler wf/compiled-clear db)}}]
    ["/todos/:id/toggle"
-    {:patch {:handler (fn [req] (run-and-respond wf/run-toggle db req))}}]
+    {:patch {:handler (wf-handler wf/compiled-toggle db)}}]
    ["/todos/:id"
-    {:delete  {:handler (fn [req] (run-and-respond wf/run-delete db req))}
-     :put     {:handler (fn [req] (run-and-respond wf/run-update db req))}}]])
+    {:delete  {:handler (wf-handler wf/compiled-delete db)}
+     :put     {:handler (wf-handler wf/compiled-update db)}}]])
 
 (derive :reitit.routes/pages :reitit/routes)
 

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -6,6 +6,7 @@
             [mycelium.workflow :as workflow]
             [mycelium.compose :as compose]
             [mycelium.manifest :as manifest]
+            [mycelium.middleware :as mw]
             [mycelium.system :as sys]
             [malli.core :as m]
             [maestro.core :as fsm]))
@@ -129,6 +130,18 @@
    (run-workflow-async workflow-def resources initial-data {}))
   ([workflow-def resources initial-data opts]
    (run-compiled-async (pre-compile workflow-def opts) resources initial-data)))
+
+;; --- Middleware ---
+
+(def workflow-handler
+  "Creates a Ring handler from a pre-compiled workflow.
+   See mycelium.middleware/workflow-handler."
+  mw/workflow-handler)
+
+(def html-response
+  "Standard HTML response from workflow result.
+   See mycelium.middleware/html-response."
+  mw/html-response)
 
 ;; --- System compilation ---
 

--- a/src/mycelium/middleware.clj
+++ b/src/mycelium/middleware.clj
@@ -1,0 +1,59 @@
+(ns mycelium.middleware
+  "Ring middleware and handlers for bridging HTTP requests to Mycelium workflows."
+  (:require [malli.core :as m]
+            [maestro.core :as fsm]))
+
+(defn html-response
+  "Standard HTML response from workflow result. Extracts :html key."
+  [result]
+  (if (:html result)
+    {:status  200
+     :headers {"Content-Type" "text/html; charset=utf-8"}
+     :body    (:html result)}
+    {:status  500
+     :headers {"Content-Type" "text/plain"}
+     :body    "Workflow produced no :html key"}))
+
+(defn- run-compiled
+  "Runs a pre-compiled workflow. Inlined to avoid cyclic dependency on mycelium.core."
+  [{:keys [compiled-fsm input-schema-raw input-schema-compiled]} resources initial-data]
+  (if-let [input-error (when input-schema-compiled
+                         (when-let [explanation (m/explain input-schema-compiled initial-data)]
+                           {:schema input-schema-raw
+                            :errors (:errors explanation)
+                            :data   initial-data}))]
+    {:mycelium/input-error input-error}
+    (fsm/run compiled-fsm resources {:data initial-data})))
+
+(defn workflow-handler
+  "Creates a Ring handler from a pre-compiled workflow.
+   Options:
+     :resources — resources map or (fn [request] resources-map)
+     :input-fn  — (fn [request] initial-data), default: (fn [req] {:http-request req})
+     :output-fn — (fn [workflow-result] ring-response), default: html-response"
+  [compiled {:keys [resources input-fn output-fn]
+             :or   {input-fn  (fn [req] {:http-request req})
+                    output-fn html-response}}]
+  (let [resources-fn (if (fn? resources) resources (constantly resources))]
+    (fn [request]
+      (let [res    (resources-fn request)
+            input  (input-fn request)
+            result (run-compiled compiled res input)]
+        (if (:mycelium/input-error result)
+          {:status  400
+           :headers {"Content-Type" "text/plain"}
+           :body    (str "Input validation failed: "
+                         (pr-str (:mycelium/input-error result)))}
+          (output-fn result))))))
+
+(defn wrap-workflow
+  "Ring middleware that runs a pre-compiled workflow for each request.
+   Options:
+     :compiled  — pre-compiled workflow (from myc/pre-compile)
+     :resources — resources map or (fn [request] resources-map)
+     :input-fn  — (fn [request] initial-data), default: (fn [req] {:http-request req})
+     :output-fn — (fn [workflow-result] ring-response), default: html-response"
+  [handler {:keys [compiled] :as opts}]
+  (let [wf-handler (workflow-handler compiled (dissoc opts :compiled))]
+    (fn [request]
+      (wf-handler request))))

--- a/test/mycelium/middleware_test.clj
+++ b/test/mycelium/middleware_test.clj
@@ -1,0 +1,123 @@
+(ns mycelium.middleware-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.middleware :as mw]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== Test helpers =====
+
+(defn- setup-simple-workflow []
+  (defmethod cell/cell-spec :mw-test/render [_]
+    {:id      :mw-test/render
+     :handler (fn [_ data]
+                (assoc data :html (str "<h1>" (:message data "Hello") "</h1>")))
+     :schema  {:input  [:map]
+               :output [:map [:html :string]]}})
+  (myc/pre-compile
+   {:cells {:start :mw-test/render}
+    :edges {:start :end}}))
+
+;; ===== 1. html-response =====
+
+(deftest html-response-test
+  (testing "html-response extracts :html and returns 200"
+    (let [resp (mw/html-response {:html "<h1>Hi</h1>"})]
+      (is (= 200 (:status resp)))
+      (is (= "<h1>Hi</h1>" (:body resp)))
+      (is (= "text/html; charset=utf-8" (get-in resp [:headers "Content-Type"])))))
+
+  (testing "html-response returns 500 when no :html key"
+    (let [resp (mw/html-response {:other "data"})]
+      (is (= 500 (:status resp))))))
+
+;; ===== 2. workflow-handler basic =====
+
+(deftest workflow-handler-basic-test
+  (testing "workflow-handler runs workflow and returns HTML response"
+    (let [compiled (setup-simple-workflow)
+          handler  (mw/workflow-handler compiled {:resources {}})
+          resp     (handler {:uri "/test"})]
+      (is (= 200 (:status resp)))
+      (is (= "<h1>Hello</h1>" (:body resp))))))
+
+;; ===== 3. workflow-handler with custom input-fn =====
+
+(deftest workflow-handler-custom-input-fn-test
+  (testing "workflow-handler uses custom input-fn"
+    (defmethod cell/cell-spec :mw-test/greet [_]
+      {:id      :mw-test/greet
+       :handler (fn [_ data]
+                  (assoc data :html (str "<h1>Hello " (:name data) "</h1>")))
+       :schema  {:input  [:map [:name :string]]
+                 :output [:map [:html :string]]}})
+    (let [compiled (myc/pre-compile
+                    {:cells {:start :mw-test/greet}
+                     :edges {:start :end}})
+          handler  (mw/workflow-handler compiled
+                     {:resources {}
+                      :input-fn  (fn [req] {:name (get-in req [:params :name])})})
+          resp     (handler {:params {:name "World"}})]
+      (is (= 200 (:status resp)))
+      (is (= "<h1>Hello World</h1>" (:body resp))))))
+
+;; ===== 4. workflow-handler with custom output-fn =====
+
+(deftest workflow-handler-custom-output-fn-test
+  (testing "workflow-handler uses custom output-fn"
+    (let [compiled (setup-simple-workflow)
+          handler  (mw/workflow-handler compiled
+                     {:resources {}
+                      :output-fn (fn [result]
+                                   {:status 200
+                                    :headers {"Content-Type" "application/json"}
+                                    :body (pr-str result)})})
+          resp     (handler {:uri "/test"})]
+      (is (= 200 (:status resp)))
+      (is (= "application/json" (get-in resp [:headers "Content-Type"]))))))
+
+;; ===== 5. workflow-handler with resources as fn =====
+
+(deftest workflow-handler-resources-fn-test
+  (testing "workflow-handler accepts resources as a function of request"
+    (defmethod cell/cell-spec :mw-test/db-render [_]
+      {:id      :mw-test/db-render
+       :handler (fn [{:keys [db]} data]
+                  (assoc data :html (str "<p>DB: " db "</p>")))
+       :schema  {:input  [:map]
+                 :output [:map [:html :string]]}})
+    (let [compiled (myc/pre-compile
+                    {:cells {:start :mw-test/db-render}
+                     :edges {:start :end}})
+          handler  (mw/workflow-handler compiled
+                     {:resources (fn [req] {:db (:db-conn req)})})
+          resp     (handler {:db-conn "test-db"})]
+      (is (= 200 (:status resp)))
+      (is (= "<p>DB: test-db</p>" (:body resp))))))
+
+;; ===== 6. workflow-handler returns 400 on input validation error =====
+
+(deftest workflow-handler-input-error-test
+  (testing "workflow-handler returns 400 on input validation failure"
+    (let [compiled (setup-simple-workflow)
+          ;; Add input-schema to the compiled workflow
+          compiled (assoc compiled
+                         :input-schema-raw [:map [:required-key :string]]
+                         :input-schema-compiled (malli.core/schema [:map [:required-key :string]]))
+          handler  (mw/workflow-handler compiled {:resources {}})
+          resp     (handler {:uri "/test"})]
+      (is (= 400 (:status resp))))))
+
+;; ===== 7. wrap-workflow middleware =====
+
+(deftest wrap-workflow-test
+  (testing "wrap-workflow returns workflow response"
+    (let [compiled   (setup-simple-workflow)
+          fallback   (fn [_] {:status 404 :body "Not found"})
+          middleware (mw/wrap-workflow fallback
+                       {:compiled compiled :resources {}})
+          resp       (middleware {:uri "/test"})]
+      (is (= 200 (:status resp)))
+      (is (= "<h1>Hello</h1>" (:body resp))))))


### PR DESCRIPTION
Four quality-of-life improvements to reduce manifest boilerplate:

- :pipeline shorthand for linear workflows (expands to :edges + :dispatches)
- :schema :inherit resolves schemas from cell registry instead of duplicating
- :dispatches is now optional when all edges are unconditional
- mycelium.middleware namespace with workflow-handler and html-response
