### PR TITLE
Graph timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ Use `:default` as an edge label for a catch-all fallback. If no other dispatch p
 
 This is especially useful as a safety net for agent-generated routing logic. `:default` must not be the only edge — if all paths lead to the same target, use an unconditional keyword edge instead.
 
+### Graph-Level Timeouts
+
+Move timeout logic from handlers to the workflow definition. When a cell exceeds its timeout, the framework injects `:mycelium/timeout true` into data and routes to the `:timeout` edge target. Handlers stay pure — no timeout logic needed:
+
+```clojure
+(myc/run-workflow
+  {:cells {:start    :api/fetch-data
+           :render   :ui/render-result
+           :fallback :ui/show-error}
+   :edges {:start    {:done :render, :timeout :fallback}
+           :render   :end
+           :fallback :end}
+   :dispatches {:start [[:done (fn [d] (not (:mycelium/timeout d)))]]}
+   :timeouts {:start 5000}}  ;; 5 seconds
+  {} {:url "https://api.example.com/data"})
+```
+
+The `:timeout` dispatch is auto-injected and evaluated first (before user predicates and `:default`). This is distinct from resilience `:timeout` policies — graph timeouts **route** to an alternative cell, resilience timeouts produce `:mycelium/resilience-error`.
+
 ### Per-Transition Output Schemas
 
 Cells with multiple outgoing edges can declare different output schemas for each transition:
@@ -454,6 +473,7 @@ Declare compile-time path invariants that are checked against all enumerated wor
 - **Dispatch coverage** — every edge label must have a corresponding dispatch predicate, and vice versa
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware: validates member inputs and accumulates union of member outputs)
 - **Constraints** — path invariants checked against all enumerated paths
+- **Graph timeouts** — timeout cells exist, values are positive integers, cells have `:timeout` edge
 - **Resilience validation** — policy keys are valid, referenced cells exist, timeout-ms is positive
 - **Join validation** — member cells exist, no name collisions with cells, members have no edges, output keys are disjoint (or `:merge-fn` provided), strategy is valid, no cell appears in multiple joins
 

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -78,9 +78,9 @@ Currently if no dispatch predicate matches, Maestro throws — catastrophic for 
 
 ---
 
-## 3. Graph-Level Timeout Transitions
+## ~~3. Graph-Level Timeout Transitions~~ (Implemented)
 
-**Value: High | Feasibility: High**
+**Value: High | Feasibility: High** — **DONE**
 
 Harel emphasizes time bounds as a property of the state itself, not the internal activity. Currently an agent writing an async cell must bake timeout logic into the handler. Moving timeouts to the edge definition lets the LLM write pure domain logic while the framework handles failure routing.
 
@@ -215,7 +215,7 @@ Interceptors already fill this role. Workflow-level interceptors with `:pre`/`:p
 |----------|---------|--------|--------------|
 | Done | Default transitions | Small | None |
 | Done | Global constraints | Medium | `enumerate-paths` (exists) |
-| Planned | Graph-level timeouts | Medium | None (reuses join timeout pattern) |
+| Done | Graph-level timeouts | Medium | None (reuses join timeout pattern) |
 | Later | Region briefs | Small | None |
 | Deferred | Error groups | Small | None |
 | Skip | Edge actions | - | Covered by interceptors |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -139,6 +139,29 @@ Use `:default` as an edge label for a catch-all fallback when no other dispatch 
 - Works with join nodes — add `:default` alongside `:done`/`:failure` edges
 - Trace entries record `:default` as the transition label
 
+### Graph-Level Timeouts
+
+Move timeout logic from handlers to the workflow definition. When a cell exceeds its timeout, the framework injects `:mycelium/timeout true` into data and routes to the `:timeout` edge target:
+
+```clojure
+{:cells {:fetch-tags :mp3/parse-id3
+         :render     :ui/render-tags
+         :fallback   :ui/show-error}
+ :edges {:fetch-tags {:done :render, :timeout :fallback}
+         :render     :end
+         :fallback   :end}
+ :dispatches {:fetch-tags [[:done (fn [d] (not (:mycelium/timeout d)))]]}
+ :timeouts {:fetch-tags 5000}}  ;; ms
+```
+
+- Timeout values must be positive integers (milliseconds)
+- Cells with timeouts must have a `:timeout` edge target
+- A `:timeout` dispatch predicate is auto-injected and evaluated **first** (before user predicates)
+- Works with both sync and async cells (async cells become blocking with timeout)
+- Output schema validation is skipped for timed-out cells (handler didn't produce normal output)
+- Trace entries include `:timeout? true` when a cell times out
+- Distinct from resilience `:timeout` policies — graph timeouts **route**, resilience timeouts **error**
+
 ## Join Nodes (Fork-Join)
 
 When multiple independent cells can run concurrently, declare a join node:
@@ -409,6 +432,7 @@ Declare compile-time path invariants that are checked against all enumerated pat
 - **Dispatch coverage** — every edge label must have a dispatch predicate, and vice versa
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware)
 - **Constraints** — path invariants checked against all enumerated paths (see Constraints)
+- **Graph timeouts** — timeout cells exist, values are positive integers, cells have `:timeout` edge
 - **Resilience validation** — policy keys valid, referenced cells exist, timeout-ms positive
 - **Join validation** — member cells exist, no name collisions, members have no edges, output keys disjoint (or `:merge-fn` provided)
 
@@ -602,6 +626,7 @@ A cell can pause the workflow by returning `:mycelium/halt` in its data. The wor
 | `:mycelium/input-error` | Input schema validation failure (workflow didn't run) |
 | `:mycelium/schema-error` | Runtime schema violation details |
 | `:mycelium/join-error` | Join node error details |
+| `:mycelium/timeout` | `true` when a cell exceeded its graph-level timeout |
 | `:mycelium/resilience-error` | Resilience policy trigger details (`:type`, `:cell`, `:message`) |
 | `:mycelium/child-trace` | Nested workflow trace (composed cells) |
 | `:mycelium/halt` | Halt context (true or map) — present when workflow is halted |

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -154,6 +154,7 @@
                 ;; Extract join sub-traces if present
                 join-traces (:mycelium/join-traces data)
                 halted?     (some? (:mycelium/halt data))
+                timed-out?  (some? (:mycelium/timeout data))
                 trace-entry (cond-> {:cell       (get state->names state-id)
                                      :cell-id    (:id cell)
                                      :transition transition
@@ -161,6 +162,7 @@
                               duration-ms   (assoc :duration-ms duration-ms)
                               join-traces   (assoc :join-traces join-traces)
                               halted?       (assoc :halted true)
+                              timed-out?    (assoc :timeout? true)
                               error         (assoc :error error))]
             (cond
               error

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -185,7 +185,7 @@
               :else
               (-> fsm-state
                   (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
-                  (update :data dissoc :mycelium/join-traces :mycelium/params))))
+                  (update :data dissoc :mycelium/join-traces :mycelium/params :mycelium/timeout))))
           fsm-state)))))
 
 (defn wrap-async-callback

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -145,9 +145,10 @@
                              (get-in state->edge-targets
                                      [state-id (:current-state-id fsm-state)]))
                 data       (:data fsm-state)
-                ;; Skip output validation when resilience error is present
-                ;; (the handler was short-circuited by the resilience wrapper)
-                error      (when-not (:mycelium/resilience-error data)
+                ;; Skip output validation when resilience error or timeout is present
+                ;; (the handler was short-circuited)
+                error      (when-not (or (:mycelium/resilience-error data)
+                                         (:mycelium/timeout data))
                              (validate-output cell data transition))
                 ;; Extract duration-ms from the latest Maestro trace segment
                 duration-ms (some-> (:trace fsm-state) last :duration-ms)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -535,6 +535,95 @@
           {}
           joins-map))
 
+;; ===== Graph-level timeout wrapping =====
+
+(defn- validate-timeouts!
+  "Validates :timeouts map entries. Each key must be a cell in :cells,
+   value must be a positive integer, and the cell must have a :timeout edge."
+  [timeouts cells edges]
+  (let [cell-names (set (keys cells))]
+    (doseq [[cell-name timeout-ms] timeouts]
+      (when-not (contains? cell-names cell-name)
+        (throw (ex-info (str "timeout references unknown cell " cell-name
+                             " — timeout cell must be in :cells")
+                        {:cell-name cell-name})))
+      (when-not (and (integer? timeout-ms) (pos? timeout-ms))
+        (throw (ex-info (str "Timeout for " cell-name " must be a positive integer, got: " timeout-ms)
+                        {:cell-name cell-name :timeout timeout-ms})))
+      (let [edge-def (get edges cell-name)]
+        (when-not (and (map? edge-def) (contains? edge-def :timeout))
+          (throw (ex-info (str "Cell " cell-name " has a timeout but no :timeout edge target")
+                          {:cell-name cell-name})))))))
+
+(defn- inject-timeout-dispatches
+  "For cells with a :timeout edge and a timeout value, auto-injects a
+   [:timeout (fn [d] (:mycelium/timeout d))] dispatch predicate.
+   Inserted before any :default predicate so timeout takes priority."
+  [dispatches-map timeouts edges]
+  (if (empty? timeouts)
+    dispatches-map
+    (reduce (fn [acc [cell-name _timeout-ms]]
+              (let [edge-def (get edges cell-name)]
+                (if (and (map? edge-def) (contains? edge-def :timeout))
+                  (let [dispatch-vec (get acc cell-name [])
+                        has-timeout? (some #(= :timeout (first %)) dispatch-vec)]
+                    (if has-timeout?
+                      acc
+                      (let [timeout-pred [:timeout (fn [d] (some? (:mycelium/timeout d)))]
+                            ;; Insert first (before user predicates) but before :default
+                            {defaults true others false} (group-by #(= :default (first %)) dispatch-vec)]
+                        (assoc acc cell-name (vec (concat [timeout-pred] others defaults))))))
+                  acc)))
+            (or dispatches-map {})
+            timeouts)))
+
+(defn- wrap-handler-with-timeout
+  "Wraps a cell handler to enforce a graph-level timeout.
+   On timeout, returns the original input data with :mycelium/timeout true.
+   Works for both sync and async handlers."
+  [handler timeout-ms async?]
+  (if async?
+    ;; Async: deliver to promise, deref with timeout
+    (fn [resources data]
+      (let [p (promise)]
+        (handler resources data
+                 (fn [result] (deliver p {:ok result}))
+                 (fn [error] (deliver p {:error error})))
+        (let [v (deref p timeout-ms ::timed-out)]
+          (if (= v ::timed-out)
+            (assoc data :mycelium/timeout true)
+            (if (:error v)
+              (throw (if (instance? Throwable (:error v))
+                       (:error v)
+                       (ex-info (str (:error v)) {})))
+              (:ok v))))))
+    ;; Sync: run in future, deref with timeout
+    (fn [resources data]
+      (let [f (future (handler resources data))
+            v (deref f timeout-ms ::timed-out)]
+        (if (= v ::timed-out)
+          (assoc data :mycelium/timeout true)
+          v)))))
+
+(defn- apply-graph-timeouts
+  "Wraps handlers for cells that have graph-level timeouts.
+   state->cell: {resolved-state-id -> cell-map}
+   timeouts: {cell-name -> ms}"
+  [state->cell timeouts]
+  (if (empty? timeouts)
+    state->cell
+    (reduce (fn [acc [cell-name timeout-ms]]
+              (let [state-id (resolve-state-id cell-name)]
+                (if-let [cell (get acc state-id)]
+                  (assoc acc state-id
+                         (-> cell
+                             (update :handler wrap-handler-with-timeout timeout-ms (:async? cell))
+                             ;; Timeout wrapper blocks, so the cell becomes sync
+                             (dissoc :async?)))
+                  acc)))
+            state->cell
+            timeouts)))
+
 ;; ===== Constraint validation =====
 
 (defn- enumerate-workflow-paths
@@ -664,12 +753,17 @@
         ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
         ;; Also auto-inject :default catch-all predicates
         ;; Join dispatches take priority (merged last) since joins compute their own dispatches
-        (let [with-defaults      (inject-default-dispatches dispatches edges)
+        (let [timeouts-map        (or (:timeouts raw-workflow) {})
+              with-timeouts      (inject-timeout-dispatches dispatches timeouts-map edges)
+              with-defaults      (inject-default-dispatches with-timeouts edges)
               join-dispatches    (compute-join-dispatches joins-map edges)
               effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
                                           join-dispatches)]
           (v/validate-dispatch-coverage! edges effective-dispatches))
         (validate-schema-chain! edges cell-ids joins-map)
+        ;; Validate graph-level timeouts
+        (when-let [timeouts (:timeouts raw-workflow)]
+          (validate-timeouts! timeouts cells edges))
         ;; Validate constraints (after all structural validations pass)
         (when-let [constraints (:constraints raw-workflow)]
           (validate-constraints! constraints edges))))))
@@ -798,10 +892,10 @@
            joins-map (or joins {})
          ;; Determine which cells are consumed by joins
          join-members (set (mapcat :cells (vals joins-map)))
-         ;; Merge default dispatches from cell specs AND join default dispatches (filtered to edge keys)
-         ;; Also auto-inject :default catch-all predicates
-         ;; Join dispatches take priority (merged last) since joins compute their own dispatches
-         with-defaults      (inject-default-dispatches dispatches edges)
+         ;; Merge timeout, default, and join dispatches
+         timeouts-map       (or (:timeouts workflow) {})
+         with-timeouts      (inject-timeout-dispatches dispatches timeouts-map edges)
+         with-defaults      (inject-default-dispatches with-timeouts edges)
          join-dispatches    (compute-join-dispatches joins-map edges)
          effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
                                      join-dispatches)
@@ -850,6 +944,8 @@
                                state->cell
                                resilience-map)
                        state->cell)
+         ;; Apply graph-level timeouts (wraps handlers with timeout logic)
+         state->cell (apply-graph-timeouts state->cell timeouts-map)
          ;; Apply workflow-level interceptors (wraps cell handlers)
          wf-interceptors (:interceptors workflow)
          state->cell (apply-workflow-interceptors state->cell cell-ids wf-interceptors)

--- a/test/mycelium/timeout_test.clj
+++ b/test/mycelium/timeout_test.clj
@@ -13,6 +13,11 @@
       :handler handler
       :schema {:input [:map] :output [:map]}})))
 
+(defn- timed-out?
+  "Checks if any trace entry has :timeout? true."
+  [result]
+  (some :timeout? (:mycelium/trace result)))
+
 ;; ===== Round 1: Basic timeout routing =====
 
 (deftest basic-timeout-routing-test
@@ -33,8 +38,8 @@
                     :dispatches {:start [[:done (constantly true)]]}
                     :timeouts {:start 50}}
                    {} {})]
-      (is (true? (:mycelium/timeout result))
-          "Timeout flag is injected into data")
+      (is (timed-out? result)
+          "Timeout recorded in trace")
       (is (true? (:c/fallback result))
           "Fallback cell ran")
       (is (nil? (:c/unreachable result))
@@ -57,8 +62,8 @@
                    {} {})]
       (is (= "fast" (:result result))
           "Handler result is present")
-      (is (nil? (:mycelium/timeout result))
-          "No timeout flag"))))
+      (is (not (timed-out? result))
+          "No timeout in trace"))))
 
 ;; ===== Round 3: Validation — timeout value must be positive integer =====
 
@@ -137,7 +142,7 @@
                     :dispatches {:start [[:done (constantly true)]]}
                     :timeouts {:start 50}}
                    {} {})]
-      (is (true? (:mycelium/timeout result)))
+      (is (timed-out? result))
       (is (true? (:c/async-fallback result))))))
 
 ;; ===== Round 7: Timeout dispatch auto-injection =====
@@ -157,7 +162,7 @@
                     :dispatches {:start [[:done (fn [d] (not (:mycelium/timeout d)))]]}
                     :timeouts {:start 50}}
                    {} {})]
-      (is (true? (:mycelium/timeout result))))))
+      (is (timed-out? result)))))
 
 ;; ===== Round 8: Timeout with :default edge =====
 
@@ -178,7 +183,7 @@
                                                              (:result d)))]]}
                     :timeouts {:start 50}}
                    {} {})]
-      (is (true? (:mycelium/timeout result)))
+      (is (timed-out? result))
       (is (true? (:c/fallback8 result))
           ":timeout routes before :default"))))
 
@@ -225,7 +230,7 @@
                     :timeouts {:start 5000, :next 50}}
                    {} {})]
       (is (= "ok" (:first result)) "First cell completes normally")
-      (is (true? (:mycelium/timeout result)) "Second cell times out")
+      (is (timed-out? result) "Second cell times out (recorded in trace)")
       (is (true? (:c/fallback10 result)) "Routes to fallback"))))
 
 ;; ===== Round 11: Timeout skips output schema validation =====
@@ -248,7 +253,51 @@
                     :dispatches {:start [[:done (fn [d] (not (:mycelium/timeout d)))]]}
                     :timeouts {:start 50}}
                    {} {})]
-      (is (true? (:mycelium/timeout result))
+      (is (timed-out? result)
           "Timeout fires")
       (is (nil? (:mycelium/schema-error result))
           "No schema error despite missing :required-key"))))
+
+;; ===== Round 12: Stale :mycelium/timeout flag is cleaned up =====
+
+(deftest timeout-flag-cleared-for-downstream-test
+  (testing ":mycelium/timeout is cleared after routing so downstream cells don't see it"
+    (make-cell :c/slow12 (fn [_ data]
+                           (Thread/sleep 200)
+                           (assoc data :slow-result "done")))
+    ;; Fallback also has a timeout — should NOT fire from stale flag
+    (make-cell :c/fallback12 (fn [_ data]
+                               (assoc data :fallback-result "recovered")))
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/slow12
+                            :fallback :c/fallback12
+                            :oops :c/fallback12}
+                    :edges {:start {:done :end, :timeout :fallback}
+                            :fallback {:done :end, :timeout :oops}
+                            :oops :end}
+                    :dispatches {:start    [[:done (fn [d] (not (:mycelium/timeout d)))]]
+                                 :fallback [[:done (fn [d] (not (:mycelium/timeout d)))]]}
+                    :timeouts {:start 50, :fallback 5000}}
+                   {} {})]
+      (is (= "recovered" (:fallback-result result))
+          "Fallback cell completes normally")
+      (is (nil? (:mycelium/timeout result))
+          "Timeout flag is cleaned up after routing"))))
+
+;; ===== Round 13: Handler exception propagates through timeout wrapper =====
+
+(deftest timeout-handler-exception-propagates-test
+  (testing "If handler throws within timeout window, exception propagates normally"
+    (make-cell :c/explode (fn [_ _data]
+                            (throw (ex-info "boom" {:reason :test}))))
+
+    ;; Maestro catches the exception and routes to ::error, wrapping as "execution error".
+    ;; The original "boom" is nested as the cause.
+    (is (thrown? Exception
+          (myc/run-workflow
+            {:cells {:start :c/explode}
+             :edges {:start {:done :end, :timeout :end}}
+             :dispatches {:start [[:done (constantly true)]]}
+             :timeouts {:start 5000}}
+            {} {})))))

--- a/test/mycelium/timeout_test.clj
+++ b/test/mycelium/timeout_test.clj
@@ -227,3 +227,28 @@
       (is (= "ok" (:first result)) "First cell completes normally")
       (is (true? (:mycelium/timeout result)) "Second cell times out")
       (is (true? (:c/fallback10 result)) "Routes to fallback"))))
+
+;; ===== Round 11: Timeout skips output schema validation =====
+
+(deftest timeout-skips-output-schema-test
+  (testing "Timed-out cell does not trigger output schema validation error"
+    (defmethod cell/cell-spec :c/strict-output [_]
+      {:id :c/strict-output
+       :handler (fn [_ data]
+                  (Thread/sleep 200)
+                  (assoc data :required-key "value"))
+       :schema {:input [:map]
+                :output [:map [:required-key :string]]}})
+    (make-cell :c/fallback11)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/strict-output, :fallback :c/fallback11}
+                    :edges {:start {:done :end, :timeout :fallback}
+                            :fallback :end}
+                    :dispatches {:start [[:done (fn [d] (not (:mycelium/timeout d)))]]}
+                    :timeouts {:start 50}}
+                   {} {})]
+      (is (true? (:mycelium/timeout result))
+          "Timeout fires")
+      (is (nil? (:mycelium/schema-error result))
+          "No schema error despite missing :required-key"))))

--- a/test/mycelium/timeout_test.clj
+++ b/test/mycelium/timeout_test.clj
@@ -1,0 +1,229 @@
+(ns mycelium.timeout-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+(defn- make-cell
+  ([id] (make-cell id (fn [_ data] (assoc data id true))))
+  ([id handler]
+   (defmethod cell/cell-spec id [_]
+     {:id id
+      :handler handler
+      :schema {:input [:map] :output [:map]}})))
+
+;; ===== Round 1: Basic timeout routing =====
+
+(deftest basic-timeout-routing-test
+  (testing "Cell that exceeds timeout routes to :timeout edge target"
+    (make-cell :c/slow (fn [_ data]
+                         (Thread/sleep 200)
+                         (assoc data :result "done")))
+    (make-cell :c/fallback)
+    (make-cell :c/unreachable)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/slow
+                            :ok    :c/unreachable
+                            :fallback :c/fallback}
+                    :edges {:start {:done :ok, :timeout :fallback}
+                            :ok :end
+                            :fallback :end}
+                    :dispatches {:start [[:done (constantly true)]]}
+                    :timeouts {:start 50}}
+                   {} {})]
+      (is (true? (:mycelium/timeout result))
+          "Timeout flag is injected into data")
+      (is (true? (:c/fallback result))
+          "Fallback cell ran")
+      (is (nil? (:c/unreachable result))
+          "Normal path cell did not run"))))
+
+;; ===== Round 2: No timeout — handler completes in time =====
+
+(deftest no-timeout-when-fast-test
+  (testing "Cell that completes before timeout routes normally"
+    (make-cell :c/fast (fn [_ data]
+                         (assoc data :result "fast")))
+    (make-cell :c/next)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/fast, :next :c/next}
+                    :edges {:start {:done :next, :timeout :end}
+                            :next :end}
+                    :dispatches {:start [[:done (constantly true)]]}
+                    :timeouts {:start 5000}}
+                   {} {})]
+      (is (= "fast" (:result result))
+          "Handler result is present")
+      (is (nil? (:mycelium/timeout result))
+          "No timeout flag"))))
+
+;; ===== Round 3: Validation — timeout value must be positive integer =====
+
+(deftest timeout-validation-positive-integer-test
+  (testing "Timeout value must be a positive integer"
+    (make-cell :c/val3)
+
+    (is (thrown-with-msg? Exception #"positive integer"
+          (myc/run-workflow
+            {:cells {:start :c/val3}
+             :edges {:start {:done :end, :timeout :end}}
+             :dispatches {:start [[:done (constantly true)]]}
+             :timeouts {:start -100}}
+            {} {})))
+
+    (is (thrown-with-msg? Exception #"positive integer"
+          (myc/run-workflow
+            {:cells {:start :c/val3}
+             :edges {:start {:done :end, :timeout :end}}
+             :dispatches {:start [[:done (constantly true)]]}
+             :timeouts {:start 0}}
+            {} {})))
+
+    (is (thrown-with-msg? Exception #"positive integer"
+          (myc/run-workflow
+            {:cells {:start :c/val3}
+             :edges {:start {:done :end, :timeout :end}}
+             :dispatches {:start [[:done (constantly true)]]}
+             :timeouts {:start "fast"}}
+            {} {})))))
+
+;; ===== Round 4: Validation — timeout cell must have :timeout edge =====
+
+(deftest timeout-requires-timeout-edge-test
+  (testing "Cell with timeout must have a :timeout edge target"
+    (make-cell :c/val4)
+
+    (is (thrown-with-msg? Exception #"timeout.*edge"
+          (myc/run-workflow
+            {:cells {:start :c/val4}
+             :edges {:start :end}
+             :timeouts {:start 1000}}
+            {} {})))))
+
+;; ===== Round 5: Validation — timeout cell must exist =====
+
+(deftest timeout-cell-must-exist-test
+  (testing "Timeout references a cell that exists in :cells"
+    (make-cell :c/val5)
+
+    (is (thrown-with-msg? Exception #"timeout.*:nonexistent"
+          (myc/run-workflow
+            {:cells {:start :c/val5}
+             :edges {:start :end}
+             :timeouts {:nonexistent 1000}}
+            {} {})))))
+
+;; ===== Round 6: Timeout with async cell =====
+
+(deftest timeout-with-async-cell-test
+  (testing "Async cell that times out routes to :timeout edge"
+    (defmethod cell/cell-spec :c/async-slow [_]
+      {:id :c/async-slow
+       :handler (fn [_resources data callback _error-cb]
+                  (future
+                    (Thread/sleep 200)
+                    (callback (assoc data :async-result "done"))))
+       :async? true
+       :schema {:input [:map] :output [:map]}})
+    (make-cell :c/async-fallback)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/async-slow, :fallback :c/async-fallback}
+                    :edges {:start {:done :end, :timeout :fallback}
+                            :fallback :end}
+                    :dispatches {:start [[:done (constantly true)]]}
+                    :timeouts {:start 50}}
+                   {} {})]
+      (is (true? (:mycelium/timeout result)))
+      (is (true? (:c/async-fallback result))))))
+
+;; ===== Round 7: Timeout dispatch auto-injection =====
+
+(deftest timeout-dispatch-auto-injected-test
+  (testing ":timeout dispatch is auto-injected — user doesn't need to write it"
+    (make-cell :c/slow7 (fn [_ data]
+                          (Thread/sleep 200)
+                          (assoc data :result "done")))
+    (make-cell :c/fallback7)
+
+    ;; No :timeout in dispatches — should be auto-injected
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/slow7, :fallback :c/fallback7}
+                    :edges {:start {:done :end, :timeout :fallback}
+                            :fallback :end}
+                    :dispatches {:start [[:done (fn [d] (not (:mycelium/timeout d)))]]}
+                    :timeouts {:start 50}}
+                   {} {})]
+      (is (true? (:mycelium/timeout result))))))
+
+;; ===== Round 8: Timeout with :default edge =====
+
+(deftest timeout-with-default-edge-test
+  (testing "Timeout works alongside :default edge"
+    (make-cell :c/slow8 (fn [_ data]
+                          (Thread/sleep 200)
+                          (assoc data :result "done")))
+    (make-cell :c/fallback8)
+    (make-cell :c/default8)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/slow8, :fallback :c/fallback8, :default-cell :c/default8}
+                    :edges {:start {:done :end, :timeout :fallback, :default :default-cell}
+                            :fallback :end
+                            :default-cell :end}
+                    :dispatches {:start [[:done (fn [d] (and (not (:mycelium/timeout d))
+                                                             (:result d)))]]}
+                    :timeouts {:start 50}}
+                   {} {})]
+      (is (true? (:mycelium/timeout result)))
+      (is (true? (:c/fallback8 result))
+          ":timeout routes before :default"))))
+
+;; ===== Round 9: Trace records timeout =====
+
+(deftest timeout-trace-test
+  (testing "Trace entry records timeout event"
+    (make-cell :c/slow9 (fn [_ data]
+                          (Thread/sleep 200)
+                          (assoc data :result "done")))
+    (make-cell :c/fallback9)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/slow9, :fallback :c/fallback9}
+                    :edges {:start {:done :end, :timeout :fallback}
+                            :fallback :end}
+                    :dispatches {:start [[:done (constantly true)]]}
+                    :timeouts {:start 50}}
+                   {} {})
+          trace (:mycelium/trace result)
+          start-entry (first (filter #(= :start (:cell %)) trace))]
+      (is (some? start-entry) "Start cell appears in trace")
+      (is (true? (:timeout? start-entry)) "Trace entry has :timeout? flag"))))
+
+;; ===== Round 10: Multiple cells with timeouts =====
+
+(deftest multiple-timeouts-test
+  (testing "Multiple cells can have independent timeouts"
+    (make-cell :c/fast10 (fn [_ data] (assoc data :first "ok")))
+    (make-cell :c/slow10 (fn [_ data]
+                           (Thread/sleep 200)
+                           (assoc data :second "done")))
+    (make-cell :c/fallback10)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/fast10
+                            :next  :c/slow10
+                            :fallback :c/fallback10}
+                    :edges {:start {:done :next, :timeout :end}
+                            :next {:done :end, :timeout :fallback}
+                            :fallback :end}
+                    :dispatches {:start [[:done (fn [d] (not (:mycelium/timeout d)))]]
+                                 :next  [[:done (fn [d] (not (:mycelium/timeout d)))]]}
+                    :timeouts {:start 5000, :next 50}}
+                   {} {})]
+      (is (= "ok" (:first result)) "First cell completes normally")
+      (is (true? (:mycelium/timeout result)) "Second cell times out")
+      (is (true? (:c/fallback10 result)) "Routes to fallback"))))


### PR DESCRIPTION
- Cells can declare timeouts via :timeouts map ({cell-name → ms}); on expiry the framework injects :mycelium/timeout into data and routes to the :timeout edge target
- Handlers stay pure — no timeout logic needed. The :timeout dispatch is auto-injected and evaluated first (before user predicates and :default)
- Works with both sync and async cells; output schema validation is skipped for timed-out cells
- Timeout flag is cleaned up after routing so downstream timed cells aren't affected by stale flags
- Distinct from resilience :timeout policies — graph timeouts route, resilience timeouts error