### PR TITLE
Global constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Declare compile-time path invariants that are checked against all enumerated wor
 | `:never-together` | Listed `:cells` must never all appear on the same path |
 | `:always-reachable` | `:cell` must appear on every path that reaches `:end` |
 
-`:always-reachable` only checks paths to `:end` — paths terminating at `:error` or `:halt` are ignored. Violations throw at compile time with the specific path that violates the constraint.
+`:always-reachable` only checks paths to `:end` — paths terminating at `:error` or `:halt` are ignored. It passes vacuously if no paths reach `:end`. Constraints reference workflow cell names (including join names), not join member cells. Violations throw at compile time with the specific path that violates the constraint.
 
 ## Compile-Time Validation
 

--- a/README.md
+++ b/README.md
@@ -425,6 +425,25 @@ Key behaviors:
 - If the halting cell dispatches to a branch, resume continues on the correct branch
 - Calling `resume-compiled` on a non-halted result throws an exception
 
+## Constraints
+
+Declare compile-time path invariants that are checked against all enumerated workflow paths:
+
+```clojure
+{:cells {:start :check/flag, :fix :repair/apply-tags, :done :ui/render}
+ :pipeline [:start :fix :done]
+ :constraints [{:type :must-follow, :if :start, :then :fix}]}
+```
+
+| Type | Meaning |
+|------|---------|
+| `:must-follow` | If `:if` cell appears on a path, `:then` cell must appear later |
+| `:must-precede` | `:cell` must appear before `:before` on every path containing `:before` |
+| `:never-together` | Listed `:cells` must never all appear on the same path |
+| `:always-reachable` | `:cell` must appear on every path that reaches `:end` |
+
+`:always-reachable` only checks paths to `:end` — paths terminating at `:error` or `:halt` are ignored. Violations throw at compile time with the specific path that violates the constraint.
+
 ## Compile-Time Validation
 
 `compile-workflow` validates before any code runs:
@@ -434,6 +453,7 @@ Key behaviors:
 - **Reachability** — every cell and join must be reachable from `:start`
 - **Dispatch coverage** — every edge label must have a corresponding dispatch predicate, and vice versa
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware: validates member inputs and accumulates union of member outputs)
+- **Constraints** — path invariants checked against all enumerated paths
 - **Resilience validation** — policy keys are valid, referenced cells exist, timeout-ms is positive
 - **Join validation** — member cells exist, no name collisions with cells, members have no edges, output keys are disjoint (or `:merge-fn` provided), strategy is valid, no cell appears in multiple joins
 

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -32,9 +32,9 @@ Currently if no dispatch predicate matches, Maestro throws — catastrophic for 
 
 ---
 
-## 2. Temporal Logic / Global Constraints
+## ~~2. Temporal Logic / Global Constraints~~ (Implemented)
 
-**Value: High | Feasibility: Medium**
+**Value: High | Feasibility: Medium** — **DONE**
 
 "If a file is flagged as missing metadata, it must pass through a tagging cell before `:end`" — the kind of invariant that catches agent mistakes at compile time rather than runtime. `dev/enumerate-paths` already walks all paths; a constraint checker would layer on top.
 
@@ -214,7 +214,7 @@ Interceptors already fill this role. Workflow-level interceptors with `:pre`/`:p
 | Priority | Feature | Effort | Dependencies |
 |----------|---------|--------|--------------|
 | Done | Default transitions | Small | None |
-| Soon | Global constraints | Medium | `enumerate-paths` (exists) |
+| Done | Global constraints | Medium | `enumerate-paths` (exists) |
 | Planned | Graph-level timeouts | Medium | None (reuses join timeout pattern) |
 | Later | Region briefs | Small | None |
 | Deferred | Error groups | Small | None |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -377,6 +377,26 @@ Output schema is inferred automatically by walking child workflow edges to `:end
 
 Per-transition schemas are validated based on which dispatch matched. The schema chain validator tracks available keys independently per path.
 
+## Constraints
+
+Declare compile-time path invariants that are checked against all enumerated paths:
+
+```clojure
+{:constraints [{:type :must-follow,      :if :flag-missing, :then :apply-tags}
+               {:type :must-precede,     :cell :validate,   :before :process}
+               {:type :never-together,   :cells [:manual-review :auto-approve]}
+               {:type :always-reachable, :cell :audit-log}]}
+```
+
+| Type | Meaning |
+|------|---------|
+| `:must-follow` | If `:if` cell appears on a path, `:then` cell must appear later on that path |
+| `:must-precede` | `:cell` must appear before `:before` on every path containing `:before` |
+| `:never-together` | All listed `:cells` must never appear on the same path |
+| `:always-reachable` | `:cell` must appear on every path that reaches `:end` (ignores `:error`/`:halt` paths) |
+
+Constraints are checked after all other validations pass. Violations throw with the specific path that violates the constraint.
+
 ## Compile-Time Validation
 
 `compile-workflow` validates before any code runs:
@@ -386,6 +406,7 @@ Per-transition schemas are validated based on which dispatch matched. The schema
 - **Reachability** — every cell and join must be reachable from `:start`
 - **Dispatch coverage** — every edge label must have a dispatch predicate, and vice versa
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware)
+- **Constraints** — path invariants checked against all enumerated paths (see Constraints)
 - **Resilience validation** — policy keys valid, referenced cells exist, timeout-ms positive
 - **Join validation** — member cells exist, no name collisions, members have no edges, output keys disjoint (or `:merge-fn` provided)
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -395,7 +395,9 @@ Declare compile-time path invariants that are checked against all enumerated pat
 | `:never-together` | All listed `:cells` must never appear on the same path |
 | `:always-reachable` | `:cell` must appear on every path that reaches `:end` (ignores `:error`/`:halt` paths) |
 
-Constraints are checked after all other validations pass. Violations throw with the specific path that violates the constraint.
+- Constraints reference **workflow cell names** (including join names), not join member cells or cell registry IDs
+- `:always-reachable` passes vacuously if no paths reach `:end` (all paths go to `:error`/`:halt`)
+- Violations throw at compile time with the specific path that violates the constraint
 
 ## Compile-Time Validation
 

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -535,6 +535,103 @@
           {}
           joins-map))
 
+;; ===== Constraint validation =====
+
+(defn- enumerate-workflow-paths
+  "Enumerates all paths from :start to terminal states.
+   Returns seq of paths, each a vector of cell-name keywords.
+   Each path also carries :terminal — the terminal state (:end, :error, :halt)."
+  [edges]
+  (loop [queue [[:start [] #{}]]
+         paths []]
+    (if (empty? queue)
+      paths
+      (let [[cell-name path-so-far visited] (first queue)
+            rest-queue (rest queue)]
+        (cond
+          (contains? #{:end :error :halt} cell-name)
+          (recur rest-queue (conj paths {:cells path-so-far :terminal cell-name}))
+
+          (contains? visited cell-name)
+          (recur rest-queue paths)
+
+          :else
+          (let [edge-def    (get edges cell-name)
+                new-visited (conj visited cell-name)
+                new-path    (conj path-so-far cell-name)]
+            (if (keyword? edge-def)
+              (recur (conj (vec rest-queue) [edge-def new-path new-visited])
+                     paths)
+              (let [next-items (mapv (fn [[_ target]]
+                                       [target new-path new-visited])
+                                     edge-def)]
+                (recur (into (vec rest-queue) next-items)
+                       paths)))))))))
+
+(defn- check-constraint
+  "Checks a single constraint against all paths. Returns nil if satisfied,
+   or an error string describing the violation."
+  [constraint paths]
+  (let [type (:type constraint)]
+    (case type
+      :must-follow
+      (let [{:keys [if then]} constraint]
+        (some (fn [{:keys [cells]}]
+                (let [cell-set (set cells)]
+                  (when (contains? cell-set if)
+                    (let [if-idx (.indexOf (vec cells) if)
+                          after  (set (drop (inc if-idx) cells))]
+                      (when-not (contains? after then)
+                        (str "Constraint :must-follow violated: " if " appears on path "
+                             cells " but " then " does not follow it"))))))
+              paths))
+
+      :must-precede
+      (let [{:keys [cell before]} constraint]
+        (some (fn [{:keys [cells]}]
+                (let [cell-set (set cells)]
+                  (when (contains? cell-set before)
+                    (let [before-idx (.indexOf (vec cells) before)
+                          preceding  (set (take before-idx cells))]
+                      (when-not (contains? preceding cell)
+                        (str "Constraint :must-precede violated: " cell " must appear before "
+                             before " on path " cells " but does not"))))))
+              paths))
+
+      :never-together
+      (let [constraint-cells (set (:cells constraint))]
+        (some (fn [{:keys [cells]}]
+                (let [cell-set (set cells)
+                      overlap  (set/intersection cell-set constraint-cells)]
+                  (when (= (count overlap) (count constraint-cells))
+                    (str "Constraint :never-together violated: "
+                         (seq constraint-cells) " all appear on path " cells))))
+              paths))
+
+      :always-reachable
+      (let [target-cell (:cell constraint)
+            end-paths   (filter #(= :end (:terminal %)) paths)]
+        (when (seq end-paths)
+          (some (fn [{:keys [cells]}]
+                  (when-not (contains? (set cells) target-cell)
+                    (str "Constraint :always-reachable violated: " target-cell
+                         " does not appear on path " cells " (which reaches :end)")))
+                end-paths)))
+
+      ;; Unknown type
+      (throw (ex-info (str "Unknown constraint type: " type)
+                      {:constraint constraint})))))
+
+(defn- validate-constraints!
+  "Validates all constraints against enumerated workflow paths.
+   Throws on the first violation found."
+  [constraints edges]
+  (when (seq constraints)
+    (let [paths (enumerate-workflow-paths edges)]
+      (doseq [constraint constraints]
+        (when-let [error (check-constraint constraint paths)]
+          (throw (ex-info error {:constraint constraint})))))))
+
 (defn validate-workflow
   "Runs all validations on a workflow definition.
    Merges :default-dispatches from cell specs as fallback for cells without explicit dispatches."
@@ -572,7 +669,10 @@
               effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
                                           join-dispatches)]
           (v/validate-dispatch-coverage! edges effective-dispatches))
-        (validate-schema-chain! edges cell-ids joins-map)))))
+        (validate-schema-chain! edges cell-ids joins-map)
+        ;; Validate constraints (after all structural validations pass)
+        (when-let [constraints (:constraints raw-workflow)]
+          (validate-constraints! constraints edges))))))
 
 ;; ===== Workflow-level interceptor matching =====
 

--- a/test/mycelium/constraints_test.clj
+++ b/test/mycelium/constraints_test.clj
@@ -1,0 +1,209 @@
+(ns mycelium.constraints-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+(defn- make-cell [id]
+  (defmethod cell/cell-spec id [_]
+    {:id id
+     :handler (fn [_ data] (assoc data id true))
+     :schema {:input [:map] :output [:map]}}))
+
+;; ===== Round 1: :must-follow — satisfied =====
+
+(deftest must-follow-satisfied-test
+  (testing ":must-follow passes when :then cell appears after :if cell"
+    (make-cell :c/flag)
+    (make-cell :c/fix)
+    (make-cell :c/done)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/flag, :fix :c/fix, :done :c/done}
+                    :pipeline [:start :fix :done]
+                    :constraints [{:type :must-follow, :if :start, :then :fix}]}
+                   {} {})]
+      (is (some? result) "Workflow compiles and runs"))))
+
+;; ===== Round 2: :must-follow — violated =====
+
+(deftest must-follow-violated-test
+  (testing ":must-follow throws when :then cell does not follow :if cell"
+    (make-cell :c/flag2)
+    (make-cell :c/skip)
+
+    (is (thrown-with-msg? Exception #"must-follow.*:start.*:skip"
+          (myc/run-workflow
+            {:cells {:start :c/flag2, :other :c/skip}
+             :edges {:start {:a :other, :b :end}
+                     :other :end}
+             :dispatches {:start [[:a (fn [_] true)]
+                                   [:b (fn [_] false)]]}
+             :constraints [{:type :must-follow, :if :start, :then :skip}]}
+            {} {})))))
+
+;; ===== Round 3: :must-follow — cell absent (vacuous truth) =====
+
+(deftest must-follow-cell-absent-test
+  (testing ":must-follow is satisfied vacuously when :if cell is not on a path"
+    (make-cell :c/a3)
+    (make-cell :c/b3)
+    (make-cell :c/c3)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/a3, :next :c/b3}
+                    :pipeline [:start :next]
+                    ;; :nonexistent is not on any path, so constraint is vacuously true
+                    :constraints [{:type :must-follow, :if :nonexistent, :then :start}]}
+                   {} {})]
+      (is (some? result)))))
+
+;; ===== Round 4: :must-precede — satisfied =====
+
+(deftest must-precede-satisfied-test
+  (testing ":must-precede passes when :cell appears before :before on all paths"
+    (make-cell :c/validate)
+    (make-cell :c/process)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/validate, :proc :c/process}
+                    :pipeline [:start :proc]
+                    :constraints [{:type :must-precede, :cell :start, :before :proc}]}
+                   {} {})]
+      (is (some? result)))))
+
+;; ===== Round 5: :must-precede — violated =====
+
+(deftest must-precede-violated-test
+  (testing ":must-precede throws when :cell does not appear before :before"
+    (make-cell :c/validate5)
+    (make-cell :c/process5)
+    (make-cell :c/other5)
+
+    ;; :proc appears on a path without :validate before it
+    (is (thrown-with-msg? Exception #"must-precede.*:validate.*:proc"
+          (myc/run-workflow
+            {:cells {:start :c/other5, :proc :c/process5, :validate :c/validate5}
+             :edges {:start {:a :proc, :b :validate}
+                     :proc :end
+                     :validate {:done :proc}
+                     }
+             :dispatches {:start    [[:a (fn [_] true)] [:b (fn [_] false)]]
+                          :validate [[:done (constantly true)]]}
+             :constraints [{:type :must-precede, :cell :validate, :before :proc}]}
+            {} {})))))
+
+;; ===== Round 6: :never-together — satisfied =====
+
+(deftest never-together-satisfied-test
+  (testing ":never-together passes when cells are on different branches"
+    (make-cell :c/manual)
+    (make-cell :c/auto)
+    (make-cell :c/start6)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/start6, :manual :c/manual, :auto :c/auto}
+                    :edges {:start {:a :manual, :b :auto}
+                            :manual :end, :auto :end}
+                    :dispatches {:start [[:a (fn [_] true)] [:b (fn [_] false)]]}
+                    :constraints [{:type :never-together, :cells [:manual :auto]}]}
+                   {} {})]
+      (is (some? result)))))
+
+;; ===== Round 7: :never-together — violated =====
+
+(deftest never-together-violated-test
+  (testing ":never-together throws when both cells appear on the same path"
+    (make-cell :c/manual7)
+    (make-cell :c/auto7)
+
+    (is (thrown-with-msg? Exception #"never-together"
+          (myc/run-workflow
+            {:cells {:start :c/manual7, :auto :c/auto7}
+             :pipeline [:start :auto]
+             :constraints [{:type :never-together, :cells [:start :auto]}]}
+            {} {})))))
+
+;; ===== Round 8: :always-reachable — satisfied =====
+
+(deftest always-reachable-satisfied-test
+  (testing ":always-reachable passes when cell appears on every path to :end"
+    (make-cell :c/audit)
+    (make-cell :c/work)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/work, :audit :c/audit}
+                    :pipeline [:start :audit]
+                    :constraints [{:type :always-reachable, :cell :audit}]}
+                   {} {})]
+      (is (some? result)))))
+
+;; ===== Round 9: :always-reachable — violated =====
+
+(deftest always-reachable-violated-test
+  (testing ":always-reachable throws when a path to :end skips the cell"
+    (make-cell :c/audit9)
+    (make-cell :c/work9)
+    (make-cell :c/skip9)
+
+    (is (thrown-with-msg? Exception #"always-reachable.*:audit"
+          (myc/run-workflow
+            {:cells {:start :c/work9, :audit :c/audit9, :fast :c/skip9}
+             :edges {:start {:normal :audit, :fast :fast}
+                     :audit :end
+                     :fast  :end}
+             :dispatches {:start [[:normal (fn [_] true)] [:fast (fn [_] false)]]}
+             :constraints [{:type :always-reachable, :cell :audit}]}
+            {} {})))))
+
+;; ===== Round 10: :always-reachable — ignores error/halt paths =====
+
+(deftest always-reachable-ignores-error-halt-paths-test
+  (testing ":always-reachable only checks paths to :end, not :error or :halt"
+    (make-cell :c/audit10)
+    (make-cell :c/work10)
+
+    ;; Two paths: start → audit → end (has :audit), start → halt (no :audit)
+    ;; :always-reachable should pass because the halt path is ignored
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/work10, :audit :c/audit10}
+                    :edges {:start {:ok :audit, :fail :halt}
+                            :audit :end}
+                    :dispatches {:start [[:ok (fn [_] true)] [:fail (fn [_] false)]]}
+                    :constraints [{:type :always-reachable, :cell :audit}]}
+                   {} {})]
+      (is (some? result)))))
+
+;; ===== Round 11: Multiple constraints =====
+
+(deftest multiple-constraints-test
+  (testing "Multiple constraints are all checked"
+    (make-cell :c/a11)
+    (make-cell :c/b11)
+
+    ;; Two paths: start→b→end and start→end
+    ;; First constraint passes (:b and :start on same path but that's fine for never-together with non-existent combo)
+    ;; Second constraint fails: start→end has no :b after :start
+    (is (thrown-with-msg? Exception #"must-follow"
+          (myc/run-workflow
+            {:cells {:start :c/a11, :b :c/b11}
+             :edges {:start {:x :b, :y :end}
+                     :b :end}
+             :dispatches {:start [[:x (fn [_] true)] [:y (fn [_] false)]]}
+             :constraints [{:type :never-together, :cells [:b :nonexistent]}  ;; passes (nonexistent not on any path)
+                           {:type :must-follow, :if :start, :then :b}]}  ;; fails (start→end has no :b)
+            {} {})))))
+
+;; ===== Round 12: Invalid constraint type =====
+
+(deftest invalid-constraint-type-throws-test
+  (testing "Unknown constraint :type throws"
+    (make-cell :c/x12)
+
+    (is (thrown-with-msg? Exception #"[Uu]nknown constraint type"
+          (myc/run-workflow
+            {:cells {:start :c/x12}
+             :edges {:start :end}
+             :constraints [{:type :bogus}]}
+            {} {})))))

--- a/test/mycelium/constraints_test.clj
+++ b/test/mycelium/constraints_test.clj
@@ -195,7 +195,32 @@
                            {:type :must-follow, :if :start, :then :b}]}  ;; fails (start→end has no :b)
             {} {})))))
 
-;; ===== Round 12: Invalid constraint type =====
+;; ===== Round 12: Constraints with join nodes =====
+
+(deftest constraints-with-join-node-test
+  (testing "Constraints work with join node names on paths"
+    (make-cell :c/start12)
+    (make-cell :c/branch-a)
+    (make-cell :c/branch-b)
+    (make-cell :c/after12)
+
+    ;; :gather is a join name — it should appear on paths and be constrainable
+    (let [result (myc/run-workflow
+                   {:cells {:start    :c/start12
+                            :branch-a :c/branch-a
+                            :branch-b :c/branch-b
+                            :after    :c/after12}
+                    :joins {:gather {:cells [:branch-a :branch-b] :strategy :parallel}}
+                    :edges {:start  :gather
+                            :gather :after
+                            :after  :end}
+                    :constraints [{:type :must-follow, :if :start, :then :gather}
+                                  {:type :must-precede, :cell :gather, :before :after}
+                                  {:type :always-reachable, :cell :gather}]}
+                   {} {})]
+      (is (some? result) "All constraints pass with join node on path"))))
+
+;; ===== Round 13: Invalid constraint type =====
 
 (deftest invalid-constraint-type-throws-test
   (testing "Unknown constraint :type throws"


### PR DESCRIPTION
- Adds four constraint types (:must-follow, :must-precede, :never-together, :always-reachable) that are validated at compile time against all enumerated workflow paths
- Constraints use workflow cell names (not cell-spec IDs) and work with join nodes
- :always-reachable only checks paths terminating at :end (ignores :error/:halt paths)