### PR TITLE
Error groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ Move timeout logic from handlers to the workflow definition. When a cell exceeds
 
 The `:timeout` dispatch is auto-injected and evaluated first (before user predicates and `:default`). This is distinct from resilience `:timeout` policies — graph timeouts **route** to an alternative cell, resilience timeouts produce `:mycelium/resilience-error`.
 
+### Error Groups
+
+Declare shared error handling across sets of cells. If any cell in the group throws, the framework catches the exception, injects `:mycelium/error` into data, and routes to the group's error handler:
+
+```clojure
+(myc/run-workflow
+  {:cells {:fetch     :data/fetch
+           :transform :data/transform
+           :err       :data/handle-error}
+   :edges {:fetch     :transform
+           :transform :end
+           :err       :end}
+   :error-groups {:pipeline {:cells [:fetch :transform]
+                              :on-error :err}}}
+  {} {})
+```
+
+This is syntactic sugar — each grouped cell gets an `:on-error` edge and dispatch predicate injected at compile time. The error handler receives `:mycelium/error` with `{:cell :cell-name, :message "..."}`.
+
 ### Per-Transition Output Schemas
 
 Cells with multiple outgoing edges can declare different output schemas for each transition:
@@ -474,6 +493,7 @@ Declare compile-time path invariants that are checked against all enumerated wor
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware: validates member inputs and accumulates union of member outputs)
 - **Constraints** — path invariants checked against all enumerated paths
 - **Graph timeouts** — timeout cells exist, values are positive integers, cells have `:timeout` edge
+- **Error groups** — grouped cells exist, error handler exists, no cell in multiple groups
 - **Resilience validation** — policy keys are valid, referenced cells exist, timeout-ms is positive
 - **Join validation** — member cells exist, no name collisions with cells, members have no edges, output keys are disjoint (or `:merge-fn` provided), strategy is valid, no cell appears in multiple joins
 - **Region validation** (manifest) — region cells exist, no cell in multiple regions

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -160,9 +160,9 @@ The existing `cell-brief` and `orchestrate` module scope context per-cell well. 
 
 ---
 
-## 5. Overlapping States (Shared Error Handling)
+## ~~5. Overlapping States (Shared Error Handling)~~ (Implemented)
 
-**Value: Medium | Feasibility: Medium**
+**Value: Medium | Feasibility: Medium** — **DONE**
 
 The gap: "if ANY cell in this set fails, route to this handler" without wiring `:on-error` individually. Between fragments, interceptors, and the existing `:on-error` manifest field, most use cases are covered. This proposal targets the remaining gap.
 
@@ -217,7 +217,7 @@ Interceptors already fill this role. Workflow-level interceptors with `:pre`/`:p
 | Done | Global constraints | Medium | `enumerate-paths` (exists) |
 | Done | Graph-level timeouts | Medium | None (reuses join timeout pattern) |
 | Done | Region briefs | Small | None |
-| Deferred | Error groups | Small | None |
+| Done | Error groups | Small | None |
 | Skip | Edge actions | - | Covered by interceptors |
 
 **Recommended sequence**: Default transitions first (quick win, pairs well with halt/resume for safety), then global constraints (highest architectural value), then graph-level timeouts.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -162,6 +162,28 @@ Move timeout logic from handlers to the workflow definition. When a cell exceeds
 - Trace entries include `:timeout? true` when a cell times out
 - Distinct from resilience `:timeout` policies — graph timeouts **route**, resilience timeouts **error**
 
+### Error Groups
+
+Declare shared error handling for sets of cells. If any cell in the group throws, the framework catches the exception, injects `:mycelium/error` into data, and routes to the group's error handler:
+
+```clojure
+{:cells {:fetch     :data/fetch
+         :transform :data/transform
+         :err       :data/handle-error}
+ :edges {:fetch     :transform
+         :transform :end
+         :err       :end}
+ :error-groups {:pipeline {:cells [:fetch :transform]
+                            :on-error :err}}}
+```
+
+- At compile time, unconditional edges are expanded to map edges with `:on-error` target
+- `:on-error` dispatch predicate is auto-injected and evaluated first
+- `:mycelium/error` contains `{:cell :cell-name, :message "..."}` — available to the error handler
+- Output schema validation is skipped for errored cells
+- Error handler cells can `dissoc :mycelium/error` to clean up
+- Grouped cells must exist, error handler must exist, no cell in multiple groups
+
 ## Join Nodes (Fork-Join)
 
 When multiple independent cells can run concurrently, declare a join node:
@@ -433,6 +455,7 @@ Declare compile-time path invariants that are checked against all enumerated pat
 - **Schema chain** — each cell's input keys must be available from upstream outputs (join-aware)
 - **Constraints** — path invariants checked against all enumerated paths (see Constraints)
 - **Graph timeouts** — timeout cells exist, values are positive integers, cells have `:timeout` edge
+- **Error groups** — grouped cells exist, error handler exists, no cell in multiple groups
 - **Resilience validation** — policy keys valid, referenced cells exist, timeout-ms positive
 - **Join validation** — member cells exist, no name collisions, members have no edges, output keys disjoint (or `:merge-fn` provided)
 
@@ -651,6 +674,7 @@ A cell can pause the workflow by returning `:mycelium/halt` in its data. The wor
 | `:mycelium/schema-error` | Runtime schema violation details |
 | `:mycelium/join-error` | Join node error details |
 | `:mycelium/timeout` | `true` when a cell exceeded its graph-level timeout |
+| `:mycelium/error` | Error group error details (`{:cell :name, :message "..."}`) |
 | `:mycelium/resilience-error` | Resilience policy trigger details (`:type`, `:cell`, `:message`) |
 | `:mycelium/child-trace` | Nested workflow trace (composed cells) |
 | `:mycelium/halt` | Halt context (true or map) — present when workflow is halted |

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -148,7 +148,8 @@
                 ;; Skip output validation when resilience error or timeout is present
                 ;; (the handler was short-circuited)
                 error      (when-not (or (:mycelium/resilience-error data)
-                                         (:mycelium/timeout data))
+                                         (:mycelium/timeout data)
+                                         (:mycelium/error data))
                              (validate-output cell data transition))
                 ;; Extract duration-ms from the latest Maestro trace segment
                 duration-ms (some-> (:trace fsm-state) last :duration-ms)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -624,6 +624,110 @@
             state->cell
             timeouts)))
 
+;; ===== Error group expansion =====
+
+(defn- validate-error-groups!
+  "Validates :error-groups. Each group's cells must exist in :cells,
+   :on-error must reference a cell in :cells, and no cell may appear
+   in multiple groups."
+  [error-groups cells]
+  (let [cell-names (set (keys cells))
+        seen (atom {})]
+    (doseq [[group-name {:keys [cells on-error]}] error-groups]
+      (when-not (contains? cell-names on-error)
+        (throw (ex-info (str "error group " group-name " :on-error references :nonexistent cell " on-error)
+                        {:group group-name :on-error on-error})))
+      (doseq [cell-name cells]
+        (when-not (contains? cell-names cell-name)
+          (throw (ex-info (str "error group " group-name " references nonexistent cell :missing " cell-name)
+                          {:group group-name :cell cell-name})))
+        (when-let [other-group (get @seen cell-name)]
+          (throw (ex-info (str "Cell " cell-name " appears in multiple error groups: "
+                               other-group " and " group-name)
+                          {:cell cell-name :groups [other-group group-name]})))
+        (swap! seen assoc cell-name group-name)))))
+
+(defn- expand-error-group-edges
+  "Expands edges for cells in error groups. For cells with unconditional edges,
+   converts to map edge adding :on-error target. For cells with map edges,
+   adds :on-error entry if not already present."
+  [edges error-groups]
+  (let [cell->handler (into {}
+                        (mapcat (fn [[_ {:keys [cells on-error]}]]
+                                  (map (fn [c] [c on-error]) cells)))
+                        error-groups)]
+    (reduce (fn [acc [cell-name handler-name]]
+              (let [edge-def (get acc cell-name)]
+                (cond
+                  ;; No edge — shouldn't happen (validation catches), skip
+                  (nil? edge-def) acc
+                  ;; Unconditional edge → convert to map with :on-error
+                  (keyword? edge-def)
+                  (assoc acc cell-name {:done edge-def :on-error handler-name})
+                  ;; Map edge — add :on-error if not present
+                  (and (map? edge-def) (not (contains? edge-def :on-error)))
+                  (assoc acc cell-name (assoc edge-def :on-error handler-name))
+                  ;; Already has :on-error — leave as-is
+                  :else acc)))
+            edges
+            cell->handler)))
+
+(defn- inject-error-group-dispatches
+  "For cells in error groups, auto-injects an :on-error dispatch predicate
+   that checks for :mycelium/error. Also injects a :done predicate for cells
+   whose edges were expanded from unconditional to map."
+  [dispatches-map error-groups edges]
+  (let [cell->handler (into {}
+                        (mapcat (fn [[_ {:keys [cells on-error]}]]
+                                  (map (fn [c] [c on-error]) cells)))
+                        error-groups)]
+    (reduce (fn [acc [cell-name _]]
+              (let [dispatch-vec (get acc cell-name [])
+                    has-on-error? (some #(= :on-error (first %)) dispatch-vec)
+                    error-pred [:on-error (fn [d] (some? (:mycelium/error d)))]]
+                (if has-on-error?
+                  acc
+                  (let [;; If cell had unconditional edge (now expanded to {:done X :on-error Y}),
+                        ;; add [:done (constantly true)] if not present
+                        edge-def (get edges cell-name)
+                        has-done? (some #(= :done (first %)) dispatch-vec)
+                        needs-done? (and (map? edge-def) (contains? edge-def :done) (not has-done?))
+                        with-done (if needs-done?
+                                    (conj (vec dispatch-vec) [:done (constantly true)])
+                                    dispatch-vec)
+                        ;; Insert :on-error first so it takes priority
+                        {defaults true others false} (group-by #(= :default (first %)) with-done)]
+                    (assoc acc cell-name (vec (concat [error-pred] others defaults)))))))
+            (or dispatches-map {})
+            cell->handler)))
+
+(defn- wrap-handler-with-error-catch
+  "Wraps a cell handler with try/catch. On error, returns data with
+   :mycelium/error {:cell cell-name, :message msg}."
+  [handler cell-name]
+  (fn [resources data]
+    (try
+      (handler resources data)
+      (catch Throwable e
+        (assoc data :mycelium/error
+               {:cell    cell-name
+                :message (or (ex-message e) (.toString e))})))))
+
+(defn- apply-error-group-wrapping
+  "Wraps handlers of cells in error groups with try/catch error catching."
+  [state->cell error-groups]
+  (if (empty? error-groups)
+    state->cell
+    (let [grouped-cells (set (mapcat :cells (vals error-groups)))]
+      (reduce (fn [acc cell-name]
+                (let [state-id (resolve-state-id cell-name)]
+                  (if-let [cell (get acc state-id)]
+                    (assoc acc state-id
+                           (update cell :handler wrap-handler-with-error-catch cell-name))
+                    acc)))
+              state->cell
+              grouped-cells))))
+
 ;; ===== Constraint validation =====
 
 (defn- enumerate-workflow-paths
@@ -727,46 +831,56 @@
   [{:keys [cells edges dispatches joins input-schema pipeline] :as raw-workflow}]
   (let [{:keys [cells edges dispatches joins input-schema]} (expand-pipeline raw-workflow)]
     (validate-cells-exist! cells)
-    ;; Validate :default edge usage (must not be sole edge)
-    (validate-default-edges! edges)
-    ;; Normalize to {name → cell-id} for all downstream validation
-    (let [cell-ids (cells->ids cells)]
-      ;; Validate :input-schema well-formedness if present
-      (when input-schema
-        (v/validate-malli-schema! input-schema "input-schema"))
-      ;; Validate :resilience policies if present
-      (when-let [resilience (:resilience raw-workflow)]
-        (resilience/validate-resilience! resilience cell-ids))
-      ;; Validate join definitions
-      (let [joins-map (or joins {})]
-        (when (seq joins-map)
-          (validate-join-defs! joins-map cell-ids edges)
-          (validate-join-output-conflicts! joins-map cell-ids))
-        ;; For edge-target and reachability validation, include join names as valid targets
-        (let [cell-names     (set (keys cell-ids))
-              join-names     (set (keys joins-map))
-              join-members   (set (mapcat :cells (vals joins-map)))
-              edge-cell-names (set/difference cell-names join-members)
-              valid-names    (set/union edge-cell-names join-names)]
-          (v/validate-edge-targets! edges valid-names)
-          (v/validate-reachability! edges valid-names))
-        ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
-        ;; Also auto-inject :default catch-all predicates
-        ;; Join dispatches take priority (merged last) since joins compute their own dispatches
-        (let [timeouts-map        (or (:timeouts raw-workflow) {})
-              with-timeouts      (inject-timeout-dispatches dispatches timeouts-map edges)
-              with-defaults      (inject-default-dispatches with-timeouts edges)
-              join-dispatches    (compute-join-dispatches joins-map edges)
-              effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
-                                          join-dispatches)]
-          (v/validate-dispatch-coverage! edges effective-dispatches))
-        (validate-schema-chain! edges cell-ids joins-map)
-        ;; Validate graph-level timeouts
-        (when-let [timeouts (:timeouts raw-workflow)]
-          (validate-timeouts! timeouts cells edges))
-        ;; Validate constraints (after all structural validations pass)
-        (when-let [constraints (:constraints raw-workflow)]
-          (validate-constraints! constraints edges))))))
+    ;; Validate and expand error groups (must happen before edge/dispatch validation)
+    (let [error-groups (or (:error-groups raw-workflow) {})
+          _            (when (seq error-groups)
+                         (validate-error-groups! error-groups cells))
+          edges        (if (seq error-groups)
+                         (expand-error-group-edges edges error-groups)
+                         edges)
+          dispatches   (if (seq error-groups)
+                         (inject-error-group-dispatches dispatches error-groups edges)
+                         dispatches)]
+      ;; Validate :default edge usage (must not be sole edge)
+      (validate-default-edges! edges)
+      ;; Normalize to {name → cell-id} for all downstream validation
+      (let [cell-ids (cells->ids cells)]
+        ;; Validate :input-schema well-formedness if present
+        (when input-schema
+          (v/validate-malli-schema! input-schema "input-schema"))
+        ;; Validate :resilience policies if present
+        (when-let [resilience (:resilience raw-workflow)]
+          (resilience/validate-resilience! resilience cell-ids))
+        ;; Validate join definitions
+        (let [joins-map (or joins {})]
+          (when (seq joins-map)
+            (validate-join-defs! joins-map cell-ids edges)
+            (validate-join-output-conflicts! joins-map cell-ids))
+          ;; For edge-target and reachability validation, include join names as valid targets
+          (let [cell-names     (set (keys cell-ids))
+                join-names     (set (keys joins-map))
+                join-members   (set (mapcat :cells (vals joins-map)))
+                edge-cell-names (set/difference cell-names join-members)
+                valid-names    (set/union edge-cell-names join-names)]
+            (v/validate-edge-targets! edges valid-names)
+            (v/validate-reachability! edges valid-names))
+          ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
+          ;; Also auto-inject :default catch-all predicates
+          ;; Join dispatches take priority (merged last) since joins compute their own dispatches
+          (let [timeouts-map        (or (:timeouts raw-workflow) {})
+                with-timeouts      (inject-timeout-dispatches dispatches timeouts-map edges)
+                with-defaults      (inject-default-dispatches with-timeouts edges)
+                join-dispatches    (compute-join-dispatches joins-map edges)
+                effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
+                                            join-dispatches)]
+            (v/validate-dispatch-coverage! edges effective-dispatches))
+          (validate-schema-chain! edges cell-ids joins-map)
+          ;; Validate graph-level timeouts
+          (when-let [timeouts (:timeouts raw-workflow)]
+            (validate-timeouts! timeouts cells edges))
+          ;; Validate constraints (after all structural validations pass)
+          (when-let [constraints (:constraints raw-workflow)]
+            (validate-constraints! constraints edges)))))))
 
 ;; ===== Workflow-level interceptor matching =====
 
@@ -886,7 +1000,15 @@
    (let [{:keys [cells edges dispatches joins] :as workflow} (expand-pipeline raw-workflow)]
      ;; Validate
      (validate-workflow workflow)
-     (let [;; Normalize cells to {name → cell-id} for compilation
+     (let [;; Expand error groups (edges + dispatches) before other processing
+           error-groups (or (:error-groups workflow) {})
+           edges        (if (seq error-groups)
+                          (expand-error-group-edges edges error-groups)
+                          edges)
+           dispatches   (if (seq error-groups)
+                          (inject-error-group-dispatches dispatches error-groups edges)
+                          dispatches)
+           ;; Normalize cells to {name → cell-id} for compilation
            cell-ids (cells->ids cells)
            cell-params (cells->params cells)
            joins-map (or joins {})
@@ -946,6 +1068,8 @@
                        state->cell)
          ;; Apply graph-level timeouts (wraps handlers with timeout logic)
          state->cell (apply-graph-timeouts state->cell timeouts-map)
+         ;; Apply error group wrapping (try/catch → :mycelium/error)
+         state->cell (apply-error-group-wrapping state->cell error-groups)
          ;; Apply workflow-level interceptors (wraps cell handlers)
          wf-interceptors (:interceptors workflow)
          state->cell (apply-workflow-interceptors state->cell cell-ids wf-interceptors)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -635,11 +635,11 @@
         seen (atom {})]
     (doseq [[group-name {:keys [cells on-error]}] error-groups]
       (when-not (contains? cell-names on-error)
-        (throw (ex-info (str "error group " group-name " :on-error references :nonexistent cell " on-error)
+        (throw (ex-info (str "error group " group-name " :on-error references nonexistent cell " on-error)
                         {:group group-name :on-error on-error})))
       (doseq [cell-name cells]
         (when-not (contains? cell-names cell-name)
-          (throw (ex-info (str "error group " group-name " references nonexistent cell :missing " cell-name)
+          (throw (ex-info (str "error group " group-name " references nonexistent cell " cell-name)
                           {:group group-name :cell cell-name})))
         (when-let [other-group (get @seen cell-name)]
           (throw (ex-info (str "Cell " cell-name " appears in multiple error groups: "
@@ -703,15 +703,26 @@
 
 (defn- wrap-handler-with-error-catch
   "Wraps a cell handler with try/catch. On error, returns data with
-   :mycelium/error {:cell cell-name, :message msg}."
-  [handler cell-name]
-  (fn [resources data]
-    (try
-      (handler resources data)
-      (catch Throwable e
-        (assoc data :mycelium/error
-               {:cell    cell-name
-                :message (or (ex-message e) (.toString e))})))))
+   :mycelium/error {:cell cell-name, :message msg}.
+   Handles both sync (2-arity) and async (4-arity) handlers."
+  [handler cell-name async?]
+  (let [make-error (fn [data e]
+                     (assoc data :mycelium/error
+                            {:cell    cell-name
+                             :message (or (ex-message e) (.toString e))}))]
+    (if async?
+      (fn [resources data callback error-callback]
+        (try
+          (handler resources data
+                   callback
+                   (fn [e] (callback (make-error data e))))
+          (catch Throwable e
+            (callback (make-error data e)))))
+      (fn [resources data]
+        (try
+          (handler resources data)
+          (catch Throwable e
+            (make-error data e)))))))
 
 (defn- apply-error-group-wrapping
   "Wraps handlers of cells in error groups with try/catch error catching."
@@ -723,7 +734,7 @@
                 (let [state-id (resolve-state-id cell-name)]
                   (if-let [cell (get acc state-id)]
                     (assoc acc state-id
-                           (update cell :handler wrap-handler-with-error-catch cell-name))
+                           (update cell :handler wrap-handler-with-error-catch cell-name (:async? cell)))
                     acc)))
               state->cell
               grouped-cells))))

--- a/test/mycelium/error_groups_test.clj
+++ b/test/mycelium/error_groups_test.clj
@@ -1,0 +1,176 @@
+(ns mycelium.error-groups-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+(defn- make-cell
+  ([id] (make-cell id (fn [_ data] (assoc data id true))))
+  ([id handler]
+   (defmethod cell/cell-spec id [_]
+     {:id id
+      :handler handler
+      :schema {:input [:map] :output [:map]}})))
+
+;; ===== Round 1: Basic error group routing =====
+
+(deftest error-group-routes-to-handler-test
+  (testing "Cell in error group that throws routes to the group's error handler"
+    (make-cell :c/explode (fn [_ _data]
+                            (throw (ex-info "boom" {:reason :test}))))
+    (make-cell :c/error-handler)
+    (make-cell :c/next)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/explode
+                            :next :c/next
+                            :err :c/error-handler}
+                    :edges {:start :next
+                            :next :end
+                            :err :end}
+                    :error-groups {:pipeline {:cells [:start]
+                                              :on-error :err}}}
+                   {} {})]
+      (is (true? (:c/error-handler result))
+          "Error handler cell ran")
+      (is (nil? (:c/next result))
+          "Normal next cell did not run"))))
+
+;; ===== Round 2: No error — normal routing unaffected =====
+
+(deftest error-group-no-error-test
+  (testing "Cell in error group that succeeds routes normally"
+    (make-cell :c/ok (fn [_ data] (assoc data :result "fine")))
+    (make-cell :c/next2)
+    (make-cell :c/err2)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/ok
+                            :next :c/next2
+                            :err :c/err2}
+                    :edges {:start :next
+                            :next :end
+                            :err :end}
+                    :error-groups {:pipeline {:cells [:start]
+                                              :on-error :err}}}
+                   {} {})]
+      (is (= "fine" (:result result))
+          "Handler result is present")
+      (is (true? (:c/next2 result))
+          "Normal next cell ran")
+      (is (nil? (:mycelium/error result))
+          "No error flag"))))
+
+;; ===== Round 3: Validation — error handler must exist =====
+
+(deftest error-group-handler-must-exist-test
+  (testing "Error group :on-error must reference a cell in :cells"
+    (make-cell :c/val3)
+
+    (is (thrown-with-msg? Exception #"error.*group.*:nonexistent|on-error.*:nonexistent"
+          (myc/run-workflow
+            {:cells {:start :c/val3}
+             :edges {:start :end}
+             :error-groups {:grp {:cells [:start]
+                                   :on-error :nonexistent}}}
+            {} {})))))
+
+;; ===== Round 4: Validation — grouped cells must exist =====
+
+(deftest error-group-cells-must-exist-test
+  (testing "Error group cells must exist in :cells"
+    (make-cell :c/val4)
+    (make-cell :c/err4)
+
+    (is (thrown-with-msg? Exception #"error.*group.*:missing"
+          (myc/run-workflow
+            {:cells {:start :c/val4, :err :c/err4}
+             :edges {:start :end, :err :end}
+             :error-groups {:grp {:cells [:missing]
+                                   :on-error :err}}}
+            {} {})))))
+
+;; ===== Round 5: Validation — groups must not overlap =====
+
+(deftest error-groups-must-not-overlap-test
+  (testing "Cell in two error groups throws"
+    (make-cell :c/val5)
+    (make-cell :c/err5a)
+    (make-cell :c/err5b)
+
+    (is (thrown-with-msg? Exception #"multiple.*error.*group|overlap"
+          (myc/run-workflow
+            {:cells {:start :c/val5, :erra :c/err5a, :errb :c/err5b}
+             :edges {:start :end, :erra :end, :errb :end}
+             :error-groups {:a {:cells [:start] :on-error :erra}
+                            :b {:cells [:start] :on-error :errb}}}
+            {} {})))))
+
+;; ===== Round 6: Error group with map edges =====
+
+(deftest error-group-with-map-edges-test
+  (testing "Cell with map edges that throws routes to error handler"
+    (make-cell :c/explode6 (fn [_ _data]
+                              (throw (ex-info "map-edge-fail" {}))))
+    (make-cell :c/ok-target)
+    (make-cell :c/err6)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/explode6
+                            :ok :c/ok-target
+                            :err :c/err6}
+                    :edges {:start {:done :ok, :on-error :err}
+                            :ok :end
+                            :err :end}
+                    :dispatches {:start [[:done (fn [d] (not (:mycelium/error d)))]]}
+                    :error-groups {:grp {:cells [:start]
+                                         :on-error :err}}}
+                   {} {})]
+      (is (true? (:c/err6 result))
+          "Error handler ran")
+      (is (nil? (:c/ok-target result))
+          "Normal target did not run"))))
+
+;; ===== Round 7: Error data includes cell name and message =====
+
+(deftest error-data-contents-test
+  (testing ":mycelium/error contains cell name and message"
+    (make-cell :c/explode7 (fn [_ _data]
+                              (throw (ex-info "detailed-error" {:key :val}))))
+    (make-cell :c/err7 (fn [_ data]
+                          ;; Preserve the error info for assertion
+                          (assoc data :captured-error (:mycelium/error data))))
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/explode7, :err :c/err7}
+                    :edges {:start :end, :err :end}
+                    :error-groups {:grp {:cells [:start]
+                                         :on-error :err}}}
+                   {} {})
+          err (:captured-error result)]
+      (is (some? err) "Error data captured")
+      (is (= :start (:cell err)) "Error has cell name")
+      (is (= "detailed-error" (:message err)) "Error has message"))))
+
+;; ===== Round 8: :mycelium/error is cleaned up after error handler =====
+
+(deftest error-handler-can-clear-error-test
+  (testing "Error handler can dissoc :mycelium/error to clean up"
+    (make-cell :c/explode8 (fn [_ _data]
+                              (throw (ex-info "cleanup-test" {}))))
+    (make-cell :c/err8 (fn [_ data]
+                          (-> data
+                              (dissoc :mycelium/error)
+                              (assoc :recovered true))))
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/explode8, :err :c/err8}
+                    :edges {:start :end, :err :end}
+                    :error-groups {:grp {:cells [:start]
+                                         :on-error :err}}}
+                   {} {})]
+      (is (nil? (:mycelium/error result))
+          "Error handler cleaned up the error")
+      (is (true? (:recovered result))
+          "Error handler ran"))))

--- a/test/mycelium/error_groups_test.clj
+++ b/test/mycelium/error_groups_test.clj
@@ -174,3 +174,55 @@
           "Error handler cleaned up the error")
       (is (true? (:recovered result))
           "Error handler ran"))))
+
+;; ===== Round 9: Async cell in error group =====
+
+(deftest error-group-async-cell-test
+  (testing "Async cell in error group that errors routes to handler"
+    (defmethod cell/cell-spec :c/async-explode [_]
+      {:id :c/async-explode
+       :handler (fn [_resources _data _callback error-cb]
+                  (future
+                    (error-cb (ex-info "async-boom" {}))))
+       :async? true
+       :schema {:input [:map] :output [:map]}})
+    (make-cell :c/async-err)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/async-explode, :err :c/async-err}
+                    :edges {:start :end, :err :end}
+                    :error-groups {:grp {:cells [:start]
+                                         :on-error :err}}}
+                   {} {})]
+      (is (true? (:c/async-err result))
+          "Error handler ran")
+      (is (= :start (get-in result [:mycelium/error :cell]))
+          "Error has cell name"))))
+
+;; ===== Round 10: Error group + timeout interaction =====
+
+(deftest error-group-with-timeout-test
+  (testing "Timeout takes priority over error group catch"
+    (make-cell :c/slow-explode (fn [_ data]
+                                  (Thread/sleep 200)
+                                  (throw (ex-info "should-not-reach" {}))))
+    (make-cell :c/timeout-handler)
+    (make-cell :c/error-handler10)
+
+    (let [result (myc/run-workflow
+                   {:cells {:start :c/slow-explode
+                            :timeout-cell :c/timeout-handler
+                            :err :c/error-handler10}
+                    :edges {:start {:done :end, :timeout :timeout-cell}
+                            :timeout-cell :end
+                            :err :end}
+                    :dispatches {:start [[:done (fn [d] (not (or (:mycelium/timeout d)
+                                                                  (:mycelium/error d))))]]}
+                    :timeouts {:start 50}
+                    :error-groups {:grp {:cells [:start]
+                                         :on-error :err}}}
+                   {} {})]
+      (is (true? (:c/timeout-handler result))
+          "Timeout handler ran (timeout fires before error)")
+      (is (nil? (:c/error-handler10 result))
+          "Error handler did not run"))))


### PR DESCRIPTION
Error groups let you declare shared error handling for sets of cells. Instead of wiring :on-error edges individually, you group related cells and name a single error handler — the framework catches exceptions from any cell in the group, injects :mycelium/error with the cell name and message, and routes to the handler automatically. Works with both sync and async cells, and composes cleanly with timeouts and default transitions.