### PR TITLE
Add composed cell output inference, pipeline for programmatic workflows, test-transitions fix, and schema synthesis

### DIFF
--- a/MYCELIUM_GUIDE.md
+++ b/MYCELIUM_GUIDE.md
@@ -1,0 +1,283 @@
+# Mycelium — LLM Quick-Start Guide
+
+> Load this file into context when working with Mycelium projects.
+
+## What It Is
+
+Mycelium is a Clojure workflow framework built on [Maestro](https://github.com/yogthos/maestro). Applications are directed graphs of **cells** (pure data transformations) with Malli schema contracts on every input/output boundary. Cells are developed and tested in isolation, then composed into workflows validated at compile time.
+
+**Key namespace:** `mycelium.core` (aliased as `myc`) — re-exports all public API functions.
+
+## Core Concepts
+
+### Cell
+
+A function with schema contracts, registered via multimethod:
+
+```clojure
+(ns my.cells
+  (:require [mycelium.cell :as cell]))
+
+(defmethod cell/cell-spec :my/double [_]
+  {:id      :my/double
+   :handler (fn [resources data]
+              (assoc data :result (* 2 (:x data))))
+   :schema  {:input  [:map [:x :int]]
+             :output [:map [:result :int]]}})
+```
+
+**Rules:**
+- Handler signature: `(fn [resources data] -> data)` — always returns enriched data map
+- `:input` / `:output` are [Malli](https://github.com/metosin/malli) schemas
+- Cells never import or call other cells — they only see `resources` and `data`
+- Resources (DB, HTTP clients, atoms) are injected, never acquired
+- `:requires [:db :cache]` documents resource dependencies (informational)
+
+### Workflow
+
+A directed graph connecting cells:
+
+```clojure
+{:cells      {:start  :my/validate
+              :step-b :my/process
+              :step-c :my/render}
+ :edges      {:start  {:valid :step-b, :invalid :end}
+              :step-b :step-c
+              :step-c :end}
+ :dispatches {:start [[:valid   (fn [d] (= :ok (:status d)))]
+                      [:invalid (fn [d] (not= :ok (:status d)))]]}}
+```
+
+**Edges** define topology. **Dispatches** are ordered `[label pred]` vectors — first matching predicate wins. Unconditional edges (keyword target) need no dispatch entry. Empty `:dispatches {}` is valid when all edges are unconditional.
+
+### Pipeline Shorthand
+
+For linear (unbranched) workflows, use `:pipeline` instead of `:edges` + `:dispatches`:
+
+```clojure
+{:cells    {:start :my/validate, :process :my/process, :render :my/render}
+ :pipeline [:start :process :render]}
+;; Expands to: {:edges {:start :process, :process :render, :render :end}, :dispatches {}}
+```
+
+Mutually exclusive with `:edges`, `:dispatches`, and `:joins`.
+
+### Data Model
+
+Cells communicate through an **accumulating data map**. Every cell receives all keys produced by every prior cell in the path. Cells `assoc` new keys; the enriched map flows forward.
+
+```
+start (has :x) → validate (adds :status) → process (sees :x AND :status, adds :result) → end
+```
+
+### Per-Transition Output Schemas
+
+Cells with multiple outgoing edges can declare different output schemas per transition:
+
+```clojure
+:schema {:input  [:map [:id :string]]
+         :output {:found     [:map [:profile [:map [:name :string]]]]
+                  :not-found [:map [:error-message :string]]}}
+```
+
+The schema chain validator tracks keys per path independently.
+
+## Running Workflows
+
+```clojure
+(require '[mycelium.core :as myc])
+
+;; One-shot (compiles + runs)
+(myc/run-workflow workflow-def resources initial-data)
+
+;; Pre-compiled (zero overhead per call — use for production)
+(def compiled (myc/pre-compile workflow-def))
+(myc/run-compiled compiled resources initial-data)
+
+;; Async variants
+(myc/run-workflow-async workflow-def resources initial-data)
+(myc/run-compiled-async compiled resources initial-data)
+```
+
+## Composition — Workflows as Cells
+
+Nest a workflow inside a parent by wrapping it as a cell:
+
+```clojure
+(require '[mycelium.compose :as compose])
+
+(compose/register-workflow-cell!
+  :my/sub-workflow
+  {:cells {:start :my/a, :step2 :my/b}
+   :pipeline [:start :step2]}
+  {:input  [:map [:x :int]]
+   :output [:map [:result :int]]})  ;; or :map to infer
+
+;; Use in parent:
+{:cells {:start :my/sub-workflow, :next :my/downstream}
+ :edges {:start {:success :next, :failure :error}
+         :next  :end}}
+;; No explicit dispatches needed — composed cells provide :default-dispatches
+```
+
+**Output inference:** `workflow->cell` automatically infers the composed cell's output schema by walking the child workflow's end-reaching cells. If you pass a concrete `[:map ...]` vector as `:output`, it takes precedence. Pass `:map` to use inference.
+
+**Default dispatches:** `:success` (no `:mycelium/error`) and `:failure` (`:mycelium/error` present) are provided automatically.
+
+## Join Nodes (Fork-Join)
+
+Run cells in parallel (or sequential), merge results:
+
+```clojure
+{:cells {:start :my/auth, :a :my/fetch-profile, :b :my/fetch-orders, :render :my/page}
+ :joins {:fetch-data {:cells [:a :b], :strategy :parallel}}
+ :edges {:start {:ok :fetch-data, :fail :error}
+         :fetch-data {:done :render, :failure :error}
+         :render :end}
+ :dispatches {:start [[:ok (fn [d] (:authed d))] [:fail (fn [d] (not (:authed d)))]]}}
+```
+
+- Join members exist in `:cells` but have **no entries in `:edges`**
+- Each member gets a **snapshot** of the input data (branches don't see each other)
+- Default dispatches: `:done` / `:failure` (provided automatically)
+- Without `:merge-fn`, results are merged via `(apply merge data results)` — output keys must be disjoint
+- With `:merge-fn`: `(fn [data results-vec] -> merged-data)`
+
+## Manifests (EDN)
+
+Define workflows as data in `.edn` files:
+
+```clojure
+{:id :user-onboarding
+ :cells {:start   {:id :auth/parse, :schema {:input [...] :output [...]}, :doc "..."}
+         :validate {:id :auth/check, :schema :inherit}}  ;; :inherit pulls from registry
+ :edges {:start {:ok :validate}, :validate :end}
+ :dispatches {:start [[:ok (fn [d] (:user-id d))]]}}
+```
+
+```clojure
+(def m (myc/load-manifest "workflows/user-onboarding.edn"))
+(myc/cell-brief m :start)  ;; Self-contained prompt for an LLM to implement the cell
+```
+
+## Dev & Testing
+
+```clojure
+(require '[mycelium.dev :as dev])
+
+;; Test a cell in isolation
+(dev/test-cell :my/cell-id
+  {:input {:x 5} :resources {} :dispatches [[:ok pred] [:fail pred]]})
+;; => {:pass? true, :output {...}, :matched-dispatch :ok, :duration-ms 0.4}
+
+;; Test multiple transitions at once
+(dev/test-transitions :my/cell-id
+  {:ok   {:input {:x 5}  :dispatches [[:ok pred] [:fail pred]]}
+   :fail {:input {:x -1} :dispatches [[:ok pred] [:fail pred]]}})
+;; => {:ok {:pass? true, ...}, :fail {:pass? true, ...}}
+
+;; Cells without dispatch predicates — output-only check
+(dev/test-transitions :my/classify
+  {:low  {:input {:score 750}}
+   :high {:input {:score 400}}})
+
+;; See accumulated schema at each workflow step
+(myc/infer-workflow-schema workflow-def)
+;; => {:start  {:available-before #{:x}, :adds #{:status}, :available-after #{:x :status}}
+;;     :step-b {:available-before #{:x :status}, :adds #{:result}, ...}}
+
+;; Enumerate all paths through a workflow
+(dev/enumerate-paths manifest)
+
+;; Static analysis (reachability, cycles, dead ends)
+(dev/analyze-workflow workflow-def)
+
+;; DOT graph for visualization
+(dev/workflow->dot manifest)  ;; pipe to `dot -Tpng`
+
+;; Implementation status
+(dev/workflow-status manifest)
+;; => {:total 4, :passing 2, :failing 1, :pending 1, :cells [...]}
+```
+
+## Ring Middleware
+
+```clojure
+(def compiled (myc/pre-compile workflow-def))
+
+;; Create a handler
+(myc/workflow-handler compiled
+  {:resources {:db db-conn}
+   :input-fn  (fn [req] {:http-request req})
+   :output-fn myc/html-response})
+```
+
+## Compile-Time Validations
+
+`compile-workflow` checks before any code runs:
+
+| Check | What it catches |
+|-------|-----------------|
+| Cell existence | All `:cells` values are registered |
+| Edge targets | Targets point to valid cells, joins, or `:end`/`:error`/`:halt` |
+| Reachability | Every cell reachable from `:start` |
+| Dispatch coverage | Every edge label has a predicate (and vice versa) |
+| Schema chain | Each cell's input keys available from upstream outputs |
+| Join validation | Members exist, no name collisions, disjoint outputs |
+| No-path-to-end | No reachable state stuck without path to `:end` |
+
+## File Layout
+
+```
+src/mycelium/
+  core.clj         Public API (re-exports)
+  cell.clj         Cell registry (multimethod)
+  schema.clj       Malli pre/post interceptors
+  workflow.clj      DSL → Maestro compiler
+  compose.clj      Hierarchical workflow nesting
+  manifest.clj     EDN manifest loading, cell briefs
+  middleware.clj   Ring middleware
+  dev.clj          Testing, visualization, schema inference
+  orchestrate.clj  Agent orchestration helpers
+```
+
+## Common Patterns
+
+### Implementing a Cell from a Brief
+
+When you receive a cell brief (from `cell-brief`), implement it as:
+
+```clojure
+(defmethod cell/cell-spec :namespace/cell-name [_]
+  {:id      :namespace/cell-name
+   :handler (fn [resources data]
+              ;; Your logic here — assoc results into data
+              (assoc data :output-key computed-value))
+   :schema  {:input  [:map [:required-key :type] ...]
+             :output [:map [:output-key :type] ...]}})
+```
+
+### Testing Workflow
+
+1. Implement cells with `defmethod cell/cell-spec`
+2. Test each cell in isolation: `(dev/test-cell :id {:input {...}})`
+3. Test dispatch paths: `(dev/test-transitions :id {:label {:input {...} :dispatches [...]}})`
+4. Compile the workflow: `(myc/compile-workflow workflow-def)` — catches schema chain errors
+5. Run end-to-end: `(myc/run-workflow workflow-def resources data)`
+6. Assert on `:mycelium/trace` in the result for execution order
+
+### Error Handling
+
+- Schema violations redirect to `::fsm/error` with `:mycelium/schema-error` in data
+- Custom error handling: pass `:on-error (fn [resources fsm-state] -> data)` to `compile-workflow`
+- Composed cells set `:mycelium/error` on failure for parent dispatch routing
+- Join errors collected in `:mycelium/join-error`
+
+### Gotchas
+
+- `::fsm/start` is NOT terminal — it runs a handler. Only `::end`, `::error`, `::halt` are terminal.
+- Handlers receive `(resources, data)` — not the full FSM state.
+- Dispatch predicates receive `data` (not fsm-state) — first truthy match wins.
+- Ring's `wrap-params` produces STRING-keyed query params — cells must check both `(get qp :key)` and `(get qp "key")`.
+- `:schema :inherit` in manifests resolves schema from cell registry — the cell must already be registered.
+- Composed cell output schemas are inferred automatically. Only use `set-cell-schema!` if you need to override the inference.

--- a/examples/loan_processing/README.md
+++ b/examples/loan_processing/README.md
@@ -1,0 +1,186 @@
+# Loan Processing Example
+
+A pure-workflow example (no DB, no HTTP, no templates) that exercises Mycelium's
+core features through a realistic loan application domain.
+
+## Running
+
+```bash
+cd examples/loan_processing
+clj -M:test
+```
+
+## Domain
+
+Three workflows process loan applications through validation, credit assessment,
+eligibility routing, and notifications — all with in-memory data.
+
+### Test Applicants
+
+| Name  | Credit Profile | Typical Outcome |
+|-------|---------------|-----------------|
+| Alice | 5 accounts, 10yr history, clean record | Low risk (score ~850) |
+| Bob   | 3 accounts, 5yr history, 1 late payment | Medium risk (score ~650) |
+| Carol | 1 account, 2yr history, 5 late + 1 bankruptcy | High risk (score 300) |
+
+### Decision Rules
+
+- **Low risk + amount <= $50k** → auto-approve
+- **High risk** → auto-reject
+- **Everything else** (medium risk, or low risk + large amount) → manual review
+
+## Mycelium Features Exercised
+
+### Subworkflow Composition
+
+The credit assessment pipeline is defined as a standalone workflow, then
+registered as a cell with `compose/register-workflow-cell!`:
+
+```
+credit-bureau-lookup → calculate-score → classify-risk
+```
+
+The main loan workflow embeds it as `:loan/credit-assessment` — a single cell
+that internally runs the full pipeline. On success it adds `:credit-score` and
+`:risk-level` to the data; on failure the parent routes via `:mycelium/error`.
+
+See `workflows.clj`.
+
+### Multi-Way Branching
+
+The `eligibility-decision` cell produces a 3-way dispatch:
+
+```
+eligibility-decision
+  ├── :approve → auto-approve
+  ├── :reject  → auto-reject
+  └── :review  → queue-for-review
+```
+
+All three branches converge back to `audit-log → send-notification → end`.
+Dispatches use predicate functions that check the `:decision` key in the data.
+
+### Per-Transition Output Schemas
+
+Several cells declare different output schemas per dispatch path:
+
+- `validate-application` — `:valid` produces `{:validation-status :valid}`,
+  `:invalid` produces `{:validation-status :invalid, :validation-errors [...]}`
+- `eligibility-decision` — three schemas, one per branch
+- `fetch-application` — `:found` vs `:not-found`
+
+This lets the schema chain validator verify that each downstream cell receives
+the exact keys it needs on each specific path through the workflow.
+
+### Cell Reuse Across Workflows
+
+Cells are registered once in the global registry and referenced by ID in
+multiple workflows:
+
+- `:loan/audit-log` — used in both the loan application workflow and the
+  status check workflow
+- `:loan/send-notification` — shared across the approve, reject, and review
+  paths within the main workflow (same cell, three different edge convergences)
+- `:loan/fetch-application` — used in the status check workflow, reads from
+  the same `app-store` atom that the loan workflow writes to
+
+### Schema Chain Validation
+
+At compile time, Mycelium walks all paths from `:start` to `:end` and verifies
+that each cell's input keys are available from upstream outputs. Composed cells
+automatically infer their output schema from the child workflow's end-reaching
+cells, so the chain validator can see the produced keys without manual overrides.
+
+### Early Exit on Validation Failure
+
+The `:invalid` path from `validate-application` routes directly to `:end`,
+skipping credit assessment and everything downstream. The integration test
+verifies that `:credit-score` and `:notification` are nil on this path.
+
+### Execution Traces
+
+Every workflow run produces a `:mycelium/trace` vector recording which cells
+executed, their IDs, and duration. The integration tests verify that:
+
+- The approve path trace contains `validate-application`, `credit-assessment`,
+  `eligibility-decision`, `auto-approve`, `audit-log`, `send-notification`
+- The reject path trace contains `auto-reject` but not `auto-approve` or
+  `queue-for-review`
+
+### Pre-Compilation
+
+Both the loan application and status check workflows are pre-compiled at
+namespace load time with `myc/pre-compile`, so repeated calls to
+`run-compiled` do zero compilation work per invocation.
+
+### Dev Testing Utilities
+
+Cell unit tests use `dev/test-cell` for isolated single-path testing and
+`dev/test-transitions` for multi-path testing in a single call. Both perform
+full schema validation (input + output) and dispatch matching. Cells without
+dispatch predicates (like `classify-risk`) can also use `test-transitions` for
+output-only validation across multiple input scenarios.
+
+## File Structure
+
+```
+src/loan/
+  cells.clj         12 cell registrations (defmethod cell/cell-spec)
+  workflows.clj     3 workflow definitions + composed cell registration
+
+test/loan/
+  cells_test.clj    22 unit tests — each cell tested in isolation
+  workflows_test.clj 14 integration tests — every path through each workflow
+```
+
+## Workflows
+
+### 1. Credit Assessment (subworkflow)
+
+```
+credit-bureau-lookup → calculate-score → classify-risk → end
+```
+
+Registered as the `:loan/credit-assessment` cell for embedding in other
+workflows. Also runnable standalone via `myc/run-workflow`.
+
+### 2. Loan Application (main)
+
+```
+validate-application ──┬── (valid) → credit-assessment ──┬── (success) → eligibility-decision
+                       │                                  │                ├── (approve) → auto-approve  ──┐
+                       │                                  │                ├── (reject)  → auto-reject   ──┤
+                       │                                  │                └── (review)  → queue-review  ──┤
+                       │                                  │                                                │
+                       │                                  └── (failure) → end                              │
+                       │                                                                                   │
+                       └── (invalid) → end                     audit-log ← ────────────────────────────────┘
+                                                                  │
+                                                           send-notification → end
+```
+
+### 3. Application Status Check
+
+```
+fetch-application ──┬── (found)     → format-status → audit-log → end
+                    └── (not-found) → end
+```
+
+Reuses `:loan/fetch-application` and `:loan/audit-log` from the same cell registry.
+
+## Cells
+
+| Cell | Purpose |
+|------|---------|
+| `:loan/validate-application` | Check required fields, produce `:valid`/`:invalid` |
+| `:loan/credit-bureau-lookup` | Look up credit history from in-memory DB |
+| `:loan/calculate-score` | Compute credit score (300-850) from history |
+| `:loan/classify-risk` | Map score to `:low`/`:medium`/`:high` |
+| `:loan/eligibility-decision` | Route based on risk + amount (3-way) |
+| `:loan/auto-approve` | Set approved status + interest rate |
+| `:loan/auto-reject` | Set rejected status + reason |
+| `:loan/queue-for-review` | Set pending status + queue assignment |
+| `:loan/send-notification` | Generate notification from current status |
+| `:loan/audit-log` | Append entry to audit trail vector |
+| `:loan/fetch-application` | Look up stored application |
+| `:loan/format-status` | Format human-readable status report |

--- a/examples/loan_processing/src/loan/workflows.clj
+++ b/examples/loan_processing/src/loan/workflows.clj
@@ -1,0 +1,112 @@
+(ns loan.workflows
+  "Workflow definitions for the loan processing example.
+   Three workflows demonstrating branching, cell reuse, and subworkflow composition."
+  (:require [mycelium.core :as myc]
+            [mycelium.compose :as compose]
+            ;; Trigger cell registrations
+            loan.cells))
+
+;; ===== Workflow 1: Credit Assessment (subworkflow) =====
+;; Linear pipeline: credit-bureau-lookup → calculate-score → classify-risk
+;; Registered as a cell via register-workflow-cell! for embedding in the main workflow.
+
+(def credit-assessment-workflow
+  {:cells      {:start         :loan/credit-bureau-lookup
+                :calc-score    :loan/calculate-score
+                :classify-risk :loan/classify-risk}
+   :edges      {:start         :calc-score
+                :calc-score    :classify-risk
+                :classify-risk :end}
+   :dispatches {}})
+
+(compose/register-workflow-cell!
+ :loan/credit-assessment
+ credit-assessment-workflow
+ {:input  [:map [:applicant-name :string]]
+  :output [:map [:credit-score :int] [:risk-level [:enum :low :medium :high]]]})
+
+;; ===== Workflow 2: Loan Application (main branching workflow) =====
+;; validate-application → credit-assessment → eligibility-decision
+;;   ├── auto-approve  ──┐
+;;   ├── auto-reject   ──┼── audit-log → send-notification → end
+;;   └── queue-review  ──┘
+
+(def loan-application-workflow
+  {:cells
+   {:start              :loan/validate-application
+    :credit-assessment  :loan/credit-assessment
+    :eligibility        :loan/eligibility-decision
+    :auto-approve       :loan/auto-approve
+    :auto-reject        :loan/auto-reject
+    :queue-review       :loan/queue-for-review
+    :audit-log          :loan/audit-log
+    :send-notification  :loan/send-notification}
+
+   :edges
+   {:start             {:valid   :credit-assessment
+                        :invalid :end}
+    :credit-assessment {:success :eligibility
+                        :failure :end}
+    :eligibility       {:approve :auto-approve
+                        :reject  :auto-reject
+                        :review  :queue-review}
+    :auto-approve      :audit-log
+    :auto-reject       :audit-log
+    :queue-review      :audit-log
+    :audit-log         :send-notification
+    :send-notification :end}
+
+   :dispatches
+   {:start      [[:valid   (fn [d] (= :valid (:validation-status d)))]
+                 [:invalid (fn [d] (= :invalid (:validation-status d)))]]
+    :eligibility [[:approve (fn [d] (= :approve (:decision d)))]
+                  [:reject  (fn [d] (= :reject (:decision d)))]
+                  [:review  (fn [d] (= :review (:decision d)))]]}})
+
+(def compiled-loan-application
+  (myc/pre-compile loan-application-workflow))
+
+(defn run-loan-application
+  "Runs the loan application workflow.
+   resources: {:credit-db {\"name\" {...}} :app-store (atom {})}
+   application: {:applicant-name \"...\" :income N :loan-amount N}"
+  [resources application]
+  (let [result (myc/run-compiled compiled-loan-application resources application)]
+    ;; Store the result for later status checks
+    (when-let [store (:app-store resources)]
+      (when (:application-status result)
+        (swap! store assoc (:applicant-name application)
+               (select-keys result [:application-status :loan-amount :credit-score
+                                    :interest-rate :risk-level :review-queue
+                                    :decision-reason :applicant-name]))))
+    result))
+
+;; ===== Workflow 3: Application Status Check =====
+;; fetch-application → format-status → audit-log → end
+;;   └── (not-found) → end
+
+(def status-check-workflow
+  {:cells
+   {:start         :loan/fetch-application
+    :format-status :loan/format-status
+    :audit-log     :loan/audit-log}
+
+   :edges
+   {:start         {:found     :format-status
+                    :not-found :end}
+    :format-status :audit-log
+    :audit-log     :end}
+
+   :dispatches
+   {:start [[:found     (fn [d] (= :found (:fetch-status d)))]
+            [:not-found (fn [d] (= :not-found (:fetch-status d)))]]}})
+
+(def compiled-status-check
+  (myc/pre-compile status-check-workflow))
+
+(defn run-status-check
+  "Runs the status check workflow.
+   resources: {:app-store (atom {...})}
+   query: {:applicant-name \"...\"}"
+  [resources query]
+  (myc/run-compiled compiled-status-check resources query))

--- a/examples/loan_processing/test/loan/cells_test.clj
+++ b/examples/loan_processing/test/loan/cells_test.clj
@@ -1,0 +1,273 @@
+(ns loan.cells-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.dev :as dev]
+            loan.cells))
+
+;; Ensure cells are registered even with random test ordering
+(use-fixtures :each (fn [f]
+                      (when-not (cell/get-cell :loan/validate-application)
+                        (require 'loan.cells :reload))
+                      (f)))
+
+;; ===== Dispatch predicate helpers =====
+
+(def validation-dispatches
+  [[:valid   (fn [d] (= :valid (:validation-status d)))]
+   [:invalid (fn [d] (= :invalid (:validation-status d)))]])
+
+(def decision-dispatches
+  [[:approve (fn [d] (= :approve (:decision d)))]
+   [:reject  (fn [d] (= :reject (:decision d)))]
+   [:review  (fn [d] (= :review (:decision d)))]])
+
+(def fetch-dispatches
+  [[:found     (fn [d] (= :found (:fetch-status d)))]
+   [:not-found (fn [d] (= :not-found (:fetch-status d)))]])
+
+;; ===== validate-application =====
+
+(deftest validate-application-valid-test
+  (testing "validates a complete, correct application"
+    (let [result (dev/test-cell :loan/validate-application
+                  {:input      {:applicant-name "Alice" :income 80000 :loan-amount 30000}
+                   :dispatches validation-dispatches})]
+      (is (:pass? result))
+      (is (= :valid (:matched-dispatch result)))
+      (is (= :valid (get-in result [:output :validation-status]))))))
+
+(deftest validate-application-invalid-test
+  (testing "rejects application with missing fields"
+    (let [result (dev/test-cell :loan/validate-application
+                  {:input      {:applicant-name "" :income nil :loan-amount nil}
+                   :dispatches validation-dispatches})]
+      (is (:pass? result))
+      (is (= :invalid (:matched-dispatch result)))
+      (is (= :invalid (get-in result [:output :validation-status])))
+      (is (seq (get-in result [:output :validation-errors]))))))
+
+(deftest validate-application-transitions-test
+  (testing "both transitions with test-transitions"
+    (let [results (dev/test-transitions :loan/validate-application
+                    {:valid   {:input      {:applicant-name "Bob" :income 50000 :loan-amount 20000}
+                               :dispatches validation-dispatches}
+                     :invalid {:input      {:applicant-name nil :income -1 :loan-amount 0}
+                               :dispatches validation-dispatches}})]
+      (is (get-in results [:valid :pass?]))
+      (is (get-in results [:invalid :pass?])))))
+
+;; ===== credit-bureau-lookup =====
+
+(deftest credit-bureau-lookup-known-test
+  (testing "returns credit history for a known applicant"
+    (let [credit-db {"Alice" {:accounts 5 :late-payments 0
+                               :bankruptcies 0 :years-of-history 10}}
+          result    (dev/test-cell :loan/credit-bureau-lookup
+                     {:input     {:applicant-name "Alice"}
+                      :resources {:credit-db credit-db}})]
+      (is (:pass? result))
+      (is (= 5 (get-in result [:output :credit-history :accounts]))))))
+
+(deftest credit-bureau-lookup-unknown-test
+  (testing "returns empty history for unknown applicant"
+    (let [result (dev/test-cell :loan/credit-bureau-lookup
+                   {:input     {:applicant-name "Unknown"}
+                    :resources {:credit-db {}}})]
+      (is (:pass? result))
+      (is (= 0 (get-in result [:output :credit-history :accounts]))))))
+
+;; ===== calculate-score =====
+
+(deftest calculate-score-good-history-test
+  (testing "good credit history produces high score"
+    (let [result (dev/test-cell :loan/calculate-score
+                   {:input {:credit-history {:accounts 5 :late-payments 0
+                                             :bankruptcies 0 :years-of-history 10}}})]
+      (is (:pass? result))
+      (is (>= (get-in result [:output :credit-score]) 720)))))
+
+(deftest calculate-score-bad-history-test
+  (testing "bad credit history produces low score"
+    (let [result (dev/test-cell :loan/calculate-score
+                   {:input {:credit-history {:accounts 1 :late-payments 5
+                                             :bankruptcies 1 :years-of-history 1}}})]
+      (is (:pass? result))
+      (is (<= (get-in result [:output :credit-score]) 620)))))
+
+(deftest calculate-score-clamped-test
+  (testing "score is clamped to 300-850 range"
+    (let [result-low (dev/test-cell :loan/calculate-score
+                       {:input {:credit-history {:accounts 0 :late-payments 10
+                                                 :bankruptcies 3 :years-of-history 0}}})
+          result-high (dev/test-cell :loan/calculate-score
+                        {:input {:credit-history {:accounts 10 :late-payments 0
+                                                  :bankruptcies 0 :years-of-history 20}}})]
+      (is (= 300 (get-in result-low [:output :credit-score])))
+      (is (= 850 (get-in result-high [:output :credit-score]))))))
+
+;; ===== classify-risk =====
+
+(deftest classify-risk-test
+  (testing "risk classification based on score thresholds via test-transitions"
+    (let [results (dev/test-transitions :loan/classify-risk
+                    {:low    {:input {:credit-score 750}}
+                     :medium {:input {:credit-score 650}}
+                     :high   {:input {:credit-score 500}}})]
+      (is (get-in results [:low :pass?]))
+      (is (= :low (get-in results [:low :output :risk-level])))
+      (is (get-in results [:medium :pass?]))
+      (is (= :medium (get-in results [:medium :output :risk-level])))
+      (is (get-in results [:high :pass?]))
+      (is (= :high (get-in results [:high :output :risk-level]))))))
+
+;; ===== eligibility-decision =====
+
+(deftest eligibility-decision-approve-test
+  (testing "low risk + small amount → approve"
+    (let [result (dev/test-cell :loan/eligibility-decision
+                   {:input      {:risk-level :low :loan-amount 30000}
+                    :dispatches decision-dispatches})]
+      (is (:pass? result))
+      (is (= :approve (:matched-dispatch result))))))
+
+(deftest eligibility-decision-reject-test
+  (testing "high risk → reject"
+    (let [result (dev/test-cell :loan/eligibility-decision
+                   {:input      {:risk-level :high :loan-amount 10000}
+                    :dispatches decision-dispatches})]
+      (is (:pass? result))
+      (is (= :reject (:matched-dispatch result))))))
+
+(deftest eligibility-decision-review-medium-test
+  (testing "medium risk → review"
+    (let [result (dev/test-cell :loan/eligibility-decision
+                   {:input      {:risk-level :medium :loan-amount 25000}
+                    :dispatches decision-dispatches})]
+      (is (:pass? result))
+      (is (= :review (:matched-dispatch result))))))
+
+(deftest eligibility-decision-review-large-amount-test
+  (testing "low risk + large amount → review"
+    (let [result (dev/test-cell :loan/eligibility-decision
+                   {:input      {:risk-level :low :loan-amount 100000}
+                    :dispatches decision-dispatches})]
+      (is (:pass? result))
+      (is (= :review (:matched-dispatch result))))))
+
+;; ===== auto-approve =====
+
+(deftest auto-approve-test
+  (testing "sets approved status with interest rate"
+    (let [result (dev/test-cell :loan/auto-approve
+                   {:input {:credit-score 780}})]
+      (is (:pass? result))
+      (is (= :approved (get-in result [:output :application-status])))
+      (is (= 3.5 (get-in result [:output :interest-rate]))))))
+
+;; ===== auto-reject =====
+
+(deftest auto-reject-test
+  (testing "sets rejected status with reason"
+    (let [result (dev/test-cell :loan/auto-reject
+                   {:input {:risk-level :high}})]
+      (is (:pass? result))
+      (is (= :rejected (get-in result [:output :application-status])))
+      (is (string? (get-in result [:output :decision-reason]))))))
+
+;; ===== queue-for-review =====
+
+(deftest queue-for-review-standard-test
+  (testing "medium risk → standard queue"
+    (let [result (dev/test-cell :loan/queue-for-review
+                   {:input {:risk-level :medium :loan-amount 25000}})]
+      (is (:pass? result))
+      (is (= :pending-review (get-in result [:output :application-status])))
+      (is (= :standard (get-in result [:output :review-queue]))))))
+
+(deftest queue-for-review-senior-test
+  (testing "large amount → senior queue"
+    (let [result (dev/test-cell :loan/queue-for-review
+                   {:input {:risk-level :low :loan-amount 100000}})]
+      (is (:pass? result))
+      (is (= :senior (get-in result [:output :review-queue]))))))
+
+;; ===== send-notification =====
+
+(deftest send-notification-approved-test
+  (testing "generates approval notification"
+    (let [result (dev/test-cell :loan/send-notification
+                   {:input {:applicant-name "Alice"
+                            :application-status :approved
+                            :interest-rate 3.5}})]
+      (is (:pass? result))
+      (is (= "Alice" (get-in result [:output :notification :to])))
+      (is (clojure.string/includes?
+           (get-in result [:output :notification :body]) "approved")))))
+
+(deftest send-notification-rejected-test
+  (testing "generates rejection notification"
+    (let [result (dev/test-cell :loan/send-notification
+                   {:input {:applicant-name "Carol"
+                            :application-status :rejected
+                            :decision-reason "High risk"}})]
+      (is (:pass? result))
+      (is (clojure.string/includes?
+           (get-in result [:output :notification :body]) "declined")))))
+
+;; ===== audit-log =====
+
+(deftest audit-log-appends-test
+  (testing "appends to existing audit trail"
+    (let [result (dev/test-cell :loan/audit-log
+                   {:input {:applicant-name "Alice"
+                            :application-status :approved
+                            :audit-trail [{:action :previous}]}})]
+      (is (:pass? result))
+      (is (= 2 (count (get-in result [:output :audit-trail])))))))
+
+(deftest audit-log-creates-trail-test
+  (testing "creates audit trail when none exists"
+    (let [result (dev/test-cell :loan/audit-log
+                   {:input {:applicant-name "Bob"
+                            :application-status :pending-review}})]
+      (is (:pass? result))
+      (is (= 1 (count (get-in result [:output :audit-trail])))))))
+
+;; ===== fetch-application =====
+
+(deftest fetch-application-found-test
+  (testing "finds an existing application"
+    (let [store  (atom {"Alice" {:application-status :approved :loan-amount 30000}})
+          result (dev/test-cell :loan/fetch-application
+                   {:input      {:applicant-name "Alice"}
+                    :resources  {:app-store store}
+                    :dispatches fetch-dispatches})]
+      (is (:pass? result))
+      (is (= :found (:matched-dispatch result)))
+      (is (= :approved (get-in result [:output :application-status]))))))
+
+(deftest fetch-application-not-found-test
+  (testing "handles missing application"
+    (let [store  (atom {})
+          result (dev/test-cell :loan/fetch-application
+                   {:input      {:applicant-name "Unknown"}
+                    :resources  {:app-store store}
+                    :dispatches fetch-dispatches})]
+      (is (:pass? result))
+      (is (= :not-found (:matched-dispatch result)))
+      (is (string? (get-in result [:output :error-message]))))))
+
+;; ===== format-status =====
+
+(deftest format-status-test
+  (testing "formats a status report"
+    (let [result (dev/test-cell :loan/format-status
+                   {:input {:applicant-name "Alice"
+                            :application-status :approved
+                            :loan-amount 30000
+                            :credit-score 780
+                            :interest-rate 3.5}})]
+      (is (:pass? result))
+      (is (string? (get-in result [:output :status-report])))
+      (is (clojure.string/includes?
+           (get-in result [:output :status-report]) "Alice")))))

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -174,3 +174,8 @@
   "Runs Maestro's static analysis on a workflow definition.
    See mycelium.dev/analyze-workflow."
   dev/analyze-workflow)
+
+(def infer-workflow-schema
+  "Walks a workflow and reports accumulated schema keys at each cell.
+   See mycelium.dev/infer-workflow-schema."
+  dev/infer-workflow-schema)


### PR DESCRIPTION
Four framework improvements:
- Infer output keys for composed cells so parent chain validation works without set-cell-schema! workaround
- Support :pipeline shorthand in programmatic workflows (not just manifests)
- Fix test-transitions to skip dispatch check when case has no :dispatches
- Add infer-workflow-schema dev helper showing accumulated keys at each cell
- Add MYCELIUM_GUIDE.md — compact LLM-loadable reference for the framework.