### PR TITLE
Add parameterized cells and resilience4j policies

### DIFF
--- a/MYCELIUM_GUIDE.md
+++ b/MYCELIUM_GUIDE.md
@@ -143,6 +143,35 @@ Run cells in parallel (or sequential), merge results:
 - Without `:merge-fn`, results are merged via `(apply merge data results)` — output keys must be disjoint
 - With `:merge-fn`: `(fn [data results-vec] -> merged-data)`
 
+## Parameterized Cells
+
+Reuse the same handler with different configuration:
+
+```clojure
+{:cells {:triple {:id :math/multiply :params {:factor 3}}
+         :double {:id :math/multiply :params {:factor 2}}}
+ :pipeline [:triple :double]}
+```
+
+Params are injected as `:mycelium/params` in data before the handler runs. Access via `(get-in data [:mycelium/params :factor])`. Cleaned up automatically after each step. Bare keywords still work as before.
+
+## Resilience Policies
+
+Wrap cells with resilience4j policies via `:resilience`:
+
+```clojure
+{:cells {:start :api/call, :fallback :ui/error}
+ :edges {:start {:done :end, :failed :fallback}, :fallback :end}
+ :dispatches {:start [[:failed (fn [d] (some? (:mycelium/resilience-error d)))]
+                       [:done   (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+ :resilience {:start {:timeout {:timeout-ms 5000}
+                       :retry   {:max-attempts 3 :wait-ms 200}}}}
+```
+
+Available policies: `:timeout`, `:retry`, `:circuit-breaker`, `:bulkhead`, `:rate-limiter`. When triggered, data gets `:mycelium/resilience-error` (map with `:type`, `:cell`, `:message`). Use dispatch predicates to route to fallback cells.
+
+Stateful policies (circuit breaker, rate limiter) require `pre-compile` + `run-compiled`. `:async-timeout-ms` (default 30s) controls promise wait time for async cells.
+
 ## Manifests (EDN)
 
 Define workflows as data in `.edn` files:
@@ -224,6 +253,7 @@ Define workflows as data in `.edn` files:
 | Dispatch coverage | Every edge label has a predicate (and vice versa) |
 | Schema chain | Each cell's input keys available from upstream outputs |
 | Join validation | Members exist, no name collisions, disjoint outputs |
+| Resilience | Policy keys valid, referenced cells exist, timeout-ms positive |
 | No-path-to-end | No reachable state stuck without path to `:end` |
 
 ## File Layout
@@ -234,6 +264,7 @@ src/mycelium/
   cell.clj         Cell registry (multimethod)
   schema.clj       Malli pre/post interceptors
   workflow.clj      DSL → Maestro compiler
+  resilience.clj   resilience4j wrapper (timeout, retry, CB, bulkhead, rate limiter)
   compose.clj      Hierarchical workflow nesting
   manifest.clj     EDN manifest loading, cell briefs
   middleware.clj   Ring middleware
@@ -272,6 +303,7 @@ When you receive a cell brief (from `cell-brief`), implement it as:
 - Custom error handling: pass `:on-error (fn [resources fsm-state] -> data)` to `compile-workflow`
 - Composed cells set `:mycelium/error` on failure for parent dispatch routing
 - Join errors collected in `:mycelium/join-error`
+- Resilience errors in `:mycelium/resilience-error` — route to fallback cells via dispatch predicates
 
 ### Gotchas
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,29 @@ External dependencies are injected, never acquired by cells:
    :async?      true})
 ```
 
+### Parameterized Cells
+
+The same cell handler can be reused with different configuration by passing a map with `:id` and `:params` instead of a bare keyword:
+
+```clojure
+(defmethod cell/cell-spec :math/multiply [_]
+  {:id      :math/multiply
+   :handler (fn [_ data]
+              (let [factor (get-in data [:mycelium/params :factor])]
+                (assoc data :result (* factor (:x data)))))
+   :schema  {:input  [:map [:x :int]]
+             :output [:map [:result :int]]}})
+
+(myc/run-workflow
+  {:cells {:start  {:id :math/multiply :params {:factor 3}}
+           :double {:id :math/multiply :params {:factor 2}}}
+   :pipeline [:start :double]}
+  {} {:x 5})
+;; => {:x 5, :result 30}  — first ×3 = 15, then ×2 = 30
+```
+
+Params are injected as `:mycelium/params` in the data map before the handler runs, and automatically cleaned up after each step. Bare keywords continue to work as before.
+
 ## Accumulating Data Model
 
 Cells communicate through an accumulating data map. Every cell receives the full map of all keys produced by every prior cell in the path — not just its immediate predecessor. Cells `assoc` their outputs into this map, and the enriched map flows forward.
@@ -292,6 +315,64 @@ Each join produces a single trace entry with a `:join-traces` vector containing 
 | `:on-failure` | `nil` | Cell name to route to on failure (informational) |
 | `:timeout-ms` | `30000` | Timeout in ms for async cell invocations within the join |
 
+## Resilience Policies
+
+Cells can be wrapped with [resilience4j](https://github.com/resilience4j/resilience4j) policies — timeouts, retries, circuit breakers, bulkheads, and rate limiters — via the `:resilience` key in a workflow definition:
+
+```clojure
+(myc/run-workflow
+  {:cells {:start :api/fetch-data
+           :fallback :ui/show-error}
+   :edges {:start    {:done :end, :failed :fallback}
+           :fallback :end}
+   :dispatches {:start [[:failed (fn [d] (some? (:mycelium/resilience-error d)))]
+                         [:done   (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+   :resilience {:start {:timeout        {:timeout-ms 5000}
+                         :retry          {:max-attempts 3 :wait-ms 200}
+                         :circuit-breaker {:failure-rate 50
+                                           :minimum-calls 10
+                                           :sliding-window-size 100
+                                           :wait-in-open-ms 60000}
+                         :bulkhead       {:max-concurrent 25 :max-wait-ms 0}
+                         :rate-limiter   {:limit-for-period 50
+                                          :limit-refresh-period-ms 500
+                                          :timeout-ms 5000}
+                         :async-timeout-ms 30000}}}
+  resources initial-data)
+```
+
+When a resilience policy triggers (timeout, circuit open, bulkhead full, rate limited, retries exhausted), the handler returns data with `:mycelium/resilience-error` instead of throwing. Use dispatch predicates to route to fallback cells.
+
+### Resilience Error Map
+
+```clojure
+{:type    :timeout       ;; :timeout, :circuit-open, :bulkhead-full, :rate-limited, :unknown
+ :cell    :start         ;; workflow cell name
+ :message "..."}         ;; human-readable description
+```
+
+### Stateful Policies
+
+Circuit breakers and rate limiters track state across calls. Use `pre-compile` + `run-compiled` so the same instance is reused:
+
+```clojure
+(def compiled (myc/pre-compile workflow-def))
+(myc/run-compiled compiled resources data)  ;; CB state persists
+```
+
+### Policy Reference
+
+| Policy | Key | Config | Default |
+|--------|-----|--------|---------|
+| Timeout | `:timeout` | `:timeout-ms` | (required) |
+| Retry | `:retry` | `:max-attempts`, `:wait-ms` | 3, 500 |
+| Circuit Breaker | `:circuit-breaker` | `:failure-rate`, `:minimum-calls`, `:sliding-window-size`, `:wait-in-open-ms` | 50, 10, 100, 60000 |
+| Bulkhead | `:bulkhead` | `:max-concurrent`, `:max-wait-ms` | 25, 0 |
+| Rate Limiter | `:rate-limiter` | `:limit-for-period`, `:limit-refresh-period-ms`, `:timeout-ms` | 50, 500, 5000 |
+| Async Timeout | `:async-timeout-ms` | (integer, ms) | 30000 |
+
+`:async-timeout-ms` controls how long the resilience wrapper waits for an async cell's promise to resolve. It is independent of the resilience4j `:timeout` policy.
+
 ## Compile-Time Validation
 
 `compile-workflow` validates before any code runs:
@@ -301,6 +382,7 @@ Each join produces a single trace entry with a `:join-traces` vector containing 
 - **Reachability** — every cell and join must be reachable from `:start`
 - **Dispatch coverage** — every edge label must have a corresponding dispatch predicate, and vice versa
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware: validates member inputs and accumulates union of member outputs)
+- **Resilience validation** — policy keys are valid, referenced cells exist, timeout-ms is positive
 - **Join validation** — member cells exist, no name collisions with cells, members have no edges, output keys are disjoint (or `:merge-fn` provided), strategy is valid, no cell appears in multiple joins
 
 ```
@@ -609,6 +691,7 @@ mycelium/
 │   ├── cell.clj          ;; Cell registry (multimethod-based)
 │   ├── schema.clj        ;; Malli pre/post interceptors
 │   ├── workflow.clj      ;; DSL → Maestro compiler
+│   ├── resilience.clj    ;; resilience4j wrapper (timeout, retry, CB, bulkhead, rate limiter)
 │   ├── compose.clj       ;; Hierarchical workflow nesting
 │   ├── manifest.clj      ;; EDN manifest loading, cell briefs
 │   ├── middleware.clj     ;; Ring middleware for workflow execution
@@ -617,6 +700,10 @@ mycelium/
 │   └── core.clj          ;; Public API
 └── test/mycelium/        ;; tests and assertions
 ```
+
+## Acknowledgements
+
+* [Statecharts: a visual formalism for complex systems](https://www.sciencedirect.com/science/article/pii/0167642387900359)
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
          io.github.yogthos/maestro {:git/url "https://github.com/yogthos/maestro"
                                     :git/sha "fc4b684a380700a693ee9502674e354835864960"}
-         metosin/malli       {:mvn/version "0.17.0"}}
+         metosin/malli       {:mvn/version "0.17.0"}
+         io.github.resilience4j/resilience4j-all {:mvn/version "2.3.0"}}
  :aliases
  {:dev  {:extra-paths ["dev" "test" "examples"]
          :extra-deps  {nrepl/nrepl {:mvn/version "1.3.0"}}}

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -76,13 +76,15 @@ A cell can depend on data produced several steps earlier without special wiring 
 ## Workflow Definition
 
 ```clojure
-{:cells       {:start :cell/id, :step2 :cell/id2}
+{:cells       {:start :cell/id, :step2 :cell/id2}    ;; or {:id :cell/id :params {...}}
  :edges       {:start {:label :step2}, :step2 {:done :end}}
  :dispatches  {:start [[:label (fn [data] (:key data))]]
                :step2 [[:done (constantly true)]]}
  :joins       {:join-name {:cells [:a :b] :strategy :parallel}}  ;; optional
  :input-schema [:map [:key :type]]                                ;; optional
- :interceptors [{:id :x :scope :all :pre (fn [d] d)}]}           ;; optional
+ :interceptors [{:id :x :scope :all :pre (fn [d] d)}]            ;; optional
+ :resilience  {:start {:timeout {:timeout-ms 5000}}}              ;; optional
+}
 ```
 
 ### Pipeline Shorthand
@@ -222,6 +224,43 @@ Scope forms:
 
 Interceptor `:pre`/`:post` receive and return the `data` map (not fsm-state).
 
+## Parameterized Cells
+
+Reuse the same handler with different config by passing a map instead of a bare keyword:
+
+```clojure
+{:cells {:triple {:id :math/multiply :params {:factor 3}}
+         :double {:id :math/multiply :params {:factor 2}}}
+ :pipeline [:triple :double]}
+```
+
+Params are injected as `:mycelium/params` in the data map and cleaned up after each step. Access via `(get-in data [:mycelium/params :factor])`.
+
+## Resilience Policies
+
+Wrap cells with [resilience4j](https://github.com/resilience4j/resilience4j) policies via `:resilience`:
+
+```clojure
+{:cells {:start :api/call, :fallback :ui/error}
+ :edges {:start {:done :end, :failed :fallback}, :fallback :end}
+ :dispatches {:start [[:failed (fn [d] (some? (:mycelium/resilience-error d)))]
+                       [:done   (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+ :resilience {:start {:timeout        {:timeout-ms 5000}
+                       :retry          {:max-attempts 3 :wait-ms 200}
+                       :circuit-breaker {:failure-rate 50 :minimum-calls 10
+                                         :sliding-window-size 100 :wait-in-open-ms 60000}
+                       :bulkhead       {:max-concurrent 25 :max-wait-ms 0}
+                       :rate-limiter   {:limit-for-period 50
+                                        :limit-refresh-period-ms 500 :timeout-ms 5000}
+                       :async-timeout-ms 30000}}}
+```
+
+When triggered, handler returns data with `:mycelium/resilience-error` (map with `:type`, `:cell`, `:message`). Error types: `:timeout`, `:circuit-open`, `:bulkhead-full`, `:rate-limited`, `:unknown`.
+
+Stateful policies (circuit breaker, rate limiter) require `pre-compile` + `run-compiled` to share state across calls.
+
+`:async-timeout-ms` controls how long the resilience wrapper waits for an async handler's promise (default 30s). Independent of the resilience4j `:timeout` policy.
+
 ## Manifest Loading
 
 ```clojure
@@ -324,6 +363,7 @@ Per-transition schemas are validated based on which dispatch matched. The schema
 - **Reachability** — every cell and join must be reachable from `:start`
 - **Dispatch coverage** — every edge label must have a dispatch predicate, and vice versa
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware)
+- **Resilience validation** — policy keys valid, referenced cells exist, timeout-ms positive
 - **Join validation** — member cells exist, no name collisions, members have no edges, output keys disjoint (or `:merge-fn` provided)
 
 ## Edge Targets
@@ -475,4 +515,5 @@ Every run produces `:mycelium/trace` — a vector of step-by-step execution reco
 | `:mycelium/input-error` | Input schema validation failure (workflow didn't run) |
 | `:mycelium/schema-error` | Runtime schema violation details |
 | `:mycelium/join-error` | Join node error details |
+| `:mycelium/resilience-error` | Resilience policy trigger details (`:type`, `:cell`, `:message`) |
 | `:mycelium/child-trace` | Nested workflow trace (composed cells) |

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -287,26 +287,28 @@
    Returns {:cells ... :edges ... :dispatches ...} suitable for `workflow/compile-workflow`."
   [{:keys [cells edges dispatches] :as manifest}]
   (let [cells    (resolve-inherit-schemas cells)
-        cell-ids (into {}
-                       (map (fn [[cell-name cell-def]]
-                              (let [{:keys [id schema requires]} cell-def]
-                                (if (cell/get-cell id)
-                                  ;; Cell already registered — apply manifest metadata
-                                  (cell/set-cell-meta! id {:schema   schema
-                                                           :requires (or requires [])})
-                                  ;; Not registered — register stub handler with full spec
-                                  (let [stub {:id      id
-                                              :handler (fn [_ data] data)
-                                              :schema  schema
-                                              :requires (or requires [])
-                                              :doc     (:doc cell-def)}]
-                                    (.addMethod cell/cell-spec id (constantly stub))
-                                    stub))
-                                [cell-name id])))
-                       cells)]
-    (cond-> {:cells cell-ids
+        cell-refs (into {}
+                        (map (fn [[cell-name cell-def]]
+                               (let [{:keys [id schema requires params]} cell-def]
+                                 (if (cell/get-cell id)
+                                   (cell/set-cell-meta! id {:schema   schema
+                                                            :requires (or requires [])})
+                                   (let [stub {:id      id
+                                               :handler (fn [_ data] data)
+                                               :schema  schema
+                                               :requires (or requires [])
+                                               :doc     (:doc cell-def)}]
+                                     (.addMethod cell/cell-spec id (constantly stub))
+                                     stub))
+                                 ;; Emit map form when params present, bare keyword otherwise
+                                 [cell-name (if params
+                                              {:id id :params params}
+                                              id)])))
+                        cells)]
+    (cond-> {:cells cell-refs
              :edges edges}
       dispatches (assoc :dispatches dispatches)
       (:joins manifest) (assoc :joins (:joins manifest))
       (:input-schema manifest) (assoc :input-schema (:input-schema manifest))
-      (:interceptors manifest) (assoc :interceptors (:interceptors manifest)))))
+      (:interceptors manifest) (assoc :interceptors (:interceptors manifest))
+      (:resilience manifest) (assoc :resilience (:resilience manifest)))))

--- a/src/mycelium/resilience.clj
+++ b/src/mycelium/resilience.clj
@@ -1,0 +1,234 @@
+(ns mycelium.resilience
+  "Resilience policies for Mycelium cells.
+   Wraps cell handlers with resilience4j circuit breakers, retries,
+   timeouts, bulkheads, and rate limiters."
+  (:require [clojure.set :as set])
+  (:import [io.github.resilience4j.circuitbreaker CircuitBreaker CircuitBreakerConfig]
+           [io.github.resilience4j.retry Retry RetryConfig]
+           [io.github.resilience4j.timelimiter TimeLimiter TimeLimiterConfig]
+           [io.github.resilience4j.bulkhead Bulkhead BulkheadConfig]
+           [io.github.resilience4j.ratelimiter RateLimiter RateLimiterConfig]
+           [io.github.resilience4j.circuitbreaker CallNotPermittedException]
+           [io.github.resilience4j.bulkhead BulkheadFullException]
+           [io.github.resilience4j.ratelimiter RequestNotPermitted]
+           [java.time Duration]
+           [java.util.function Supplier]
+           [java.util.concurrent TimeoutException CompletableFuture]))
+
+;; ===== Config builders =====
+
+(defn- build-timeout
+  "Builds a TimeLimiter from config map.
+   Config keys: :timeout-ms (required)."
+  [cell-name {:keys [timeout-ms]}]
+  (let [config (-> (TimeLimiterConfig/custom)
+                   (.timeoutDuration (Duration/ofMillis timeout-ms))
+                   (.cancelRunningFuture true)
+                   (.build))]
+    (TimeLimiter/of (str (name cell-name) "-timeout") config)))
+
+(defn- build-retry
+  "Builds a Retry from config map.
+   Config keys: :max-attempts (default 3), :wait-ms (default 500)."
+  [cell-name {:keys [max-attempts wait-ms]}]
+  (let [config (-> (RetryConfig/custom)
+                   (.maxAttempts (or max-attempts 3))
+                   (.waitDuration (Duration/ofMillis (or wait-ms 500)))
+                   (.build))]
+    (Retry/of (str (name cell-name) "-retry") config)))
+
+(defn- build-circuit-breaker
+  "Builds a CircuitBreaker from config map.
+   Config keys: :failure-rate (default 50), :wait-in-open-ms (default 60000),
+   :sliding-window-size (default 100), :minimum-calls (default 10)."
+  [cell-name {:keys [failure-rate wait-in-open-ms sliding-window-size minimum-calls]}]
+  (let [config (-> (CircuitBreakerConfig/custom)
+                   (.failureRateThreshold (float (or failure-rate 50)))
+                   (.waitDurationInOpenState (Duration/ofMillis (or wait-in-open-ms 60000)))
+                   (.slidingWindowSize (or sliding-window-size 100))
+                   (.minimumNumberOfCalls (or minimum-calls 10))
+                   (.build))]
+    (CircuitBreaker/of (str (name cell-name) "-cb") config)))
+
+(defn- build-bulkhead
+  "Builds a Bulkhead from config map.
+   Config keys: :max-concurrent (default 25), :max-wait-ms (default 0)."
+  [cell-name {:keys [max-concurrent max-wait-ms]}]
+  (let [config (-> (BulkheadConfig/custom)
+                   (.maxConcurrentCalls (or max-concurrent 25))
+                   (.maxWaitDuration (Duration/ofMillis (or max-wait-ms 0)))
+                   (.build))]
+    (Bulkhead/of (str (name cell-name) "-bh") config)))
+
+(defn- build-rate-limiter
+  "Builds a RateLimiter from config map.
+   Config keys: :limit-for-period (default 50), :limit-refresh-period-ms (default 500),
+   :timeout-ms (default 5000)."
+  [cell-name {:keys [limit-for-period limit-refresh-period-ms timeout-ms]}]
+  (let [config (-> (RateLimiterConfig/custom)
+                   (.limitForPeriod (or limit-for-period 50))
+                   (.limitRefreshPeriod (Duration/ofMillis (or limit-refresh-period-ms 500)))
+                   (.timeoutDuration (Duration/ofMillis (or timeout-ms 5000)))
+                   (.build))]
+    (RateLimiter/of (str (name cell-name) "-rl") config)))
+
+;; ===== Error classification =====
+
+(defn- classify-error
+  "Classifies a resilience4j exception into a :mycelium/resilience-error map."
+  [cell-name ^Throwable e]
+  (let [cause (if (instance? java.util.concurrent.ExecutionException e)
+                (.getCause e)
+                e)]
+    (cond
+      (instance? TimeoutException cause)
+      {:type :timeout :cell cell-name :message (.getMessage cause)}
+
+      (instance? CallNotPermittedException cause)
+      {:type :circuit-open :cell cell-name :message (.getMessage cause)}
+
+      (instance? BulkheadFullException cause)
+      {:type :bulkhead-full :cell cell-name :message (.getMessage cause)}
+
+      (instance? RequestNotPermitted cause)
+      {:type :rate-limited :cell cell-name :message (.getMessage cause)}
+
+      :else
+      {:type :unknown :cell cell-name :message (.getMessage cause)
+       :exception-type (str (type cause))})))
+
+;; ===== Handler wrapping =====
+
+(defn- wrap-with-decorators
+  "Wraps a Supplier with non-timeout resilience decorators using static decorator methods.
+   Each decorator is a pure function: (instance, Supplier) → Supplier.
+   Applied innermost-first: circuit-breaker → bulkhead → rate-limiter → retry (outermost)."
+  ^Supplier [^Supplier supplier {:keys [circuit-breaker retry bulkhead rate-limiter]}]
+  (let [s (if circuit-breaker (CircuitBreaker/decorateSupplier circuit-breaker supplier) supplier)
+        s (if bulkhead        (Bulkhead/decorateSupplier bulkhead s) s)
+        s (if rate-limiter    (RateLimiter/decorateSupplier rate-limiter s) s)
+        s (if retry           (Retry/decorateSupplier retry s) s)]
+    s))
+
+(def ^:private default-async-timeout-ms
+  "Default timeout in ms for blocking on async handler promises."
+  30000)
+
+(defn- invoke-handler-sync
+  "Invokes a handler synchronously. For async (4-arity) handlers, blocks on a promise.
+   For sync (2-arity) handlers, calls directly.
+   `async-timeout-ms` controls how long to wait for the async promise (default 30s)."
+  [handler async? resources data async-timeout-ms]
+  (if async?
+    (let [p (promise)]
+      (handler resources data
+              (fn [result] (deliver p {:ok result}))
+              (fn [error]  (deliver p {:error error})))
+      (let [v (deref p (or async-timeout-ms default-async-timeout-ms)
+                      {:error (ex-info "Async cell timed out in resilience wrapper" {})})]
+        (if (:error v)
+          (throw (if (instance? Throwable (:error v))
+                   (:error v)
+                   (ex-info (str (:error v)) {})))
+          (:ok v))))
+    (handler resources data)))
+
+(defn wrap-handler
+  "Wraps a cell handler with resilience policies.
+   `cell-name` — the workflow cell name (for error reporting).
+   `policies` — map of policy configs, e.g. {:timeout {:timeout-ms 5000}, :retry {:max-attempts 3}}.
+   `opts` — optional map with :async? flag for async handlers.
+   Returns a wrapped handler that catches resilience failures
+   and returns data with :mycelium/resilience-error.
+   Supports both sync (2-arity) and async (4-arity) handlers."
+  ([handler cell-name policies]
+   (wrap-handler handler cell-name policies {}))
+  ([handler cell-name policies opts]
+  (let [timeout-cfg     (:timeout policies)
+        retry-cfg       (:retry policies)
+        cb-cfg          (:circuit-breaker policies)
+        bulkhead-cfg    (:bulkhead policies)
+        rate-limiter-cfg (:rate-limiter policies)
+        ;; Build resilience4j instances (stateful — built once at compile time)
+        tl    (when timeout-cfg (build-timeout cell-name timeout-cfg))
+        r     (when retry-cfg (build-retry cell-name retry-cfg))
+        cb    (when cb-cfg (build-circuit-breaker cell-name cb-cfg))
+        bh    (when bulkhead-cfg (build-bulkhead cell-name bulkhead-cfg))
+        rl    (when rate-limiter-cfg (build-rate-limiter cell-name rate-limiter-cfg))
+        has-decorators? (or r cb bh rl)
+        async? (:async? opts)
+        async-timeout-ms (:async-timeout-ms policies)
+        invoke (fn [resources data]
+                 (try
+                   (if tl
+                     ;; Timeout requires CompletableFuture path
+                     (if has-decorators?
+                       (let [supplier (reify Supplier
+                                        (get [_] (invoke-handler-sync handler async? resources data async-timeout-ms)))
+                             decorated (wrap-with-decorators supplier
+                                         {:circuit-breaker cb :retry r
+                                          :bulkhead bh :rate-limiter rl})
+                             future-supplier (reify Supplier
+                                               (get [_]
+                                                 (CompletableFuture/supplyAsync decorated)))]
+                         (.executeFutureSupplier tl future-supplier))
+                       ;; Timeout only
+                       (let [future-supplier (reify Supplier
+                                               (get [_]
+                                                 (CompletableFuture/supplyAsync
+                                                   (reify Supplier
+                                                     (get [_] (invoke-handler-sync handler async? resources data async-timeout-ms))))))]
+                         (.executeFutureSupplier tl future-supplier)))
+                     ;; No timeout — use synchronous decorator path
+                     (if has-decorators?
+                       (let [supplier (reify Supplier
+                                        (get [_] (invoke-handler-sync handler async? resources data async-timeout-ms)))
+                             decorated (wrap-with-decorators supplier
+                                         {:circuit-breaker cb :retry r
+                                          :bulkhead bh :rate-limiter rl})]
+                         (.get decorated))
+                       ;; No policies at all — shouldn't happen, but return normally
+                       (invoke-handler-sync handler async? resources data async-timeout-ms)))
+                   (catch Exception e
+                     (assoc data :mycelium/resilience-error
+                            (classify-error cell-name e)))))]
+    (fn
+      ([resources data]
+       (invoke resources data))
+      ([resources data callback _error-callback]
+       (future (callback (invoke resources data)))
+       nil)))))
+
+;; ===== Validation =====
+
+(def ^:private valid-policy-keys
+  #{:timeout :retry :circuit-breaker :bulkhead :rate-limiter :async-timeout-ms})
+
+(defn validate-resilience!
+  "Validates the :resilience map in a workflow definition.
+   Each key must be a cell name in the cells map, each value a map of policy configs."
+  [resilience-map cells]
+  (let [cell-names (set (keys cells))]
+    (doseq [[cell-name policies] resilience-map]
+      (when-not (contains? cell-names cell-name)
+        (throw (ex-info (str "Resilience policy references cell " cell-name
+                             " which is not in :cells")
+                        {:cell-name cell-name :valid-cells cell-names})))
+      (when-not (map? policies)
+        (throw (ex-info (str "Resilience policies for " cell-name " must be a map")
+                        {:cell-name cell-name :policies policies})))
+      (let [unknown (set/difference (set (keys policies)) valid-policy-keys)]
+        (when (seq unknown)
+          (throw (ex-info (str "Unknown resilience policy keys for " cell-name ": " unknown)
+                          {:cell-name cell-name :unknown-keys unknown
+                           :valid-keys valid-policy-keys}))))
+      (when-let [timeout (:timeout policies)]
+        (when-not (and (:timeout-ms timeout) (pos? (:timeout-ms timeout)))
+          (throw (ex-info (str "Resilience :timeout for " cell-name
+                               " requires positive :timeout-ms")
+                          {:cell-name cell-name :timeout timeout}))))
+      (when-let [async-timeout (:async-timeout-ms policies)]
+        (when-not (and (integer? async-timeout) (pos? async-timeout))
+          (throw (ex-info (str "Resilience :async-timeout-ms for " cell-name
+                               " must be a positive integer")
+                          {:cell-name cell-name :async-timeout-ms async-timeout})))))))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -145,7 +145,10 @@
                              (get-in state->edge-targets
                                      [state-id (:current-state-id fsm-state)]))
                 data       (:data fsm-state)
-                error      (validate-output cell data transition)
+                ;; Skip output validation when resilience error is present
+                ;; (the handler was short-circuited by the resilience wrapper)
+                error      (when-not (:mycelium/resilience-error data)
+                             (validate-output cell data transition))
                 ;; Extract duration-ms from the latest Maestro trace segment
                 duration-ms (some-> (:trace fsm-state) last :duration-ms)
                 ;; Extract join sub-traces if present
@@ -160,12 +163,12 @@
             (if error
               (-> fsm-state
                   (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
-                  (update :data dissoc :mycelium/join-traces)
+                  (update :data dissoc :mycelium/join-traces :mycelium/params)
                   (assoc :current-state-id ::fsm/error)
                   (assoc-in [:data :mycelium/schema-error] error))
               (-> fsm-state
                   (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
-                  (update :data dissoc :mycelium/join-traces))))
+                  (update :data dissoc :mycelium/join-traces :mycelium/params))))
           fsm-state)))))
 
 (defn wrap-async-callback

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -3,9 +3,47 @@
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [mycelium.cell :as cell]
+            [mycelium.resilience :as resilience]
             [mycelium.schema :as schema]
             [mycelium.validation :as v]
             [maestro.core :as fsm]))
+
+;; ===== Cell reference normalization =====
+
+(defn- normalize-cell-ref
+  "Normalizes a cell reference to {:id cell-id, :params params-map-or-nil}.
+   Accepts either a keyword (bare cell-id) or a map with :id and optional :params."
+  [cell-name cell-ref]
+  (cond
+    (keyword? cell-ref)
+    {:id cell-ref :params nil}
+
+    (and (map? cell-ref) (:id cell-ref))
+    {:id (:id cell-ref) :params (:params cell-ref)}
+
+    (map? cell-ref)
+    (throw (ex-info (str "Cell " cell-name " map ref missing :id")
+                    {:cell-name cell-name :cell-ref cell-ref}))
+
+    :else
+    (throw (ex-info (str "Cell " cell-name " has invalid ref type: " (type cell-ref))
+                    {:cell-name cell-name :cell-ref cell-ref}))))
+
+(defn- cells->ids
+  "Extracts a {cell-name → cell-id} map from cells, normalizing map refs."
+  [cells]
+  (into {} (map (fn [[cell-name cell-ref]]
+                  [cell-name (:id (normalize-cell-ref cell-name cell-ref))]))
+        cells))
+
+(defn- cells->params
+  "Extracts a {cell-name → params} map from cells, only for cells with params."
+  [cells]
+  (into {} (keep (fn [[cell-name cell-ref]]
+                   (let [{:keys [params]} (normalize-cell-ref cell-name cell-ref)]
+                     (when params
+                       [cell-name params]))))
+        cells))
 
 ;; ===== State ID resolution =====
 
@@ -325,10 +363,12 @@
 ;; ===== Validation =====
 
 (defn- validate-cells-exist!
-  "Checks all cells referenced in :cells exist in the registry."
+  "Checks all cells referenced in :cells exist in the registry.
+   Accepts both bare keyword and map cell refs."
   [cells]
-  (doseq [[_name cell-id] cells]
-    (cell/get-cell! cell-id)))
+  (doseq [[cell-name cell-ref] cells]
+    (let [{:keys [id]} (normalize-cell-ref cell-name cell-ref)]
+      (cell/get-cell! id))))
 
 (defn- merge-default-dispatches
   "Merges default dispatches from cell specs into the workflow dispatches.
@@ -463,31 +503,33 @@
   [{:keys [cells edges dispatches joins input-schema pipeline] :as raw-workflow}]
   (let [{:keys [cells edges dispatches joins input-schema]} (expand-pipeline raw-workflow)]
     (validate-cells-exist! cells)
-    ;; Validate :input-schema well-formedness if present
-    (when input-schema
-      (v/validate-malli-schema! input-schema "input-schema"))
-    ;; Validate join definitions
-    (let [joins-map (or joins {})]
-      (when (seq joins-map)
-        (validate-join-defs! joins-map cells edges)
-        (validate-join-output-conflicts! joins-map cells))
-      ;; For edge-target and reachability validation, include join names as valid targets
-      (let [cell-names     (set (keys cells))
-            join-names     (set (keys joins-map))
-            ;; Members consumed by joins should not be in edges but are valid cells
-            join-members   (set (mapcat :cells (vals joins-map)))
-            ;; Non-member cell names = cells that appear in edges
-            edge-cell-names (set/difference cell-names join-members)
-            ;; Valid names for edge targets = non-member cells + join names
-            valid-names    (set/union edge-cell-names join-names)]
-        (v/validate-edge-targets! edges valid-names)
-        (v/validate-reachability! edges valid-names))
-      ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
-      (let [join-dispatches    (compute-join-dispatches joins-map edges)
-            effective-dispatches (merge join-dispatches
-                                        (merge-default-dispatches dispatches edges cells))]
-        (v/validate-dispatch-coverage! edges effective-dispatches))
-      (validate-schema-chain! edges cells joins-map))))
+    ;; Normalize to {name → cell-id} for all downstream validation
+    (let [cell-ids (cells->ids cells)]
+      ;; Validate :input-schema well-formedness if present
+      (when input-schema
+        (v/validate-malli-schema! input-schema "input-schema"))
+      ;; Validate :resilience policies if present
+      (when-let [resilience (:resilience raw-workflow)]
+        (resilience/validate-resilience! resilience cell-ids))
+      ;; Validate join definitions
+      (let [joins-map (or joins {})]
+        (when (seq joins-map)
+          (validate-join-defs! joins-map cell-ids edges)
+          (validate-join-output-conflicts! joins-map cell-ids))
+        ;; For edge-target and reachability validation, include join names as valid targets
+        (let [cell-names     (set (keys cell-ids))
+              join-names     (set (keys joins-map))
+              join-members   (set (mapcat :cells (vals joins-map)))
+              edge-cell-names (set/difference cell-names join-members)
+              valid-names    (set/union edge-cell-names join-names)]
+          (v/validate-edge-targets! edges valid-names)
+          (v/validate-reachability! edges valid-names))
+        ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
+        (let [join-dispatches    (compute-join-dispatches joins-map edges)
+              effective-dispatches (merge join-dispatches
+                                          (merge-default-dispatches dispatches edges cell-ids))]
+          (v/validate-dispatch-coverage! edges effective-dispatches))
+        (validate-schema-chain! edges cell-ids joins-map)))))
 
 ;; ===== Workflow-level interceptor matching =====
 
@@ -519,6 +561,16 @@
     (contains? (set (:cells scope)) cell-name)
 
     :else false))
+
+(defn- wrap-handler-with-params
+  "Wraps a cell handler to inject :mycelium/params into data before invocation.
+   Handles both sync (2-arity) and async (4-arity) handlers."
+  [handler params]
+  (fn
+    ([resources data]
+     (handler resources (assoc data :mycelium/params params)))
+    ([resources data callback error-callback]
+     (handler resources (assoc data :mycelium/params params) callback error-callback))))
 
 (defn- apply-pres [data pres]
   (reduce (fn [d pre-fn] (pre-fn d)) data pres))
@@ -597,25 +649,28 @@
    (let [{:keys [cells edges dispatches joins] :as workflow} (expand-pipeline raw-workflow)]
      ;; Validate
      (validate-workflow workflow)
-     (let [joins-map (or joins {})
+     (let [;; Normalize cells to {name → cell-id} for compilation
+           cell-ids (cells->ids cells)
+           cell-params (cells->params cells)
+           joins-map (or joins {})
          ;; Determine which cells are consumed by joins
          join-members (set (mapcat :cells (vals joins-map)))
          ;; Merge default dispatches from cell specs AND join default dispatches (filtered to edge keys)
          join-dispatches    (compute-join-dispatches joins-map edges)
          effective-dispatches (merge join-dispatches
-                                     (merge-default-dispatches dispatches edges cells))
+                                     (merge-default-dispatches dispatches edges cell-ids))
          ;; Build state->cell map for non-join-member cells
          state->cell (into {}
                            (keep (fn [[cell-name cell-id]]
                                    (when-not (contains? join-members cell-name)
                                      [(resolve-state-id cell-name)
                                       (cell/get-cell! cell-id)])))
-                           cells)
+                           cell-ids)
          ;; Build synthetic join cell specs for state->cell
          join-cell-specs (into {}
                                (map (fn [[join-name join-def]]
-                                      (let [handler   (build-join-handler join-name join-def cells)
-                                            in-schema (build-join-input-schema join-def cells)]
+                                      (let [handler   (build-join-handler join-name join-def cell-ids)
+                                            in-schema (build-join-input-schema join-def cell-ids)]
                                         [(resolve-state-id join-name)
                                          {:id       (keyword "mycelium.join" (name join-name))
                                           :handler  handler
@@ -626,9 +681,32 @@
          state->cell (merge state->cell join-cell-specs)
          ;; Pre-compile all Malli schemas so interceptors use compiled objects
          state->cell (schema/pre-compile-schemas state->cell)
+         ;; Apply params wrapping for parameterized cells
+         state->cell (reduce (fn [acc [cell-name params]]
+                               (let [state-id (resolve-state-id cell-name)]
+                                 (if-let [cell (get acc state-id)]
+                                   (assoc acc state-id
+                                          (update cell :handler wrap-handler-with-params params))
+                                   acc)))
+                             state->cell
+                             cell-params)
+         ;; Apply resilience policies
+         resilience-map (:resilience workflow)
+         state->cell (if (seq resilience-map)
+                       (reduce (fn [acc [cell-name policies]]
+                                 (let [state-id (resolve-state-id cell-name)]
+                                   (if-let [cell (get acc state-id)]
+                                     (assoc acc state-id
+                                            (update cell :handler
+                                                    resilience/wrap-handler cell-name policies
+                                                    {:async? (:async? cell)}))
+                                     acc)))
+                               state->cell
+                               resilience-map)
+                       state->cell)
          ;; Apply workflow-level interceptors (wraps cell handlers)
          wf-interceptors (:interceptors workflow)
-         state->cell (apply-workflow-interceptors state->cell cells wf-interceptors)
+         state->cell (apply-workflow-interceptors state->cell cell-ids wf-interceptors)
          ;; Build state->edge-targets for post-interceptor transition lookup
          state->edge-targets (build-edge-targets edges)
          ;; Build state->names for human-readable trace entries
@@ -636,7 +714,7 @@
                        (into {}
                              (map (fn [[cell-name _]]
                                     [(resolve-state-id cell-name) cell-name]))
-                             cells)
+                             cell-ids)
                        (into {}
                              (map (fn [[join-name _]]
                                     [(resolve-state-id join-name) join-name]))
@@ -655,7 +733,7 @@
                                               :dispatches (compile-edges edge-def dispatch-vec)}
                                              (when (:async? cell)
                                                {:async? true}))]))))
-                               cells)
+                               cell-ids)
          ;; Build FSM states for joins (use interceptor-wrapped handlers from state->cell)
          fsm-join-states (into {}
                                (map (fn [[join-name _join-def]]

--- a/test/mycelium/integration_test.clj
+++ b/test/mycelium/integration_test.clj
@@ -1,6 +1,7 @@
 (ns mycelium.integration-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [mycelium.cell :as cell]
+            [mycelium.core :as myc]
             [mycelium.workflow :as wf]
             [maestro.core :as fsm]
             [promesa.core :as p]))
@@ -482,3 +483,62 @@
       (doseq [entry trace]
         (is (not (contains? (:data entry) :mycelium/trace))
             (str "Trace entry for " (:cell entry) " should not contain :mycelium/trace in :data"))))))
+
+;; ===== Parameterized cells =====
+
+(deftest parameterized-cell-receives-params-test
+  (testing "Handler receives :mycelium/params from workflow params"
+    (defmethod cell/cell-spec :int/param-multiply [_]
+      {:id      :int/param-multiply
+       :handler (fn [_ data]
+                  (let [mult (get-in data [:mycelium/params :multiplier])]
+                    (assoc data :result (* (:x data) mult))))
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:result :int]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start {:id :int/param-multiply
+                                   :params {:multiplier 3}}}
+                   :edges {:start {:done :end}}
+                   :dispatches {:start [[:done (constantly true)]]}}
+                  {}
+                  {:x 10})]
+      (is (= 30 (:result result))))))
+
+(deftest parameterized-cell-same-handler-different-params-test
+  (testing "Same cell-id used twice with different params"
+    (defmethod cell/cell-spec :int/param-prefix [_]
+      {:id      :int/param-prefix
+       :handler (fn [_ data]
+                  (let [prefix (get-in data [:mycelium/params :prefix])
+                        k      (get-in data [:mycelium/params :output-key])]
+                    (assoc data k (str prefix "-" (:value data)))))
+       :schema  {:input  [:map [:value :string]]
+                 :output [:map]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start  {:id :int/param-prefix
+                                    :params {:prefix "hello" :output-key :greeting}}
+                           :step-b {:id :int/param-prefix
+                                    :params {:prefix "goodbye" :output-key :farewell}}}
+                   :pipeline [:start :step-b]}
+                  {}
+                  {:value "world"})]
+      (is (= "hello-world" (:greeting result)))
+      (is (= "goodbye-world" (:farewell result))))))
+
+(deftest parameterized-cell-params-not-in-output-test
+  (testing ":mycelium/params is cleaned up from final result"
+    (defmethod cell/cell-spec :int/param-simple [_]
+      {:id      :int/param-simple
+       :handler (fn [_ data] (assoc data :done true))
+       :schema  {:input [:map] :output [:map [:done :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start {:id :int/param-simple
+                                   :params {:mode "fast"}}}
+                   :edges {:start :end}}
+                  {}
+                  {})]
+      (is (true? (:done result)))
+      (is (not (contains? result :mycelium/params))))))

--- a/test/mycelium/manifest_test.clj
+++ b/test/mycelium/manifest_test.clj
@@ -389,6 +389,81 @@
       (is (thrown-with-msg? Exception #"at least 1"
             (manifest/validate-manifest m))))))
 
+;; ===== Parameterized cells in manifest =====
+
+(deftest manifest-parameterized-cell-validates-test
+  (testing "Manifest with :params on a cell def passes validation"
+    (let [m {:id :test/param-wf
+             :cells {:start {:id       :test/pm-cell
+                              :schema   {:input [:map [:x :int]] :output [:map [:y :int]]}
+                              :params   {:multiplier 3}
+                              :on-error nil}}
+             :edges {:start :end}}]
+      (is (some? (manifest/validate-manifest m))))))
+
+(deftest manifest-parameterized-to-workflow-test
+  (testing "manifest->workflow passes params through to workflow cells map"
+    (let [m {:id :test/param-wf2
+             :cells {:start {:id       :test/pm-cell2
+                              :schema   {:input [:map [:x :int]] :output [:map [:y :int]]}
+                              :params   {:mode "fast"}
+                              :on-error nil}}
+             :edges {:start :end}}
+          wf-def (manifest/manifest->workflow m)
+          cell-ref (get-in wf-def [:cells :start])]
+      (is (map? cell-ref))
+      (is (= :test/pm-cell2 (:id cell-ref)))
+      (is (= {:mode "fast"} (:params cell-ref))))))
+
+(deftest manifest-parameterized-pipeline-e2e-test
+  (testing "Pipeline manifest with same cell-id, different params, runs correctly"
+    (defmethod cell/cell-spec :test/pm-adder [_]
+      {:id      :test/pm-adder
+       :handler (fn [_ data]
+                  (let [amount (get-in data [:mycelium/params :amount])
+                        k      (get-in data [:mycelium/params :output-key])]
+                    (assoc data k (+ (:x data) amount))))
+       :schema  {:input [:map [:x :int]] :output [:map]}})
+
+    (let [m {:id :test/param-pipeline
+             :pipeline [:start :step-b]
+             :cells {:start  {:id       :test/pm-adder
+                                :schema   :inherit
+                                :params   {:amount 10 :output-key :first}
+                                :on-error nil}
+                     :step-b {:id       :test/pm-adder
+                                :schema   :inherit
+                                :params   {:amount 100 :output-key :second}
+                                :on-error nil}}}
+          validated (manifest/validate-manifest m)
+          wf-def   (manifest/manifest->workflow validated)
+          result   (myc/run-workflow wf-def {} {:x 5})]
+      (is (= 15  (:first result)))
+      (is (= 105 (:second result))))))
+
+;; ===== Resilience in manifest =====
+
+(deftest manifest-resilience-validates-test
+  (testing "Manifest with :resilience passes validation"
+    (let [m {:id :test/res-wf
+             :cells {:start {:id       :test/res-cell
+                              :schema   {:input [:map [:x :int]] :output [:map [:y :int]]}
+                              :on-error nil}}
+             :edges {:start :end}
+             :resilience {:start {:timeout {:timeout-ms 5000}}}}]
+      (is (some? (manifest/validate-manifest m))))))
+
+(deftest manifest-resilience-to-workflow-test
+  (testing "manifest->workflow passes :resilience through"
+    (let [m {:id :test/res-wf2
+             :cells {:start {:id       :test/res-cell2
+                              :schema   {:input [:map [:x :int]] :output [:map [:y :int]]}
+                              :on-error nil}}
+             :edges {:start :end}
+             :resilience {:start {:retry {:max-attempts 3}}}}
+          wf-def (manifest/manifest->workflow m)]
+      (is (= {:start {:retry {:max-attempts 3}}} (:resilience wf-def))))))
+
 (deftest pipeline-e2e-run-test
   (testing "Pipeline manifest compiles and runs end-to-end"
     (defmethod cell/cell-spec :test/pipe-double [_]

--- a/test/mycelium/resilience_test.clj
+++ b/test/mycelium/resilience_test.clj
@@ -1,0 +1,403 @@
+(ns mycelium.resilience-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.workflow :as wf]
+            [maestro.core :as fsm]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== Round 1: Timeout =====
+
+(deftest timeout-triggers-on-slow-cell-test
+  (testing "Slow handler exceeding timeout produces :mycelium/resilience-error"
+    (defmethod cell/cell-spec :res/slow [_]
+      {:id      :res/slow
+       :handler (fn [_ data]
+                  (Thread/sleep 200)
+                  (assoc data :result "done"))
+       :schema  {:input [:map [:x :int]]
+                 :output {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+    (defmethod cell/cell-spec :res/handle-timeout [_]
+      {:id      :res/handle-timeout
+       :handler (fn [_ data] (assoc data :handled true))
+       :schema  {:input [:map] :output [:map [:handled :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start   :res/slow
+                           :timeout :res/handle-timeout}
+                   :edges {:start   {:done :end, :timeout :timeout}
+                           :timeout :end}
+                   :dispatches {:start [[:timeout (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done    (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   :resilience {:start {:timeout {:timeout-ms 50}}}}
+                  {}
+                  {:x 1})]
+      (is (some? (:mycelium/resilience-error result)))
+      (is (= :timeout (get-in result [:mycelium/resilience-error :type]))))))
+
+(deftest timeout-does-not-trigger-on-fast-cell-test
+  (testing "Fast handler within timeout completes normally"
+    (defmethod cell/cell-spec :res/fast [_]
+      {:id      :res/fast
+       :handler (fn [_ data] (assoc data :result "fast"))
+       :schema  {:input  [:map [:x :int]]
+                 :output {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start :res/fast}
+                   :edges {:start {:done :end, :timeout :error}}
+                   :dispatches {:start [[:timeout (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done    (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   :resilience {:start {:timeout {:timeout-ms 5000}}}}
+                  {}
+                  {:x 1})]
+      (is (= "fast" (:result result)))
+      (is (nil? (:mycelium/resilience-error result))))))
+
+(deftest timeout-preserves-upstream-data-test
+  (testing "On timeout, upstream data keys are preserved"
+    (defmethod cell/cell-spec :res/slow-preserve [_]
+      {:id      :res/slow-preserve
+       :handler (fn [_ data]
+                  (Thread/sleep 200)
+                  (assoc data :result "done"))
+       :schema  {:input  [:map [:x :int]]
+                 :output {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+    (defmethod cell/cell-spec :res/handle-timeout2 [_]
+      {:id      :res/handle-timeout2
+       :handler (fn [_ data] (assoc data :handled true))
+       :schema  {:input [:map] :output [:map [:handled :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start   :res/slow-preserve
+                           :timeout :res/handle-timeout2}
+                   :edges {:start   {:done :end, :timeout :timeout}
+                           :timeout :end}
+                   :dispatches {:start [[:timeout (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done    (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   :resilience {:start {:timeout {:timeout-ms 50}}}}
+                  {}
+                  {:x 42})]
+      (is (= 42 (:x result))))))
+
+;; ===== Round 2: Retry =====
+
+(deftest retry-recovers-from-transient-failure-test
+  (testing "Retry recovers after transient failures"
+    (let [call-count (atom 0)]
+      (defmethod cell/cell-spec :res/flaky [_]
+        {:id      :res/flaky
+         :handler (fn [_ data]
+                    (swap! call-count inc)
+                    (if (< @call-count 3)
+                      (throw (ex-info "transient failure" {}))
+                      (assoc data :result "recovered")))
+         :schema  {:input [:map [:x :int]]
+                   :output [:map [:result :string]]}})
+
+      (let [result (myc/run-workflow
+                    {:cells {:start :res/flaky}
+                     :edges {:start :end}
+                     :resilience {:start {:retry {:max-attempts 5 :wait-ms 10}}}}
+                    {}
+                    {:x 1})]
+        (is (= "recovered" (:result result)))
+        (is (= 3 @call-count))))))
+
+(deftest retry-exhausted-test
+  (testing "When retries exhausted, resilience error is produced"
+    (defmethod cell/cell-spec :res/always-fail [_]
+      {:id      :res/always-fail
+       :handler (fn [_ _] (throw (ex-info "permanent failure" {})))
+       :schema  {:input [:map [:x :int]]
+                 :output [:map]}})
+    (defmethod cell/cell-spec :res/handle-fail [_]
+      {:id      :res/handle-fail
+       :handler (fn [_ data] (assoc data :handled true))
+       :schema  {:input [:map] :output [:map [:handled :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start   :res/always-fail
+                           :fallback :res/handle-fail}
+                   :edges {:start   {:done :end, :failed :fallback}
+                           :fallback :end}
+                   :dispatches {:start [[:failed (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done   (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   :resilience {:start {:retry {:max-attempts 2 :wait-ms 10}}}}
+                  {}
+                  {:x 1})]
+      (is (true? (:handled result)))
+      (is (some? (:mycelium/resilience-error result))))))
+
+;; ===== Round 3: Circuit breaker =====
+
+(deftest circuit-breaker-opens-after-failures-test
+  (testing "Circuit breaker opens after threshold failures"
+    (let [call-count (atom 0)]
+      (defmethod cell/cell-spec :res/cb-fail [_]
+        {:id      :res/cb-fail
+         :handler (fn [_ data]
+                    (swap! call-count inc)
+                    (throw (ex-info "fail" {})))
+         :schema  {:input [:map [:x :int]]
+                   :output [:map]}})
+      (defmethod cell/cell-spec :res/cb-fallback [_]
+        {:id      :res/cb-fallback
+         :handler (fn [_ data] (assoc data :fallback true))
+         :schema  {:input [:map] :output [:map [:fallback :boolean]]}})
+
+      ;; Pre-compile once so the CB instance is shared across runs
+      (let [compiled (myc/pre-compile
+                      {:cells {:start    :res/cb-fail
+                               :fallback :res/cb-fallback}
+                       :edges {:start   {:done :end, :failed :fallback}
+                               :fallback :end}
+                       :dispatches {:start [[:failed (fn [d] (some? (:mycelium/resilience-error d)))]
+                                            [:done   (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                       :resilience {:start {:circuit-breaker {:failure-rate 50
+                                                             :minimum-calls 5
+                                                             :sliding-window-size 10
+                                                             :wait-in-open-ms 60000}}}})]
+        ;; First 5+ runs: handler throws, cb records failures
+        (dotimes [_ 6]
+          (myc/run-compiled compiled {} {:x 1}))
+        (let [calls-before @call-count]
+          ;; Now circuit should be OPEN — handler should NOT be called
+          (let [result (myc/run-compiled compiled {} {:x 1})]
+            (is (some? (:mycelium/resilience-error result)))
+            (is (= :circuit-open (get-in result [:mycelium/resilience-error :type])))
+            ;; Handler was not invoked — call count unchanged
+            (is (= calls-before @call-count))))))))
+
+;; ===== Round 4: Bulkhead =====
+
+(deftest bulkhead-limits-concurrency-test
+  (testing "Bulkhead rejects calls exceeding max concurrency"
+    (defmethod cell/cell-spec :res/bh-slow [_]
+      {:id      :res/bh-slow
+       :handler (fn [_ data]
+                  (Thread/sleep 200)
+                  (assoc data :result "ok"))
+       :schema  {:input [:map [:x :int]]
+                 :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :res/bh-fallback [_]
+      {:id      :res/bh-fallback
+       :handler (fn [_ data] (assoc data :rejected true))
+       :schema  {:input [:map] :output [:map [:rejected :boolean]]}})
+
+    (let [compiled (myc/pre-compile
+                    {:cells {:start    :res/bh-slow
+                             :fallback :res/bh-fallback}
+                     :edges {:start    {:done :end, :rejected :fallback}
+                             :fallback :end}
+                     :dispatches {:start [[:rejected (fn [d] (some? (:mycelium/resilience-error d)))]
+                                          [:done     (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                     :resilience {:start {:bulkhead {:max-concurrent 1 :max-wait-ms 0}}}})
+          ;; Launch 3 concurrent calls — only 1 should proceed
+          results (let [futures (doall (repeatedly 3 #(future (myc/run-compiled compiled {} {:x 1}))))]
+                    (mapv deref futures))
+          rejected (filter #(some? (:mycelium/resilience-error %)) results)
+          succeeded (filter #(= "ok" (:result %)) results)]
+      (is (>= (count rejected) 1) "At least one call should be rejected")
+      (is (>= (count succeeded) 1) "At least one call should succeed"))))
+
+;; ===== Round 5: Composition & interaction =====
+
+(deftest composed-timeout-and-retry-test
+  (testing "Retry recovers within timeout window"
+    (let [call-count (atom 0)]
+      (defmethod cell/cell-spec :res/retry-within-timeout [_]
+        {:id      :res/retry-within-timeout
+         :handler (fn [_ data]
+                    (swap! call-count inc)
+                    (if (< @call-count 3)
+                      (throw (ex-info "transient" {}))
+                      (assoc data :result "ok")))
+         :schema  {:input [:map [:x :int]]
+                   :output [:map [:result :string]]}})
+
+      (let [result (myc/run-workflow
+                    {:cells {:start :res/retry-within-timeout}
+                     :edges {:start :end}
+                     :resilience {:start {:timeout {:timeout-ms 5000}
+                                          :retry   {:max-attempts 5 :wait-ms 10}}}}
+                    {}
+                    {:x 1})]
+        (is (= "ok" (:result result)))
+        (is (= 3 @call-count))))))
+
+(deftest parameterized-cell-with-resilience-test
+  (testing "Parameterized cells work with resilience policies"
+    (let [call-count (atom 0)]
+      (defmethod cell/cell-spec :res/param-retry [_]
+        {:id      :res/param-retry
+         :handler (fn [_ data]
+                    (swap! call-count inc)
+                    (let [mult (get-in data [:mycelium/params :multiplier])]
+                      (if (< @call-count 2)
+                        (throw (ex-info "transient" {}))
+                        (assoc data :result (* (:x data) mult)))))
+         :schema  {:input [:map [:x :int]]
+                   :output [:map [:result :int]]}})
+
+      (let [result (myc/run-workflow
+                    {:cells {:start {:id :res/param-retry
+                                     :params {:multiplier 7}}}
+                     :edges {:start :end}
+                     :resilience {:start {:retry {:max-attempts 3 :wait-ms 10}}}}
+                    {}
+                    {:x 6})]
+        (is (= 42 (:result result)))))))
+
+(deftest resilience-trace-records-error-test
+  (testing "Trace entry records resilience timeout"
+    (defmethod cell/cell-spec :res/trace-slow [_]
+      {:id      :res/trace-slow
+       :handler (fn [_ data]
+                  (Thread/sleep 200)
+                  (assoc data :result "done"))
+       :schema  {:input [:map [:x :int]]
+                 :output [:map]}})
+    (defmethod cell/cell-spec :res/trace-fallback [_]
+      {:id      :res/trace-fallback
+       :handler (fn [_ data] (assoc data :handled true))
+       :schema  {:input [:map] :output [:map [:handled :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start    :res/trace-slow
+                           :fallback :res/trace-fallback}
+                   :edges {:start    {:done :end, :timeout :fallback}
+                           :fallback :end}
+                   :dispatches {:start [[:timeout (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done    (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   :resilience {:start {:timeout {:timeout-ms 50}}}}
+                  {}
+                  {:x 1})
+          trace (:mycelium/trace result)
+          start-entry (first trace)]
+      (is (= :timeout (:transition start-entry))))))
+
+;; ===== Round 6: Async cells =====
+
+(deftest async-cell-with-retry-test
+  (testing "Async cell handler works with retry resilience policy"
+    (let [call-count (atom 0)]
+      (defmethod cell/cell-spec :res/async-flaky [_]
+        {:id      :res/async-flaky
+         :async?  true
+         :handler (fn [_ data callback error-callback]
+                    (swap! call-count inc)
+                    (if (< @call-count 3)
+                      (error-callback (ex-info "transient async failure" {}))
+                      (callback (assoc data :result "async-recovered"))))
+         :schema  {:input [:map [:x :int]]
+                   :output [:map [:result :string]]}})
+
+      (let [result (myc/run-workflow
+                    {:cells {:start :res/async-flaky}
+                     :edges {:start :end}
+                     :resilience {:start {:retry {:max-attempts 5 :wait-ms 10}}}}
+                    {}
+                    {:x 1})]
+        (is (= "async-recovered" (:result result)))
+        (is (= 3 @call-count))))))
+
+(deftest async-cell-with-timeout-test
+  (testing "Async cell that takes too long gets timed out"
+    (defmethod cell/cell-spec :res/async-slow [_]
+      {:id      :res/async-slow
+       :async?  true
+       :handler (fn [_ data callback _error-callback]
+                  (future
+                    (Thread/sleep 500)
+                    (callback (assoc data :result "done"))))
+       :schema  {:input [:map [:x :int]]
+                 :output {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+    (defmethod cell/cell-spec :res/async-timeout-handler [_]
+      {:id      :res/async-timeout-handler
+       :handler (fn [_ data] (assoc data :handled true))
+       :schema  {:input [:map] :output [:map [:handled :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start   :res/async-slow
+                           :timeout :res/async-timeout-handler}
+                   :edges {:start   {:done :end, :timeout :timeout}
+                           :timeout :end}
+                   :dispatches {:start [[:timeout (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done    (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   :resilience {:start {:timeout {:timeout-ms 50}}}}
+                  {}
+                  {:x 1})]
+      (is (some? (:mycelium/resilience-error result)))
+      (is (= :timeout (get-in result [:mycelium/resilience-error :type]))))))
+
+(deftest async-timeout-ms-configurable-test
+  (testing "Custom :async-timeout-ms controls how long resilience waits for async handler"
+    (defmethod cell/cell-spec :res/async-hang [_]
+      {:id      :res/async-hang
+       :async?  true
+       :handler (fn [_ data callback _error-callback]
+                  ;; Never calls back within 200ms
+                  (future
+                    (Thread/sleep 500)
+                    (callback (assoc data :result "late"))))
+       :schema  {:input [:map [:x :int]]
+                 :output {:done [:map [:result :string]]
+                          :failed [:map [:mycelium/resilience-error :map]]}}})
+    (defmethod cell/cell-spec :res/async-hang-fallback [_]
+      {:id      :res/async-hang-fallback
+       :handler (fn [_ data] (assoc data :handled true))
+       :schema  {:input [:map] :output [:map [:handled :boolean]]}})
+
+    (let [result (myc/run-workflow
+                  {:cells {:start    :res/async-hang
+                           :fallback :res/async-hang-fallback}
+                   :edges {:start    {:done :end, :failed :fallback}
+                           :fallback :end}
+                   :dispatches {:start [[:failed (fn [d] (some? (:mycelium/resilience-error d)))]
+                                        [:done   (fn [d] (nil? (:mycelium/resilience-error d)))]]}
+                   ;; No resilience4j timeout — only retry. The async-timeout-ms
+                   ;; controls the inner promise deref timeout.
+                   :resilience {:start {:async-timeout-ms 100
+                                        :retry {:max-attempts 1 :wait-ms 10}}}}
+                  {}
+                  {:x 1})]
+      (is (some? (:mycelium/resilience-error result)))
+      (is (true? (:handled result))))))
+
+;; ===== Validation =====
+
+(deftest resilience-invalid-cell-throws-test
+  (testing "Resilience policy referencing non-existent cell throws"
+    (defmethod cell/cell-spec :res/valid [_]
+      {:id :res/valid :handler (fn [_ d] d) :schema {:input [:map] :output [:map]}})
+    (is (thrown-with-msg? Exception #"not in :cells"
+          (wf/compile-workflow
+           {:cells {:start :res/valid}
+            :edges {:start :end}
+            :resilience {:nonexistent {:timeout {:timeout-ms 100}}}})))))
+
+(deftest resilience-unknown-policy-key-throws-test
+  (testing "Unknown resilience policy key throws with helpful message"
+    (defmethod cell/cell-spec :res/valid3 [_]
+      {:id :res/valid3 :handler (fn [_ d] d) :schema {:input [:map] :output [:map]}})
+    (is (thrown-with-msg? Exception #"Unknown resilience policy keys"
+          (wf/compile-workflow
+           {:cells {:start :res/valid3}
+            :edges {:start :end}
+            :resilience {:start {:bogus {:foo 1}}}})))))
+
+(deftest resilience-invalid-timeout-ms-throws-test
+  (testing "Negative timeout-ms throws"
+    (defmethod cell/cell-spec :res/valid2 [_]
+      {:id :res/valid2 :handler (fn [_ d] d) :schema {:input [:map] :output [:map]}})
+    (is (thrown-with-msg? Exception #"timeout-ms"
+          (wf/compile-workflow
+           {:cells {:start :res/valid2}
+            :edges {:start :end}
+            :resilience {:start {:timeout {:timeout-ms -1}}}})))))

--- a/test/mycelium/workflow_test.clj
+++ b/test/mycelium/workflow_test.clj
@@ -517,3 +517,41 @@
            {:cells {:start :test/cell-a}
             :pipeline [:start :nonexistent]})))))
 
+;; ===== Parameterized cells =====
+
+(deftest parameterized-cell-compiles-test
+  (testing "Workflow with parameterized cell (map form) compiles"
+    (register-cells!)
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start {:id :test/cell-a :params {:mode "fast"}}}
+                     :edges {:start :end}})]
+      (is (some? compiled)))))
+
+(deftest parameterized-cell-backward-compat-test
+  (testing "Bare keyword cell refs still compile (regression guard)"
+    (register-cells!)
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start :test/cell-a}
+                     :edges {:start :end}})]
+      (is (some? compiled)))))
+
+(deftest parameterized-cell-missing-id-throws-test
+  (testing "Map cell ref without :id throws"
+    (register-cells!)
+    (is (thrown-with-msg? Exception #":id"
+          (wf/compile-workflow
+           {:cells {:start {:params {:x 1}}}
+            :edges {:start :end}})))))
+
+(deftest parameterized-cell-schema-chain-test
+  (testing "Parameterized cells participate in schema chain validation"
+    (register-cells!)
+    (let [compiled (wf/compile-workflow
+                    {:cells {:start  {:id :test/cell-a :params {:mode "fast"}}
+                             :step-b :test/cell-b}
+                     :edges {:start  {:success :step-b}
+                             :step-b {:done :end}}
+                     :dispatches {:start  [[:success (constantly true)]]
+                                  :step-b [[:done (constantly true)]]}})]
+      (is (some? compiled)))))
+


### PR DESCRIPTION
Parameterized cells allow reusing the same handler with different config by passing {:id :cell/id :params {:key val}} in the :cells map. Params are injected as :mycelium/params in data and cleaned up after each step.

Resilience policies wrap cell handlers with resilience4j via the :resilience key: timeout, retry, circuit-breaker, bulkhead, and rate-limiter. Triggered policies return :mycelium/resilience-error in data for dispatch-based routing to fallback cells. Supports both sync and async handlers. :async-timeout-ms configures the promise wait time for async cells (default 30s).

299 tests, 608 assertions, 0 failures.