### PR TITLE
Region briefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Declare compile-time path invariants that are checked against all enumerated wor
 - **Graph timeouts** — timeout cells exist, values are positive integers, cells have `:timeout` edge
 - **Resilience validation** — policy keys are valid, referenced cells exist, timeout-ms is positive
 - **Join validation** — member cells exist, no name collisions with cells, members have no edges, output keys are disjoint (or `:merge-fn` provided), strategy is valid, no cell appears in multiple joins
+- **Region validation** (manifest) — region cells exist, no cell in multiple regions
 
 ```
 Schema chain error: :user/fetch-profile at :fetch-profile requires keys #{:user-id}
@@ -773,7 +774,26 @@ Also available as `myc/infer-workflow-schema`. Handles branching (union of all i
 
 ;; Progress report
 (println (orch/progress manifest))
+
+;; Region brief — scoped context for a subgraph cluster
+(orch/region-brief manifest :auth)
+;; => {:cells [{:name :start, :id :auth/parse, :schema {...}}, ...]
+;;     :internal-edges {:start {:ok :validate-session}}
+;;     :entry-points [:start]
+;;     :exit-points [{:cell :validate-session, :transitions {:authorized :fetch-profile}}]
+;;     :prompt "## Region: auth\n..."}
 ```
+
+### Regions
+
+Group cells into named regions in the manifest for LLM context scoping. `region-brief` generates a focused brief showing cells, schemas, internal edges, and entry/exit points — useful when an LLM only needs context for a subgraph:
+
+```clojure
+{:cells {:start :auth/parse, :validate :auth/validate, :fetch :user/fetch}
+ :regions {:auth [:start :validate]}}
+```
+
+Region cells must exist in `:cells` and no cell may appear in multiple regions. Regions have no runtime effect.
 
 ## Architecture
 

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -124,9 +124,9 @@ This is distinct from resilience4j `:timeout` policies (which wrap the handler w
 
 ---
 
-## 4. Zooming / Depth for LLM Context Management
+## ~~4. Zooming / Depth for LLM Context Management~~ (Implemented)
 
-**Value: Medium | Feasibility: High**
+**Value: Medium | Feasibility: High** — **DONE**
 
 The existing `cell-brief` and `orchestrate` module scope context per-cell well. What's missing is a "region brief" — context for a subgraph cluster rather than a single cell. For example: "here are the 3 cells in the metadata-fixing region, their schemas, and how they connect to each other."
 
@@ -216,7 +216,7 @@ Interceptors already fill this role. Workflow-level interceptors with `:pre`/`:p
 | Done | Default transitions | Small | None |
 | Done | Global constraints | Medium | `enumerate-paths` (exists) |
 | Done | Graph-level timeouts | Medium | None (reuses join timeout pattern) |
-| Later | Region briefs | Small | None |
+| Done | Region briefs | Small | None |
 | Deferred | Error groups | Small | None |
 | Skip | Edge actions | - | Covered by interceptors |
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -561,6 +561,7 @@ Group cells into named regions in the manifest for LLM context scoping:
 - Region cells must exist in `:cells`
 - No cell may appear in multiple regions
 - `region-brief` returns cell schemas, internal edges, entry/exit points, and a prompt
+- Exit point `:transitions` is always a map — unconditional edges use `{:unconditional :target}`
 - Regions are purely informational — no runtime behavior change
 
 ## Workflow Trace

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -538,7 +538,30 @@ Declare compile-time path invariants that are checked against all enumerated pat
 
 ;; Progress report
 (println (orch/progress manifest))
+
+;; Region brief — scoped context for a subgraph cluster
+(orch/region-brief manifest :auth)
+;; => {:cells [{:name :start, :id :auth/parse, :schema {...}}, ...]
+;;     :internal-edges {:start {:ok :validate-session}}
+;;     :entry-points [:start]
+;;     :exit-points [{:cell :validate-session, :transitions {:authorized :fetch-profile}}]
+;;     :prompt "## Region: auth\n..."}
 ```
+
+### Regions
+
+Group cells into named regions in the manifest for LLM context scoping:
+
+```clojure
+{:cells {:start :auth/parse, :validate :auth/validate, :fetch :user/fetch, :render :ui/render}
+ :regions {:auth       [:start :validate]
+           :data-fetch [:fetch]}}
+```
+
+- Region cells must exist in `:cells`
+- No cell may appear in multiple regions
+- `region-brief` returns cell schemas, internal edges, entry/exit points, and a prompt
+- Regions are purely informational — no runtime behavior change
 
 ## Workflow Trace
 

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -86,6 +86,25 @@
             (assoc :edges edges
                    :dispatches {}))))))
 
+;; ===== Region validation =====
+
+(defn- validate-regions!
+  "Validates :regions definitions. Each region's cells must exist in :cells,
+   and no cell may appear in multiple regions."
+  [regions cells]
+  (let [cell-names (set (keys cells))
+        seen (atom {})]
+    (doseq [[region-name region-cells] regions]
+      (doseq [cell-name region-cells]
+        (when-not (contains? cell-names cell-name)
+          (throw (ex-info (str "region " region-name " references nonexistent cell " cell-name)
+                          {:region region-name :cell cell-name})))
+        (when-let [other-region (get @seen cell-name)]
+          (throw (ex-info (str "Cell " cell-name " appears in multiple regions: "
+                               other-region " and " region-name)
+                          {:cell cell-name :regions [other-region region-name]})))
+        (swap! seen assoc cell-name region-name)))))
+
 ;; ===== Manifest validation =====
 
 (defn- validate-on-error!
@@ -169,6 +188,9 @@
        ;; Validate :input-schema if present
        (when-let [input-schema (:input-schema manifest)]
          (v/validate-malli-schema! input-schema "input-schema"))
+       ;; Validate :regions if present
+       (when-let [regions (:regions manifest)]
+         (validate-regions! regions cells))
        manifest))))
 
 ;; ===== Fragment expansion =====

--- a/src/mycelium/orchestrate.clj
+++ b/src/mycelium/orchestrate.clj
@@ -25,6 +25,105 @@
     (assoc base-brief
            :prompt (str (:prompt base-brief) error-section))))
 
+(defn region-brief
+  "Generates a scoped brief for a named region in a manifest.
+   Returns {:cells [...], :internal-edges {...}, :entry-points [...],
+            :exit-points [...], :prompt \"...\"}."
+  [manifest-data region-name]
+  (let [regions (:regions manifest-data)
+        region-cells (get regions region-name)]
+    (when-not region-cells
+      (throw (ex-info (str "Unknown region " region-name " — not found in :regions")
+                      {:region region-name :available (keys regions)})))
+    (let [region-set   (set region-cells)
+          all-edges    (:edges manifest-data)
+          all-cells    (:cells manifest-data)
+          ;; Cell info
+          cells-info   (mapv (fn [cell-name]
+                               (let [cell-def (get all-cells cell-name)]
+                                 {:name   cell-name
+                                  :id     (:id cell-def)
+                                  :doc    (:doc cell-def)
+                                  :schema (:schema cell-def)}))
+                             region-cells)
+          ;; Internal edges: edges where both source and all targets are within the region
+          internal-edges (into {}
+                           (keep (fn [cell-name]
+                                   (let [edge-def (get all-edges cell-name)]
+                                     (when edge-def
+                                       (if (keyword? edge-def)
+                                         (when (contains? region-set edge-def)
+                                           [cell-name edge-def])
+                                         (let [internal (into {}
+                                                         (filter (fn [[_ target]]
+                                                                   (contains? region-set target)))
+                                                         edge-def)]
+                                           (when (seq internal)
+                                             [cell-name internal])))))))
+                           region-cells)
+          ;; Entry points: region cells that have incoming edges from outside the region
+          ;; :start is always an entry point if it's in the region (implicit workflow entry)
+          external-targets (set
+                             (concat
+                               [:start] ;; implicit entry from Maestro
+                               (mapcat (fn [[cell-name edge-def]]
+                                         (when-not (contains? region-set cell-name)
+                                           (if (keyword? edge-def)
+                                             [edge-def]
+                                             (vals edge-def))))
+                                       all-edges)))
+          entry-points (filterv #(contains? external-targets %) region-cells)
+          ;; Exit points: region cells with edges going outside the region
+          exit-points (into []
+                        (keep (fn [cell-name]
+                                (let [edge-def (get all-edges cell-name)]
+                                  (when edge-def
+                                    (let [external (if (keyword? edge-def)
+                                                     (when-not (contains? region-set edge-def)
+                                                       {::unconditional edge-def})
+                                                     (into {}
+                                                       (remove (fn [[_ target]]
+                                                                 (contains? region-set target)))
+                                                       edge-def))]
+                                      (when (seq external)
+                                        {:cell cell-name
+                                         :transitions (if (contains? external ::unconditional)
+                                                        (::unconditional external)
+                                                        external)}))))))
+                        region-cells)
+          ;; Generate prompt
+          prompt (str "## Region: " (name region-name) "\n\n"
+                      "### Cells\n\n"
+                      (str/join "\n"
+                                (map (fn [{:keys [name id doc schema]}]
+                                       (str "- **" name "** (" id ")"
+                                            (when doc (str " — " doc))
+                                            "\n  Input: " (pr-str (:input schema))
+                                            "\n  Output: " (pr-str (:output schema))))
+                                     cells-info))
+                      "\n\n### Internal Edges\n\n"
+                      (if (seq internal-edges)
+                        (str/join "\n"
+                                  (map (fn [[from targets]]
+                                         (str "- " from " → " (pr-str targets)))
+                                       internal-edges))
+                        "(none)")
+                      "\n\n### Entry Points\n\n"
+                      (str/join ", " (map str entry-points))
+                      "\n\n### Exit Points\n\n"
+                      (if (seq exit-points)
+                        (str/join "\n"
+                                  (map (fn [{:keys [cell transitions]}]
+                                         (str "- " cell " → " (pr-str transitions)))
+                                       exit-points))
+                        "(none)")
+                      "\n")]
+      {:cells          cells-info
+       :internal-edges internal-edges
+       :entry-points   entry-points
+       :exit-points    exit-points
+       :prompt         prompt})))
+
 (defn plan
   "Generates an execution plan from a manifest.
    Identifies which cells can be built in parallel."

--- a/src/mycelium/orchestrate.clj
+++ b/src/mycelium/orchestrate.clj
@@ -78,18 +78,17 @@
                         (keep (fn [cell-name]
                                 (let [edge-def (get all-edges cell-name)]
                                   (when edge-def
-                                    (let [external (if (keyword? edge-def)
-                                                     (when-not (contains? region-set edge-def)
-                                                       {::unconditional edge-def})
-                                                     (into {}
+                                    (if (keyword? edge-def)
+                                      (when-not (contains? region-set edge-def)
+                                        {:cell cell-name
+                                         :transitions {:unconditional edge-def}})
+                                      (let [external (into {}
                                                        (remove (fn [[_ target]]
                                                                  (contains? region-set target)))
-                                                       edge-def))]
-                                      (when (seq external)
-                                        {:cell cell-name
-                                         :transitions (if (contains? external ::unconditional)
-                                                        (::unconditional external)
-                                                        external)}))))))
+                                                       edge-def)]
+                                        (when (seq external)
+                                          {:cell cell-name
+                                           :transitions external})))))))
                         region-cells)
           ;; Generate prompt
           prompt (str "## Region: " (name region-name) "\n\n"

--- a/test/mycelium/orchestrate_test.clj
+++ b/test/mycelium/orchestrate_test.clj
@@ -1,6 +1,7 @@
 (ns mycelium.orchestrate-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [mycelium.cell :as cell]
+            [mycelium.manifest :as manifest]
             [mycelium.orchestrate :as orchestrate]))
 
 (use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
@@ -80,3 +81,115 @@
       ;; Should show total count and pending info
       (is (re-find #"2 total" report))
       (is (re-find #"1 pending" report)))))
+
+;; ===== Region briefs =====
+
+(def region-manifest
+  {:id :test/region-workflow
+   :cells {:start
+           {:id :auth/parse
+            :doc "Parse incoming request"
+            :schema {:input [:map [:raw :string]]
+                     :output [:map [:token :string]]}
+            :on-error nil}
+           :validate-session
+           {:id :auth/validate
+            :doc "Validate session token"
+            :schema {:input [:map [:token :string]]
+                     :output [:map [:user-id :int]]}
+            :on-error nil}
+           :fetch-profile
+           {:id :user/fetch-profile
+            :doc "Fetch user profile"
+            :schema {:input [:map [:user-id :int]]
+                     :output [:map [:profile [:map]]]}
+            :requires [:db]
+            :on-error nil}
+           :render
+           {:id :ui/render
+            :doc "Render output"
+            :schema {:input [:map [:profile [:map]]]
+                     :output [:map [:html :string]]}
+            :on-error nil}}
+   :edges {:start            {:ok :validate-session}
+           :validate-session {:authorized :fetch-profile, :unauthorized :end}
+           :fetch-profile    :render
+           :render           :end}
+   :dispatches {:start            [[:ok (constantly true)]]
+                :validate-session [[:authorized (fn [d] (:user-id d))]
+                                   [:unauthorized (fn [d] (not (:user-id d)))]]}
+   :regions {:auth       [:start :validate-session]
+             :data-fetch [:fetch-profile]}})
+
+;; ===== Round 1: Validation — region cells must exist =====
+
+(deftest region-cells-must-exist-test
+  (testing "Region referencing nonexistent cell throws"
+    (is (thrown-with-msg? Exception #"region.*nonexistent"
+          (manifest/validate-manifest
+            (assoc region-manifest
+                   :regions {:bad [:nonexistent]}))))))
+
+;; ===== Round 2: Validation — regions must not overlap =====
+
+(deftest regions-must-not-overlap-test
+  (testing "Two regions sharing a cell throws"
+    (is (thrown-with-msg? Exception #"overlap|multiple"
+          (manifest/validate-manifest
+            (assoc region-manifest
+                   :regions {:a [:start]
+                             :b [:start :validate-session]}))))))
+
+;; ===== Round 3: Basic region-brief returns cell info =====
+
+(deftest region-brief-returns-cells-test
+  (testing "region-brief returns cell info for each cell in region"
+    (let [brief (orchestrate/region-brief region-manifest :auth)]
+      (is (= 2 (count (:cells brief))))
+      (is (some #(= :auth/parse (:id %)) (:cells brief)))
+      (is (some #(= :auth/validate (:id %)) (:cells brief)))
+      (is (some #(some? (:schema %)) (:cells brief))))))
+
+;; ===== Round 4: region-brief returns internal edges =====
+
+(deftest region-brief-internal-edges-test
+  (testing "Edges between region cells appear in :internal-edges"
+    (let [brief (orchestrate/region-brief region-manifest :auth)]
+      (is (= {:start {:ok :validate-session}}
+             (:internal-edges brief))))))
+
+;; ===== Round 5: region-brief identifies entry points =====
+
+(deftest region-brief-entry-points-test
+  (testing "Entry points are cells reachable from outside the region"
+    (let [brief (orchestrate/region-brief region-manifest :auth)]
+      (is (= [:start] (:entry-points brief))))))
+
+;; ===== Round 6: region-brief identifies exit points =====
+
+(deftest region-brief-exit-points-test
+  (testing "Exit points are cells with edges leaving the region"
+    (let [brief (orchestrate/region-brief region-manifest :auth)]
+      ;; validate-session has :authorized → :fetch-profile (outside) and :unauthorized → :end
+      (is (= 1 (count (:exit-points brief))))
+      (let [exit (first (:exit-points brief))]
+        (is (= :validate-session (:cell exit)))
+        (is (= {:authorized :fetch-profile, :unauthorized :end}
+               (:transitions exit)))))))
+
+;; ===== Round 7: region-brief generates prompt =====
+
+(deftest region-brief-prompt-test
+  (testing "region-brief generates a prompt string"
+    (let [brief (orchestrate/region-brief region-manifest :auth)]
+      (is (string? (:prompt brief)))
+      (is (re-find #"auth" (:prompt brief)))
+      (is (re-find #"auth/parse" (:prompt brief)))
+      (is (re-find #"auth/validate" (:prompt brief))))))
+
+;; ===== Round 8: region-brief for unknown region throws =====
+
+(deftest region-brief-unknown-region-test
+  (testing "region-brief for nonexistent region throws"
+    (is (thrown-with-msg? Exception #"region.*:nonexistent"
+          (orchestrate/region-brief region-manifest :nonexistent)))))

--- a/test/mycelium/orchestrate_test.clj
+++ b/test/mycelium/orchestrate_test.clj
@@ -187,7 +187,19 @@
       (is (re-find #"auth/parse" (:prompt brief)))
       (is (re-find #"auth/validate" (:prompt brief))))))
 
-;; ===== Round 8: region-brief for unknown region throws =====
+;; ===== Round 8: region with unconditional exit edge =====
+
+(deftest region-brief-unconditional-exit-test
+  (testing "Region with unconditional edge leaving the region returns map transitions"
+    (let [brief (orchestrate/region-brief region-manifest :data-fetch)]
+      (is (= 1 (count (:exit-points brief))))
+      (let [exit (first (:exit-points brief))]
+        (is (= :fetch-profile (:cell exit)))
+        ;; Unconditional exit should be wrapped as a map for consistent interface
+        (is (map? (:transitions exit))
+            "Transitions should always be a map, even for unconditional edges")))))
+
+;; ===== Round 9: region-brief for unknown region throws =====
 
 (deftest region-brief-unknown-region-test
   (testing "region-brief for nonexistent region throws"


### PR DESCRIPTION
- Manifests can declare optional :regions — named groupings of cells for LLM context scoping
- orch/region-brief generates a focused brief with cell schemas, internal edges, entry/exit points, and a prompt string
- Validation ensures region cells exist and no cell appears in multiple regions
- Exit point :transitions is always a map for consistent interface (unconditional edges use {:unconditional :target})
- Purely informational — no runtime behavior change