### PR TITLE
Default transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ Edges map transition labels to targets. Dispatch predicates examine the data to 
 
 Handlers compute data; dispatch predicates decide the route. This keeps business logic decoupled from graph navigation.
 
+### Default Transitions
+
+Use `:default` as an edge label for a catch-all fallback. If no other dispatch predicate matches, the `:default` edge is taken automatically — no dispatch predicate needed:
+
+```clojure
+(myc/run-workflow
+  {:cells {:start :check/threshold
+           :big   :process/big-values
+           :err   :process/error-handler}
+   :edges {:start {:high :big, :default :err}
+           :big   {:done :end}
+           :err   {:done :end}}
+   :dispatches {:start [[:high (fn [data] (> (:value data) 10))]]
+                :big   [[:done (constantly true)]]
+                :err   [[:done (constantly true)]]}}
+  {} {:value 3})
+;; value <= 10, :high predicate fails → :default catches → routes to :err
+```
+
+This is especially useful as a safety net for agent-generated routing logic. `:default` must not be the only edge — if all paths lead to the same target, use an unconditional keyword edge instead.
+
 ### Per-Transition Output Schemas
 
 Cells with multiple outgoing edges can declare different output schemas for each transition:

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -1,0 +1,223 @@
+# Feature Proposals
+
+Evaluated ideas inspired by Harel statecharts, ranked by combined value and feasibility. History states (#1 from the original ranking) has been implemented as halt/resume — see the [quick reference](quick-reference.md#halt--resume-human-in-the-loop).
+
+## ~~1. Default Transitions~~ (Implemented)
+
+**Value: Medium-High | Feasibility: High** — **DONE**
+
+Currently if no dispatch predicate matches, Maestro throws — catastrophic for agent-generated routing logic. A `:default` edge label that auto-generates a catch-all `(constantly true)` as the last dispatch predicate would be ~10 lines in `compile-edges`. Every complex workflow benefits from `{:success :next, :default :error-handler}` as a safety net.
+
+### Proposed API
+
+```clojure
+{:edges {:start {:success :process, :default :error-handler}
+         :process {:done :end, :default :error-handler}
+         :error-handler :end}
+ :dispatches {:start [[:success (fn [d] (:valid d))]]
+              ;; :default auto-generates (constantly true) as last predicate
+              }}
+```
+
+### Implementation
+
+- In `compile-edges` (workflow.clj), detect `:default` edge labels
+- Auto-append `[:default (constantly true)]` as the final dispatch predicate for cells that have a `:default` edge
+- Validate that `:default` is never the *only* edge (would mean unconditional — just use a bare keyword edge instead)
+- Schema chain validation: the `:default` path inherits only the cell's input keys (no output guarantees since the handler may have partially failed)
+
+### Scope
+
+~30-50 lines across `workflow.clj` + tests.
+
+---
+
+## 2. Temporal Logic / Global Constraints
+
+**Value: High | Feasibility: Medium**
+
+"If a file is flagged as missing metadata, it must pass through a tagging cell before `:end`" — the kind of invariant that catches agent mistakes at compile time rather than runtime. `dev/enumerate-paths` already walks all paths; a constraint checker would layer on top.
+
+### Proposed Constraint Language
+
+```clojure
+{:constraints [{:type :must-follow
+                :if   :flag-missing     ;; if this cell runs...
+                :then :apply-tags}      ;; ...this cell must appear later on the same path
+
+               {:type :must-precede
+                :cell :validate         ;; this cell...
+                :before :process}       ;; ...must appear before this on every path containing it
+
+               {:type :never-together
+                :cells [:manual-review :auto-approve]}  ;; mutually exclusive paths
+
+               {:type :always-reachable
+                :cell :error-handler}]} ;; must be reachable from every non-terminal cell
+```
+
+### Implementation
+
+1. Enumerate all paths using existing `dev/enumerate-paths`
+2. For each constraint type, check the relevant property across all paths
+3. Report violations at compile time with the specific path that violates
+4. Add constraints to manifest validation
+
+### Constraint Types
+
+| Type | Meaning |
+|------|---------|
+| `:must-follow` | If cell A appears on a path, cell B must appear later on that path |
+| `:must-precede` | Cell A must appear before cell B on every path containing B |
+| `:never-together` | Cells A and B never appear on the same path |
+| `:always-reachable` | Cell must be reachable from every non-terminal cell |
+
+### Scope
+
+~150-250 lines in a new `constraints.clj` or added to `dev.clj`. The key design risk is making the language expressive enough to be useful but simple enough that agents can generate constraints, not just satisfy them.
+
+---
+
+## 3. Graph-Level Timeout Transitions
+
+**Value: High | Feasibility: High**
+
+Harel emphasizes time bounds as a property of the state itself, not the internal activity. Currently an agent writing an async cell must bake timeout logic into the handler. Moving timeouts to the edge definition lets the LLM write pure domain logic while the framework handles failure routing.
+
+The pattern already exists — `invoke-cell-handler` in `workflow.clj` wraps async cells with promise-based timeout logic inside joins (30s default). This just needs to be lifted to the general handler invocation path.
+
+### Proposed API
+
+```clojure
+{:cells {:fetch-tags :mp3/parse-id3
+         :render     :ui/render-tags
+         :fallback   :ui/show-error}
+ :edges {:fetch-tags {:done :render, :timeout :fallback}
+         :render     :end
+         :fallback   :end}
+ :dispatches {:fetch-tags [[:done (constantly true)]]}
+ :timeouts {:fetch-tags 5000}}  ;; ms
+```
+
+When `:fetch-tags` exceeds 5000ms, the framework injects `:mycelium/timeout true` into data and routes to the `:timeout` edge target. The handler stays pure:
+
+```clojure
+(fn [resources data]
+  (assoc data :tags (parse-id3 (:path data))))
+```
+
+### Implementation
+
+1. Add optional `:timeouts` map to workflow definition (cell-name -> ms)
+2. In `compile-workflow`, wrap handlers of timed cells with promise-race (reuse join timeout pattern)
+3. On timeout, inject `:mycelium/timeout true` into data; dispatch predicates route naturally
+4. Schema chain validation: timeout edges need valid targets
+5. Validate timeout values are positive integers
+
+### Interaction with Resilience Policies
+
+This is distinct from resilience4j `:timeout` policies (which wrap the handler with a resilience4j `TimeLimiter`). Graph-level timeouts are about **routing** — they redirect to an alternative cell. Resilience timeouts are about **error handling** — they produce `:mycelium/resilience-error`. Both can coexist: resilience timeout catches within the cell, graph timeout routes around it.
+
+### Scope
+
+~100-150 lines. Needs schema chain awareness and validation updates.
+
+---
+
+## 4. Zooming / Depth for LLM Context Management
+
+**Value: Medium | Feasibility: High**
+
+The existing `cell-brief` and `orchestrate` module scope context per-cell well. What's missing is a "region brief" — context for a subgraph cluster rather than a single cell. For example: "here are the 3 cells in the metadata-fixing region, their schemas, and how they connect to each other."
+
+### Proposed API
+
+```clojure
+;; Workflow definition adds optional :regions
+{:regions {:auth       [:parse-request :validate-session]
+           :data-fetch [:fetch-profile :fetch-orders]
+           :rendering  [:render-summary :render-error]}}
+
+;; Generate a brief for a region
+(orch/region-brief manifest :auth)
+;; => {:cells [{:id :auth/parse, :schema {...}}, {:id :auth/validate, :schema {...}}]
+;;     :internal-edges {:parse-request {:success :validate-session}}
+;;     :entry-points [:parse-request]
+;;     :exit-points [{:cell :validate-session, :transitions {:authorized :_exit, :unauthorized :_exit}}]
+;;     :prompt "## Region: auth\n..."}
+```
+
+### Implementation
+
+- Add `:regions` to workflow definition (optional, informational grouping)
+- `orch/region-brief` generates a scoped brief showing cells, their schemas, internal edges, and boundary connections
+- No runtime behavior change — purely a tooling/orchestration enhancement
+- Validate that region cells exist and regions don't overlap
+
+### Scope
+
+~100-150 lines in `orchestrate.clj` + tests. This is an incremental addition to existing tooling.
+
+---
+
+## 5. Overlapping States (Shared Error Handling)
+
+**Value: Medium | Feasibility: Medium**
+
+The gap: "if ANY cell in this set fails, route to this handler" without wiring `:on-error` individually. Between fragments, interceptors, and the existing `:on-error` manifest field, most use cases are covered. This proposal targets the remaining gap.
+
+### Proposed API
+
+```clojure
+{:error-groups {:data-pipeline {:cells [:fetch :transform :validate]
+                                 :on-error :pipeline-error-handler}
+                :auth          {:cells [:parse :check-session]
+                                 :on-error :auth-error-handler}}}
+```
+
+### Implementation
+
+- At compile time, for each cell in an error group, inject a catch-all error transition to the group's error handler
+- This is syntactic sugar over per-cell `:on-error` — it expands to individual error edges
+- Validate that error handler cells exist and groups don't overlap
+- Schema chain: error handler inputs should be satisfied by any cell in the group (union of possible states)
+
+### Why It's Lower Priority
+
+- Fragments already provide reusable subgraph extraction with shared error routing
+- Workflow-level interceptors apply cross-cutting logic by scope
+- The `:on-error` manifest field handles individual cells
+- The remaining unaddressed cases are rare enough that explicit wiring is acceptable
+
+### Scope
+
+~80-120 lines. Mostly compile-time expansion in `workflow.clj`.
+
+---
+
+## 6. Edge Actions (Instantaneous Transitions)
+
+**Value: Low | Feasibility: High**
+
+Per-edge data transformations that run between cells without being full cells themselves.
+
+### Why It's Not Recommended
+
+Interceptors already fill this role. Workflow-level interceptors with `:pre`/`:post` can transform data at cell boundaries with scope matching. The only gap is per-edge (not per-cell) actions, but this conflicts with Mycelium's core philosophy: every data transformation should be explicit and schema-validated. A 3-line cell to strip whitespace is better than an inline edge action that bypasses the contract system.
+
+**Recommendation**: Document the interceptor pattern as the solution. Don't add edge actions.
+
+---
+
+## Implementation Priority
+
+| Priority | Feature | Effort | Dependencies |
+|----------|---------|--------|--------------|
+| Done | Default transitions | Small | None |
+| Soon | Global constraints | Medium | `enumerate-paths` (exists) |
+| Planned | Graph-level timeouts | Medium | None (reuses join timeout pattern) |
+| Later | Region briefs | Small | None |
+| Deferred | Error groups | Small | None |
+| Skip | Edge actions | - | Covered by interceptors |
+
+**Recommended sequence**: Default transitions first (quick win, pairs well with halt/resume for safety), then global constraints (highest architectural value), then graph-level timeouts.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -135,6 +135,8 @@ Use `:default` as an edge label for a catch-all fallback when no other dispatch 
 
 - `:default` must not be the only edge (use an unconditional keyword edge instead)
 - You can provide an explicit `:default` predicate in `:dispatches` to override the auto-generated one
+- `:default` is always evaluated last, even if listed first in `:dispatches`
+- Works with join nodes — add `:default` alongside `:done`/`:failure` edges
 - Trace entries record `:default` as the transition label
 
 ## Join Nodes (Fork-Join)

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -120,6 +120,23 @@ Edges map transition labels to targets. Dispatch predicates examine data to pick
 
 Handlers compute data; dispatch predicates decide the route.
 
+### Default Transitions
+
+Use `:default` as an edge label for a catch-all fallback when no other dispatch predicate matches:
+
+```clojure
+{:cells {:start :check/validate, :ok :process/run, :err :process/error}
+ :edges {:start {:success :ok, :default :err}
+         :ok :end, :err :end}
+ :dispatches {:start [[:success (fn [d] (:valid d))]]}}
+;; :default auto-generates (constantly true) as the last predicate
+;; No need to add [:default ...] to :dispatches
+```
+
+- `:default` must not be the only edge (use an unconditional keyword edge instead)
+- You can provide an explicit `:default` predicate in `:dispatches` to override the auto-generated one
+- Trace entries record `:default` as the transition label
+
 ## Join Nodes (Fork-Join)
 
 When multiple independent cells can run concurrently, declare a join node:

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -370,6 +370,35 @@
     (let [{:keys [id]} (normalize-cell-ref cell-name cell-ref)]
       (cell/get-cell! id))))
 
+(defn- validate-default-edges!
+  "Validates :default edge usage. Throws if :default is the only edge for a cell."
+  [edges-map]
+  (doseq [[cell-name edge-def] edges-map]
+    (when (and (map? edge-def)
+               (contains? edge-def :default)
+               (= 1 (count edge-def)))
+      (throw (ex-info (str "Cell " cell-name " has :default as its only edge. "
+                           "Use an unconditional edge (keyword) instead.")
+                      {:cell-name cell-name})))))
+
+(defn- inject-default-dispatches
+  "For cells with a :default edge and no explicit :default dispatch predicate,
+   auto-appends [:default (constantly true)] as the last dispatch predicate."
+  [dispatches-map edges-map]
+  (reduce (fn [acc [cell-name edge-def]]
+            (if (and (map? edge-def)
+                     (contains? edge-def :default))
+              (let [dispatch-vec (get acc cell-name [])
+                    has-default? (some #(= :default (first %)) dispatch-vec)]
+                (if has-default?
+                  acc
+                  (assoc acc cell-name
+                         (conj (vec dispatch-vec)
+                               [:default (constantly true)]))))
+              acc))
+          (or dispatches-map {})
+          edges-map))
+
 (defn- merge-default-dispatches
   "Merges default dispatches from cell specs into the workflow dispatches.
    For each cell with map edges and no explicit dispatch, checks the cell spec
@@ -503,6 +532,8 @@
   [{:keys [cells edges dispatches joins input-schema pipeline] :as raw-workflow}]
   (let [{:keys [cells edges dispatches joins input-schema]} (expand-pipeline raw-workflow)]
     (validate-cells-exist! cells)
+    ;; Validate :default edge usage (must not be sole edge)
+    (validate-default-edges! edges)
     ;; Normalize to {name → cell-id} for all downstream validation
     (let [cell-ids (cells->ids cells)]
       ;; Validate :input-schema well-formedness if present
@@ -525,9 +556,11 @@
           (v/validate-edge-targets! edges valid-names)
           (v/validate-reachability! edges valid-names))
         ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
+        ;; Also auto-inject :default catch-all predicates
         (let [join-dispatches    (compute-join-dispatches joins-map edges)
+              with-defaults      (inject-default-dispatches dispatches edges)
               effective-dispatches (merge join-dispatches
-                                          (merge-default-dispatches dispatches edges cell-ids))]
+                                          (merge-default-dispatches with-defaults edges cell-ids))]
           (v/validate-dispatch-coverage! edges effective-dispatches))
         (validate-schema-chain! edges cell-ids joins-map)))))
 
@@ -656,9 +689,11 @@
          ;; Determine which cells are consumed by joins
          join-members (set (mapcat :cells (vals joins-map)))
          ;; Merge default dispatches from cell specs AND join default dispatches (filtered to edge keys)
+         ;; Also auto-inject :default catch-all predicates
          join-dispatches    (compute-join-dispatches joins-map edges)
+         with-defaults      (inject-default-dispatches dispatches edges)
          effective-dispatches (merge join-dispatches
-                                     (merge-default-dispatches dispatches edges cell-ids))
+                                     (merge-default-dispatches with-defaults edges cell-ids))
          ;; Build state->cell map for non-join-member cells
          state->cell (into {}
                            (keep (fn [[cell-name cell-id]]

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -66,17 +66,21 @@
   "Compiles edge definitions into Maestro dispatch pairs.
    If edges is a keyword → unconditional dispatch to that target.
    If edges is a map → uses dispatch-vec (vector of [label pred] pairs) to
-   produce ordered [[target pred] ...] matching Maestro's format."
+   produce ordered [[target pred] ...] matching Maestro's format.
+   :default dispatches are always placed last to ensure catch-all semantics."
   [edges dispatch-vec]
   (if (keyword? edges)
     [[(resolve-state-id edges) (constantly true)]]
-    (mapv (fn [[label pred]]
-            (let [target (get edges label)]
-              (when-not target
-                (throw (ex-info (str "No edge target for dispatch label " label)
-                                {:label label})))
-              [(resolve-state-id target) pred]))
-          dispatch-vec)))
+    (let [;; Partition into non-default and default, then concat so :default is last
+          {defaults true others false} (group-by #(= :default (first %)) dispatch-vec)
+          ordered (concat others defaults)]
+      (mapv (fn [[label pred]]
+              (let [target (get edges label)]
+                (when-not target
+                  (throw (ex-info (str "No edge target for dispatch label " label)
+                                  {:label label})))
+                [(resolve-state-id target) pred]))
+            ordered))))
 
 ;; ===== Schema key utilities =====
 
@@ -508,8 +512,9 @@
 
 (defn- compute-join-dispatches
   "Computes effective dispatches for join nodes, filtering join-default-dispatches
-   to only include labels that match existing edge keys. Returns a dispatches map
-   keyed by join name."
+   to only include labels that match existing edge keys. Also appends a :default
+   catch-all predicate if the join's edge map contains a :default target.
+   Returns a dispatches map keyed by join name."
   [joins-map edges]
   (reduce (fn [acc [join-name _]]
             (let [edge-def (get edges join-name)]
@@ -518,9 +523,13 @@
                 (let [edge-keys (set (keys edge-def))
                       filtered  (filterv (fn [[label _]]
                                            (contains? edge-keys label))
-                                         join-default-dispatches)]
-                  (if (seq filtered)
-                    (assoc acc join-name filtered)
+                                         join-default-dispatches)
+                      ;; Append :default catch-all if edge map has :default target
+                      with-default (if (contains? edge-def :default)
+                                     (conj (vec filtered) [:default (constantly true)])
+                                     filtered)]
+                  (if (seq with-default)
+                    (assoc acc join-name with-default)
                     acc))
                 acc)))
           {}
@@ -557,10 +566,11 @@
           (v/validate-reachability! edges valid-names))
         ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
         ;; Also auto-inject :default catch-all predicates
-        (let [join-dispatches    (compute-join-dispatches joins-map edges)
-              with-defaults      (inject-default-dispatches dispatches edges)
-              effective-dispatches (merge join-dispatches
-                                          (merge-default-dispatches with-defaults edges cell-ids))]
+        ;; Join dispatches take priority (merged last) since joins compute their own dispatches
+        (let [with-defaults      (inject-default-dispatches dispatches edges)
+              join-dispatches    (compute-join-dispatches joins-map edges)
+              effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
+                                          join-dispatches)]
           (v/validate-dispatch-coverage! edges effective-dispatches))
         (validate-schema-chain! edges cell-ids joins-map)))))
 
@@ -690,10 +700,11 @@
          join-members (set (mapcat :cells (vals joins-map)))
          ;; Merge default dispatches from cell specs AND join default dispatches (filtered to edge keys)
          ;; Also auto-inject :default catch-all predicates
-         join-dispatches    (compute-join-dispatches joins-map edges)
+         ;; Join dispatches take priority (merged last) since joins compute their own dispatches
          with-defaults      (inject-default-dispatches dispatches edges)
-         effective-dispatches (merge join-dispatches
-                                     (merge-default-dispatches with-defaults edges cell-ids))
+         join-dispatches    (compute-join-dispatches joins-map edges)
+         effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
+                                     join-dispatches)
          ;; Build state->cell map for non-join-member cells
          state->cell (into {}
                            (keep (fn [[cell-name cell-id]]

--- a/test/mycelium/default_transition_test.clj
+++ b/test/mycelium/default_transition_test.clj
@@ -207,3 +207,75 @@
                                          [:default (fn [_] true)]]}}
                    {} {})]
       (is (= "b" (:result result))))))
+
+;; ===== Round 9: Default placed first in dispatches still fires last =====
+
+(deftest default-first-in-dispatches-still-fires-last-test
+  (testing ":default is reordered to last even if user puts it first in :dispatches"
+    (defmethod cell/cell-spec :dt9/step [_]
+      {:id      :dt9/step
+       :handler (fn [_ data] (assoc data :x 1))
+       :schema  {:input [:map] :output [:map [:x :int]]}})
+    (defmethod cell/cell-spec :dt9/a [_]
+      {:id      :dt9/a
+       :handler (fn [_ data] (assoc data :result "a"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :dt9/b [_]
+      {:id      :dt9/b
+       :handler (fn [_ data] (assoc data :result "b"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+
+    ;; :default listed FIRST but :success matches, so :success should win
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt9/step
+                            :a     :dt9/a
+                            :b     :dt9/b}
+                    :edges {:start {:success :a, :default :b}
+                            :a :end, :b :end}
+                    :dispatches {:start [[:default (fn [_] true)]
+                                         [:success (fn [_] true)]]}}
+                   {} {})]
+      (is (= "a" (:result result)) ":success should win even though :default was listed first"))))
+
+;; ===== Round 10: Default on join node =====
+
+(deftest default-on-join-node-test
+  (testing ":default edge on a join node acts as catch-all"
+    (defmethod cell/cell-spec :dt10/branch-a [_]
+      {:id      :dt10/branch-a
+       :handler (fn [_ data] (assoc data :a-result 1))
+       :schema  {:input [:map] :output [:map [:a-result :int]]}})
+    (defmethod cell/cell-spec :dt10/branch-b [_]
+      {:id      :dt10/branch-b
+       :handler (fn [_ data] (assoc data :b-result 2))
+       :schema  {:input [:map] :output [:map [:b-result :int]]}})
+    (defmethod cell/cell-spec :dt10/after [_]
+      {:id      :dt10/after
+       :handler (fn [_ data] (assoc data :sum (+ (:a-result data) (:b-result data))))
+       :schema  {:input [:map [:a-result :int] [:b-result :int]] :output [:map [:sum :int]]}})
+    (defmethod cell/cell-spec :dt10/fallback [_]
+      {:id      :dt10/fallback
+       :handler (fn [_ data] (assoc data :fell-back true))
+       :schema  {:input [:map] :output [:map [:fell-back :boolean]]}})
+    (defmethod cell/cell-spec :dt10/start [_]
+      {:id      :dt10/start
+       :handler (fn [_ data] data)
+       :schema  {:input [:map] :output [:map]}})
+
+    ;; Join succeeds → :done route. But if we only wire :default (no :done),
+    ;; the join's default dispatch for :done won't match any edge, so :default catches.
+    (let [result (myc/run-workflow
+                   {:cells {:start     :dt10/start
+                            :branch-a  :dt10/branch-a
+                            :branch-b  :dt10/branch-b
+                            :after     :dt10/after
+                            :fallback  :dt10/fallback}
+                    :joins {:gather {:cells [:branch-a :branch-b]
+                                     :strategy :parallel}}
+                    :edges {:start   :gather
+                            :gather  {:done :after, :default :fallback}
+                            :after   :end
+                            :fallback :end}}
+                   {} {})]
+      ;; Join succeeds, :done matches, should route to :after
+      (is (= 3 (:sum result))))))

--- a/test/mycelium/default_transition_test.clj
+++ b/test/mycelium/default_transition_test.clj
@@ -1,0 +1,209 @@
+(ns mycelium.default-transition-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== Round 1: Basic default transition =====
+
+(deftest default-transition-fires-when-no-predicate-matches-test
+  (testing ":default edge is taken when no other dispatch matches"
+    (defmethod cell/cell-spec :dt/check [_]
+      {:id      :dt/check
+       :handler (fn [_ data] (assoc data :status :unknown))
+       :schema  {:input [:map] :output [:map [:status :keyword]]}})
+    (defmethod cell/cell-spec :dt/success [_]
+      {:id      :dt/success
+       :handler (fn [_ data] (assoc data :result "ok"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :dt/fallback [_]
+      {:id      :dt/fallback
+       :handler (fn [_ data] (assoc data :result "fallback"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt/check
+                            :ok    :dt/success
+                            :fb    :dt/fallback}
+                    :edges {:start {:success :ok, :default :fb}
+                            :ok :end
+                            :fb :end}
+                    :dispatches {:start [[:success (fn [d] (= :good (:status d)))]]}}
+                   {} {})]
+      (is (= "fallback" (:result result))))))
+
+;; ===== Round 2: Default not taken when another matches =====
+
+(deftest default-not-taken-when-predicate-matches-test
+  (testing ":default is skipped when a real predicate matches"
+    (defmethod cell/cell-spec :dt2/check [_]
+      {:id      :dt2/check
+       :handler (fn [_ data] (assoc data :status :good))
+       :schema  {:input [:map] :output [:map [:status :keyword]]}})
+    (defmethod cell/cell-spec :dt2/success [_]
+      {:id      :dt2/success
+       :handler (fn [_ data] (assoc data :result "ok"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :dt2/fallback [_]
+      {:id      :dt2/fallback
+       :handler (fn [_ data] (assoc data :result "fallback"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt2/check
+                            :ok    :dt2/success
+                            :fb    :dt2/fallback}
+                    :edges {:start {:success :ok, :default :fb}
+                            :ok :end
+                            :fb :end}
+                    :dispatches {:start [[:success (fn [d] (= :good (:status d)))]]}}
+                   {} {})]
+      (is (= "ok" (:result result))))))
+
+;; ===== Round 3: Default as sole edge is rejected =====
+
+(deftest default-as-sole-edge-throws-test
+  (testing ":default as the only edge is rejected (use unconditional edge)"
+    (defmethod cell/cell-spec :dt3/step [_]
+      {:id      :dt3/step
+       :handler (fn [_ data] data)
+       :schema  {:input [:map] :output [:map]}})
+
+    (is (thrown-with-msg? Exception #"[Dd]efault.*only"
+          (myc/run-workflow
+            {:cells {:start :dt3/step}
+             :edges {:start {:default :end}}}
+            {} {})))))
+
+;; ===== Round 4: Default with schema chain =====
+
+(deftest default-path-schema-chain-works-test
+  (testing "Schema chain validation works for the :default path"
+    (defmethod cell/cell-spec :dt4/produce [_]
+      {:id      :dt4/produce
+       :handler (fn [_ data] (assoc data :value 42))
+       :schema  {:input  [:map]
+                 :output {:success [:map [:value :int]]
+                          :default [:map [:value :int]]}}})
+    (defmethod cell/cell-spec :dt4/consume [_]
+      {:id      :dt4/consume
+       :handler (fn [_ data] (assoc data :doubled (* 2 (:value data))))
+       :schema  {:input [:map [:value :int]] :output [:map [:doubled :int]]}})
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt4/produce
+                            :next  :dt4/consume}
+                    :edges {:start {:success :next, :default :next}
+                            :next :end}
+                    :dispatches {:start [[:success (fn [_] false)]]}}
+                   {} {})]
+      (is (= 84 (:doubled result))))))
+
+;; ===== Round 5: Default with multiple branches =====
+
+(deftest default-with-multiple-branches-test
+  (testing ":default acts as catch-all with multiple named branches"
+    (defmethod cell/cell-spec :dt5/classify [_]
+      {:id      :dt5/classify
+       :handler (fn [_ data] (assoc data :category :other))
+       :schema  {:input [:map] :output [:map [:category :keyword]]}})
+    (defmethod cell/cell-spec :dt5/high [_]
+      {:id      :dt5/high
+       :handler (fn [_ data] (assoc data :result "high"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :dt5/low [_]
+      {:id      :dt5/low
+       :handler (fn [_ data] (assoc data :result "low"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :dt5/unknown [_]
+      {:id      :dt5/unknown
+       :handler (fn [_ data] (assoc data :result "unknown"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt5/classify
+                            :high  :dt5/high
+                            :low   :dt5/low
+                            :unk   :dt5/unknown}
+                    :edges {:start {:high :high, :low :low, :default :unk}
+                            :high :end, :low :end, :unk :end}
+                    :dispatches {:start [[:high (fn [d] (= :high (:category d)))]
+                                         [:low  (fn [d] (= :low (:category d)))]]}}
+                   {} {})]
+      (is (= "unknown" (:result result))))))
+
+;; ===== Round 6: Default preserves trace =====
+
+(deftest default-transition-recorded-in-trace-test
+  (testing "Trace records :default as the transition label"
+    (defmethod cell/cell-spec :dt6/step [_]
+      {:id      :dt6/step
+       :handler (fn [_ data] (assoc data :done true))
+       :schema  {:input [:map] :output [:map [:done :boolean]]}})
+    (defmethod cell/cell-spec :dt6/fb [_]
+      {:id      :dt6/fb
+       :handler (fn [_ data] (assoc data :fell-back true))
+       :schema  {:input [:map] :output [:map [:fell-back :boolean]]}})
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt6/step
+                            :fb    :dt6/fb}
+                    :edges {:start {:success :end, :default :fb}
+                            :fb :end}
+                    :dispatches {:start [[:success (fn [_] false)]]}}
+                   {} {})]
+      (is (= :default (:transition (first (:mycelium/trace result))))))))
+
+;; ===== Round 7: Default with halt =====
+
+(deftest default-with-halt-works-test
+  (testing "Cell can halt on the :default path"
+    (defmethod cell/cell-spec :dt7/check [_]
+      {:id      :dt7/check
+       :handler (fn [_ data] (assoc data :checked true))
+       :schema  {:input [:map] :output [:map [:checked :boolean]]}})
+    (defmethod cell/cell-spec :dt7/review [_]
+      {:id      :dt7/review
+       :handler (fn [_ data] (assoc data :mycelium/halt {:reason :needs-review}))
+       :schema  {:input [:map] :output [:map]}})
+
+    (let [compiled (myc/pre-compile
+                     {:cells {:start :dt7/check
+                              :review :dt7/review}
+                      :edges {:start {:ok :end, :default :review}
+                              :review :end}
+                      :dispatches {:start [[:ok (fn [_] false)]]}})
+          halted (myc/run-compiled compiled {} {})]
+      (is (some? (:mycelium/halt halted)))
+      (is (= {:reason :needs-review} (:mycelium/halt halted)))
+      (let [result (myc/resume-compiled compiled {} halted)]
+        (is (nil? (:mycelium/halt result)))))))
+
+;; ===== Round 8: Explicit :default dispatch predicate is allowed =====
+
+(deftest explicit-default-predicate-allowed-test
+  (testing "User can provide an explicit :default predicate (overrides auto-inject)"
+    (defmethod cell/cell-spec :dt8/step [_]
+      {:id      :dt8/step
+       :handler (fn [_ data] (assoc data :x 1))
+       :schema  {:input [:map] :output [:map [:x :int]]}})
+    (defmethod cell/cell-spec :dt8/a [_]
+      {:id      :dt8/a
+       :handler (fn [_ data] (assoc data :result "a"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+    (defmethod cell/cell-spec :dt8/b [_]
+      {:id      :dt8/b
+       :handler (fn [_ data] (assoc data :result "b"))
+       :schema  {:input [:map] :output [:map [:result :string]]}})
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :dt8/step
+                            :a     :dt8/a
+                            :b     :dt8/b}
+                    :edges {:start {:success :a, :default :b}
+                            :a :end, :b :end}
+                    :dispatches {:start [[:success (fn [_] false)]
+                                         [:default (fn [_] true)]]}}
+                   {} {})]
+      (is (= "b" (:result result))))))


### PR DESCRIPTION
- Add :default edge label as a catch-all fallback transition — when no other dispatch predicate matches, the :default edge is taken automatically
- Auto-injects [:default (constantly true)] as the last dispatch predicate; no manual dispatch entry needed
- :default is always evaluated last even if user places it first in :dispatches
- Works with join nodes alongside :done/:failure edges
- Rejects :default as the sole edge (use unconditional keyword edge instead)