### PR TITLE
Workflow store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-03-06
+
+### WorkflowStore Persistence Protocol
+
+Formal persistence layer for halt/resume. `WorkflowStore` protocol with `save-workflow!`, `load-workflow`, `delete-workflow!`, `list-workflows`. Includes an in-memory implementation for dev/testing. Store-aware helpers (`run-with-store`, `resume-with-store`) auto-persist on halt, auto-delete on completion, and reuse session IDs across re-halts.
+
+```clojure
+(def s (store/memory-store))
+(def halted (store/run-with-store compiled resources data s))
+(store/resume-with-store compiled resources (:mycelium/session-id halted) s {:approved true})
+```
+
 ## 2026-03-05
 
 ### Error Groups

--- a/README.md
+++ b/README.md
@@ -463,6 +463,24 @@ Key behaviors:
 - If the halting cell dispatches to a branch, resume continues on the correct branch
 - Calling `resume-compiled` on a non-halted result throws an exception
 
+### Persistent Store
+
+For workflows that halt across process restarts, use the `WorkflowStore` protocol to auto-persist halted state:
+
+```clojure
+(require '[mycelium.store :as store])
+
+(def s (store/memory-store))  ;; or your DB/Redis implementation
+
+;; Run — persists on halt, returns {:mycelium/session-id id}
+(def halted (store/run-with-store compiled resources initial-data s))
+
+;; Resume by session ID — loads from store, cleans up on completion
+(store/resume-with-store compiled resources (:mycelium/session-id halted) s {:approved true})
+```
+
+Implement `WorkflowStore` for your backend — the protocol has four methods: `save-workflow!`, `load-workflow`, `delete-workflow!`, `list-workflows`.
+
 ## Constraints
 
 Declare compile-time path invariants that are checked against all enumerated workflow paths:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -665,6 +665,42 @@ A cell can pause the workflow by returning `:mycelium/halt` in its data. The wor
 - **Halt trace entry** — the trace entry for the halting cell has `:halted true`
 - **Resume validation** — calling `resume-compiled` on a non-halted result throws an exception
 
+### Persistent Store
+
+For workflows that halt across process restarts or sessions, use the `WorkflowStore` protocol to persist and retrieve halted state:
+
+```clojure
+(require '[mycelium.store :as store])
+
+;; In-memory store (dev/testing)
+(def s (store/memory-store))
+
+;; Run — auto-persists on halt, returns {:mycelium/session-id id, :mycelium/halt context}
+(def halted (store/run-with-store compiled resources initial-data s))
+
+;; Resume by session ID — loads from store, resumes, cleans up on completion
+(def result (store/resume-with-store compiled resources (:mycelium/session-id halted) s))
+
+;; Resume with human input
+(store/resume-with-store compiled resources session-id s {:approved true})
+```
+
+Implement the protocol for your persistence backend (DB, Redis, etc.):
+
+```clojure
+(defrecord MyStore [conn]
+  store/WorkflowStore
+  (save-workflow! [_ session-id data] ...)
+  (load-workflow [_ session-id] ...)
+  (delete-workflow! [_ session-id] ...)
+  (list-workflows [_] ...))
+```
+
+- On halt: state persisted, `:mycelium/session-id` returned (`:mycelium/resume` hidden from caller)
+- On resume completion: state deleted from store automatically
+- On re-halt: store updated with new state, same session ID reused
+- Custom session IDs: `(store/run-with-store compiled res data s {:session-id "my-id"})`
+
 ## Workflow Result Keys
 
 | Key | Description |
@@ -679,3 +715,4 @@ A cell can pause the workflow by returning `:mycelium/halt` in its data. The wor
 | `:mycelium/child-trace` | Nested workflow trace (composed cells) |
 | `:mycelium/halt` | Halt context (true or map) — present when workflow is halted |
 | `:mycelium/resume` | Resume state token — present when workflow is halted |
+| `:mycelium/session-id` | Store session ID — present when using `run-with-store`/`resume-with-store` on halt |

--- a/examples/expense_approval/README.md
+++ b/examples/expense_approval/README.md
@@ -1,0 +1,88 @@
+# Expense Approval Example
+
+A human-in-the-loop expense approval workflow demonstrating Mycelium's halt/resume and `WorkflowStore` persistence.
+
+## Running
+
+```bash
+cd examples/expense_approval
+clj -M:test
+```
+
+## Domain
+
+Employees submit expense reports. Small expenses are auto-approved; larger ones halt the workflow and wait for a manager to approve or reject via the persistent store.
+
+### Decision Flow
+
+```mermaid
+flowchart TD
+    START[validate] --> |valid| CAT[categorize]
+    START --> |invalid| END1((end))
+
+    CAT --> |small ≤ $100| AUTO[auto-approve]
+    CAT --> |medium/large| REQ[request-approval]
+
+    REQ --> |"⏸ HALT — awaits manager"| DEC[record-decision]
+
+    AUTO --> NOTIFY[notify]
+    DEC --> NOTIFY
+    NOTIFY --> END2((end))
+
+    style REQ fill:#fff3e0,stroke:#ef6c00
+    style DEC fill:#e8f5e9
+```
+
+## Store Lifecycle
+
+```clojure
+(require '[mycelium.store :as store])
+
+(def s (store/memory-store))
+
+;; 1. Employee submits $750 expense → halts for approval
+(def halted (store/run-with-store compiled {} expense-data s))
+;; => {:mycelium/session-id "abc-123", :mycelium/halt {:reason :manager-approval-needed, ...}}
+
+;; 2. Later — manager looks up pending workflows
+(store/list-workflows s)
+;; => ("abc-123")
+
+;; 3. Manager approves
+(store/resume-with-store compiled {} "abc-123" s {:manager-approved true, :manager-name "eve"})
+;; => {:decision :approved, :notification {...}, ...}
+
+;; 4. Session automatically cleaned up
+(store/list-workflows s)
+;; => ()
+```
+
+## Cells
+
+| Cell | Purpose | Halts? |
+|------|---------|--------|
+| `:expense/validate` | Check required fields | No |
+| `:expense/categorize` | Route by amount | No |
+| `:expense/auto-approve` | Approve small expenses | No |
+| `:expense/request-approval` | Halt for manager review | **Yes** |
+| `:expense/record-decision` | Record approve/reject after resume | No |
+| `:expense/notify` | Send notification | No |
+
+## Mycelium Features Exercised
+
+- **Halt/resume** — `request-approval` halts with context; `record-decision` runs after resume with manager input
+- **WorkflowStore** — `run-with-store` / `resume-with-store` for persistent session management
+- **`:default` transitions** — invalid expenses and non-small categories route via `:default`
+- **Per-transition output schemas** — `validate` declares different output for `:valid` vs `:invalid`
+- **Schema chain validation** — compile-time verification that each cell receives required keys
+
+## File Structure
+
+```
+src/expense/
+  cells.clj         6 cell registrations
+  workflows.clj     workflow definition + pre-compilation
+
+test/expense/
+  workflow_test.clj  8 tests — direct run/resume + store-backed lifecycle
+```

--- a/examples/expense_approval/deps.edn
+++ b/examples/expense_approval/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps  {io.github.yogthos/mycelium {:local/root "../.."}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+         :main-opts   ["-m" "kaocha.runner"]}}}

--- a/examples/expense_approval/src/expense/cells.clj
+++ b/examples/expense_approval/src/expense/cells.clj
@@ -1,0 +1,102 @@
+(ns expense.cells
+  (:require [mycelium.cell :as cell]))
+
+;; --- Validate expense report ---
+
+(defmethod cell/cell-spec :expense/validate [_]
+  {:id      :expense/validate
+   :handler (fn [_ data]
+              (let [{:keys [amount description]} data]
+                (cond
+                  (nil? amount)
+                  (assoc data :validation-status :invalid
+                              :validation-error "Amount is required")
+
+                  (not (pos? amount))
+                  (assoc data :validation-status :invalid
+                              :validation-error "Amount must be positive")
+
+                  (empty? description)
+                  (assoc data :validation-status :invalid
+                              :validation-error "Description is required")
+
+                  :else
+                  (assoc data :validation-status :valid))))
+   :schema {:input  [:map [:amount [:maybe number?]] [:description :string]]
+            :output {:valid   [:map [:validation-status [:= :valid]]]
+                     :invalid [:map [:validation-status [:= :invalid]]
+                                    [:validation-error :string]]}}})
+
+;; --- Categorize by amount ---
+
+(defmethod cell/cell-spec :expense/categorize [_]
+  {:id      :expense/categorize
+   :handler (fn [_ data]
+              (let [amount (:amount data)]
+                (assoc data :category
+                       (cond
+                         (<= amount 100)  :small
+                         (<= amount 1000) :medium
+                         :else            :large))))
+   :schema {:input  [:map [:amount number?]]
+            :output [:map [:category [:enum :small :medium :large]]]}})
+
+;; --- Auto-approve small expenses ---
+
+(defmethod cell/cell-spec :expense/auto-approve [_]
+  {:id      :expense/auto-approve
+   :handler (fn [_ data]
+              (assoc data :decision :approved
+                          :approved-by "policy:auto-small"))
+   :schema {:input  [:map]
+            :output [:map [:decision [:= :approved]]
+                          [:approved-by :string]]}})
+
+;; --- Request manager approval (halts workflow) ---
+
+(defmethod cell/cell-spec :expense/request-approval [_]
+  {:id      :expense/request-approval
+   :handler (fn [_ data]
+              (assoc data :mycelium/halt
+                     {:reason     :manager-approval-needed
+                      :message    (str "Expense of $" (:amount data) " requires manager approval")
+                      :expense-id (:expense-id data)
+                      :amount     (:amount data)}))
+   :schema {:input  [:map [:amount number?]]
+            :output [:map]}})
+
+;; --- Record manager decision (runs after resume) ---
+;; :manager-approved and :manager-name come from resume merge-data,
+;; so input uses open [:map] (schema chain can't track external input).
+
+(defmethod cell/cell-spec :expense/record-decision [_]
+  {:id      :expense/record-decision
+   :handler (fn [_ data]
+              (let [{:keys [manager-approved manager-name]} data]
+                (if manager-approved
+                  (assoc data :decision :approved
+                              :approved-by (str "manager:" manager-name))
+                  (assoc data :decision :rejected
+                              :rejected-by (str "manager:" manager-name)
+                              :rejection-reason (or (:rejection-reason data)
+                                                    "Manager declined")))))
+   :schema {:input  [:map]
+            :output [:map [:decision [:enum :approved :rejected]]]}})
+
+;; --- Send notification ---
+;; :submitter comes from initial data (not tracked by schema chain).
+
+(defmethod cell/cell-spec :expense/notify [_]
+  {:id      :expense/notify
+   :handler (fn [_ data]
+              (assoc data :notification
+                     {:to      (:submitter data)
+                      :subject (str "Expense " (name (:decision data)))
+                      :body    (if (= :approved (:decision data))
+                                 (str "Your expense of $" (:amount data) " has been approved.")
+                                 (str "Your expense of $" (:amount data) " was rejected: "
+                                      (:rejection-reason data "")))}))
+   :schema {:input  [:map [:decision [:enum :approved :rejected]]]
+            :output [:map [:notification [:map [:to [:maybe :string]]
+                                               [:subject :string]
+                                               [:body :string]]]]}})

--- a/examples/expense_approval/src/expense/workflows.clj
+++ b/examples/expense_approval/src/expense/workflows.clj
@@ -1,0 +1,23 @@
+(ns expense.workflows
+  (:require [expense.cells]
+            [mycelium.core :as myc]))
+
+(def expense-workflow
+  {:cells {:start      :expense/validate
+           :categorize :expense/categorize
+           :auto       :expense/auto-approve
+           :request    :expense/request-approval
+           :decision   :expense/record-decision
+           :notify     :expense/notify}
+
+   :edges {:start      {:valid :categorize, :default :end}
+           :categorize {:small :auto, :default :request}
+           :auto       :notify
+           :request    :decision
+           :decision   :notify
+           :notify     :end}
+
+   :dispatches {:start      [[:valid (fn [d] (= :valid (:validation-status d)))]]
+                :categorize [[:small (fn [d] (= :small (:category d)))]]}})
+
+(def compiled (myc/pre-compile expense-workflow))

--- a/examples/expense_approval/test/expense/workflow_test.clj
+++ b/examples/expense_approval/test/expense/workflow_test.clj
@@ -1,0 +1,136 @@
+(ns expense.workflow-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [expense.workflows :as wf]
+            [mycelium.core :as myc]
+            [mycelium.store :as store]))
+
+;; --- Direct run/resume (no store) ---
+
+(deftest small-expense-auto-approved-test
+  (testing "Expenses <= $100 are auto-approved without halting"
+    (let [result (myc/run-compiled wf/compiled {}
+                   {:expense-id  "EXP-001"
+                    :submitter   "alice@co.com"
+                    :amount      50
+                    :description "Office supplies"})]
+      (is (= :approved (:decision result)))
+      (is (= "policy:auto-small" (:approved-by result)))
+      (is (= "alice@co.com" (get-in result [:notification :to]))))))
+
+(deftest medium-expense-halts-for-approval-test
+  (testing "Expenses > $100 halt for manager approval"
+    (let [result (myc/run-compiled wf/compiled {}
+                   {:expense-id  "EXP-002"
+                    :submitter   "bob@co.com"
+                    :amount      500
+                    :description "Conference ticket"})]
+      (is (some? (:mycelium/halt result)) "Workflow halted")
+      (is (= :manager-approval-needed (get-in result [:mycelium/halt :reason])))
+      (is (= 500 (get-in result [:mycelium/halt :amount]))))))
+
+(deftest resume-approved-test
+  (testing "Manager approves → notification sent"
+    (let [halted (myc/run-compiled wf/compiled {}
+                   {:expense-id  "EXP-003"
+                    :submitter   "bob@co.com"
+                    :amount      500
+                    :description "Conference ticket"})
+          result (myc/resume-compiled wf/compiled {} halted
+                   {:manager-approved true
+                    :manager-name     "carol"})]
+      (is (= :approved (:decision result)))
+      (is (= "manager:carol" (:approved-by result)))
+      (is (= "bob@co.com" (get-in result [:notification :to]))))))
+
+(deftest resume-rejected-test
+  (testing "Manager rejects → rejection notification sent"
+    (let [halted (myc/run-compiled wf/compiled {}
+                   {:expense-id  "EXP-004"
+                    :submitter   "bob@co.com"
+                    :amount      2000
+                    :description "New laptop"})
+          result (myc/resume-compiled wf/compiled {} halted
+                   {:manager-approved false
+                    :manager-name     "carol"
+                    :rejection-reason "Over budget"})]
+      (is (= :rejected (:decision result)))
+      (is (= "manager:carol" (:rejected-by result)))
+      (is (clojure.string/includes?
+            (get-in result [:notification :body]) "rejected")))))
+
+(deftest invalid-expense-test
+  (testing "Invalid expense exits early"
+    (let [result (myc/run-compiled wf/compiled {}
+                   {:expense-id  "EXP-005"
+                    :submitter   "bob@co.com"
+                    :amount      -10
+                    :description "Bad expense"})]
+      (is (= :invalid (:validation-status result)))
+      (is (nil? (:decision result))))))
+
+;; --- Store-backed workflow ---
+
+(deftest store-full-lifecycle-test
+  (testing "Full halt/resume cycle through the store"
+    (let [s (store/memory-store)
+
+          ;; 1. Submit expense — halts for approval
+          halted (store/run-with-store wf/compiled {}
+                   {:expense-id  "EXP-100"
+                    :submitter   "dave@co.com"
+                    :amount      750
+                    :description "Team dinner"}
+                   s)
+          sid (:mycelium/session-id halted)]
+
+      (is (string? sid) "Got a session ID back")
+      (is (= :manager-approval-needed (get-in halted [:mycelium/halt :reason])))
+
+      ;; 2. Inspect pending workflows
+      (is (= [sid] (vec (store/list-workflows s))))
+
+      ;; 3. Manager approves via session ID
+      (let [result (store/resume-with-store wf/compiled {} sid s
+                     {:manager-approved true
+                      :manager-name     "eve"})]
+
+        (is (= :approved (:decision result)))
+        (is (= "manager:eve" (:approved-by result)))
+        (is (some? (:notification result)) "Notification was sent")
+
+        ;; 4. Store cleaned up
+        (is (empty? (store/list-workflows s)) "Session removed after completion")))))
+
+(deftest store-rejection-lifecycle-test
+  (testing "Store-backed rejection"
+    (let [s (store/memory-store)
+          halted (store/run-with-store wf/compiled {}
+                   {:expense-id  "EXP-101"
+                    :submitter   "frank@co.com"
+                    :amount      5000
+                    :description "Server hardware"}
+                   s)
+          sid (:mycelium/session-id halted)
+          result (store/resume-with-store wf/compiled {} sid s
+                   {:manager-approved false
+                    :manager-name     "eve"
+                    :rejection-reason "Use cloud instead"})]
+
+      (is (= :rejected (:decision result)))
+      (is (clojure.string/includes?
+            (get-in result [:notification :body]) "Use cloud instead"))
+      (is (empty? (store/list-workflows s))))))
+
+(deftest store-small-expense-no-persist-test
+  (testing "Small expenses complete without touching the store"
+    (let [s (store/memory-store)
+          result (store/run-with-store wf/compiled {}
+                   {:expense-id  "EXP-102"
+                    :submitter   "grace@co.com"
+                    :amount      25
+                    :description "Lunch"}
+                   s)]
+
+      (is (= :approved (:decision result)))
+      (is (nil? (:mycelium/session-id result)) "No session ID — didn't halt")
+      (is (empty? (store/list-workflows s)) "Nothing persisted"))))

--- a/examples/expense_approval/tests.edn
+++ b/examples/expense_approval/tests.edn
@@ -1,0 +1,8 @@
+#kaocha/v1
+{:tests [{:id          :unit
+          :type        :kaocha.type/clojure.test
+          :source-paths ["src"]
+          :test-paths   ["test"]}]
+ :reporter [kaocha.report/dots]
+ :color?   true
+ :randomize? true}

--- a/src/mycelium/store.clj
+++ b/src/mycelium/store.clj
@@ -1,0 +1,81 @@
+(ns mycelium.store
+  "Persistence protocol and helpers for halted workflow state.
+   Allows workflows to halt, persist their state, and resume later
+   (potentially in a different process or after a restart)."
+  (:require [mycelium.core :as myc]))
+
+(defprotocol WorkflowStore
+  (save-workflow! [store session-id halted-data]
+    "Persist halted workflow state. Returns session-id.")
+  (load-workflow [store session-id]
+    "Load halted workflow state. Returns data map or nil if not found.")
+  (delete-workflow! [store session-id]
+    "Remove persisted state after completion or cancellation.")
+  (list-workflows [store]
+    "List all persisted session IDs."))
+
+(defn memory-store
+  "Creates an in-memory workflow store backed by an atom.
+   Suitable for development and testing."
+  []
+  (let [state (atom {})]
+    (reify WorkflowStore
+      (save-workflow! [_ session-id data]
+        (swap! state assoc session-id data)
+        session-id)
+      (load-workflow [_ session-id]
+        (get @state session-id))
+      (delete-workflow! [_ session-id]
+        (swap! state dissoc session-id)
+        nil)
+      (list-workflows [_]
+        (keys @state)))))
+
+(defn new-session-id
+  "Generates a unique session ID string."
+  []
+  (str (java.util.UUID/randomUUID)))
+
+(defn run-with-store
+  "Runs a pre-compiled workflow. If it halts, persists state to store and returns
+   {:mycelium/session-id id, :mycelium/halt halt-context, ...visible-data}.
+   If it completes normally, returns the result unchanged (nothing persisted).
+   `session-id` can be provided in opts as :session-id, otherwise auto-generated."
+  ([compiled-workflow resources initial-data store]
+   (run-with-store compiled-workflow resources initial-data store {}))
+  ([compiled-workflow resources initial-data store opts]
+   (let [result (myc/run-compiled compiled-workflow resources initial-data)]
+     (if (:mycelium/resume result)
+       ;; Halted — persist and return session reference
+       (let [session-id (or (:session-id opts) (new-session-id))]
+         (save-workflow! store session-id result)
+         (-> result
+             (dissoc :mycelium/resume)
+             (assoc :mycelium/session-id session-id)))
+       ;; Completed normally
+       result))))
+
+(defn resume-with-store
+  "Loads halted state from store by session-id, resumes the workflow.
+   On completion, deletes persisted state and returns result.
+   On re-halt, updates store and returns session reference.
+   Optional merge-data is merged into the data before resuming."
+  ([compiled-workflow resources session-id store]
+   (resume-with-store compiled-workflow resources session-id store nil))
+  ([compiled-workflow resources session-id store merge-data]
+   (let [halted-data (load-workflow store session-id)]
+     (when-not halted-data
+       (throw (ex-info (str "Workflow session not found: " session-id)
+                       {:session-id session-id})))
+     (let [result (myc/resume-compiled compiled-workflow resources halted-data merge-data)]
+       (if (:mycelium/resume result)
+         ;; Re-halted — update store with new state
+         (do
+           (save-workflow! store session-id result)
+           (-> result
+               (dissoc :mycelium/resume)
+               (assoc :mycelium/session-id session-id)))
+         ;; Completed — clean up store
+         (do
+           (delete-workflow! store session-id)
+           result))))))

--- a/test/mycelium/store_test.clj
+++ b/test/mycelium/store_test.clj
@@ -178,6 +178,35 @@
       (is (thrown-with-msg? Exception #"not found"
             (store/resume-with-store compiled {} "nonexistent" s))))))
 
+(deftest run-with-store-custom-session-id-test
+  (testing "Custom session ID via opts"
+    (defmethod cell/cell-spec :store/custom-sid [_]
+      {:id :store/custom-sid
+       :handler (fn [_ data] (assoc data :done true :mycelium/halt true))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/custom-sid}
+                      :edges {:start :end}})
+          result (store/run-with-store compiled {} {} s {:session-id "my-session"})]
+      (is (= "my-session" (:mycelium/session-id result)))
+      (is (some? (store/load-workflow s "my-session"))))))
+
+(deftest run-with-store-error-not-persisted-test
+  (testing "Errored workflow throws and nothing is persisted"
+    (defmethod cell/cell-spec :store/err-cell [_]
+      {:id :store/err-cell
+       :handler (fn [_ _data] (throw (ex-info "boom" {})))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/err-cell}
+                      :edges {:start :end}})]
+      (is (thrown? Exception (store/run-with-store compiled {} {} s)))
+      (is (empty? (store/list-workflows s)) "Nothing persisted"))))
+
 ;; ===== Round 7: Custom store via reify =====
 
 (deftest custom-store-protocol-test

--- a/test/mycelium/store_test.clj
+++ b/test/mycelium/store_test.clj
@@ -1,0 +1,207 @@
+(ns mycelium.store-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.store :as store]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== Round 1: Memory store basics =====
+
+(deftest memory-store-save-load-test
+  (testing "save-workflow! persists and load-workflow retrieves"
+    (let [s (store/memory-store)
+          data {:mycelium/halt true :mycelium/resume :some-state :x 1}]
+      (store/save-workflow! s "sess-1" data)
+      (is (= data (store/load-workflow s "sess-1"))))))
+
+(deftest memory-store-delete-test
+  (testing "delete-workflow! removes persisted state"
+    (let [s (store/memory-store)]
+      (store/save-workflow! s "sess-1" {:x 1})
+      (store/delete-workflow! s "sess-1")
+      (is (nil? (store/load-workflow s "sess-1"))))))
+
+(deftest memory-store-list-test
+  (testing "list-workflows returns all session IDs"
+    (let [s (store/memory-store)]
+      (store/save-workflow! s "a" {:x 1})
+      (store/save-workflow! s "b" {:x 2})
+      (is (= #{"a" "b"} (set (store/list-workflows s)))))))
+
+(deftest memory-store-overwrite-test
+  (testing "save-workflow! overwrites existing state"
+    (let [s (store/memory-store)]
+      (store/save-workflow! s "sess-1" {:x 1})
+      (store/save-workflow! s "sess-1" {:x 2})
+      (is (= {:x 2} (store/load-workflow s "sess-1")))
+      (is (= 1 (count (store/list-workflows s)))))))
+
+(deftest new-session-id-test
+  (testing "new-session-id returns unique strings"
+    (let [ids (repeatedly 100 store/new-session-id)]
+      (is (= 100 (count (set ids))))
+      (is (every? string? ids)))))
+
+;; ===== Round 2: run-with-store halts =====
+
+(deftest run-with-store-halt-persists-test
+  (testing "Halted workflow state is persisted to store"
+    (defmethod cell/cell-spec :store/halt-cell [_]
+      {:id :store/halt-cell
+       :handler (fn [_ data] (assoc data :done true :mycelium/halt {:reason :review}))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/halt-cell}
+                      :edges {:start :end}})
+          result (store/run-with-store compiled {} {} s)]
+      (is (string? (:mycelium/session-id result)) "Returns session ID")
+      (is (= {:reason :review} (:mycelium/halt result)) "Returns halt context")
+      (is (nil? (:mycelium/resume result)) "Resume token not exposed to caller")
+      (let [stored (store/load-workflow s (:mycelium/session-id result))]
+        (is (some? stored) "State persisted in store")
+        (is (some? (:mycelium/resume stored)) "Stored state has resume token")
+        (is (true? (:done stored)) "Stored state has cell output")))))
+
+(deftest run-with-store-completes-no-persist-test
+  (testing "Completed workflow is not persisted"
+    (defmethod cell/cell-spec :store/ok-cell [_]
+      {:id :store/ok-cell
+       :handler (fn [_ data] (assoc data :done true))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/ok-cell}
+                      :edges {:start :end}})
+          result (store/run-with-store compiled {} {} s)]
+      (is (true? (:done result)) "Returns normal result")
+      (is (nil? (:mycelium/session-id result)) "No session ID for completed workflow")
+      (is (empty? (store/list-workflows s)) "Nothing persisted"))))
+
+;; ===== Round 3: resume-with-store completes =====
+
+(deftest resume-with-store-completes-test
+  (testing "Resume from store completes and deletes state"
+    (defmethod cell/cell-spec :store/r-step1 [_]
+      {:id :store/r-step1
+       :handler (fn [_ data] (assoc data :step1 true :mycelium/halt true))
+       :schema {:input [:map] :output [:map]}})
+    (defmethod cell/cell-spec :store/r-step2 [_]
+      {:id :store/r-step2
+       :handler (fn [_ data] (assoc data :step2 true))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/r-step1, :next :store/r-step2}
+                      :edges {:start :next, :next :end}})
+          halted (store/run-with-store compiled {} {} s)
+          session-id (:mycelium/session-id halted)
+          result (store/resume-with-store compiled {} session-id s)]
+      (is (true? (:step1 result)) "Data from before halt")
+      (is (true? (:step2 result)) "Resumed cell ran")
+      (is (nil? (:mycelium/session-id result)) "No session ID on completion")
+      (is (nil? (store/load-workflow s session-id)) "State deleted after completion"))))
+
+;; ===== Round 4: resume-with-store re-halts =====
+
+(deftest resume-with-store-rehalts-test
+  (testing "Resume that halts again updates the store"
+    (defmethod cell/cell-spec :store/rh-a [_]
+      {:id :store/rh-a
+       :handler (fn [_ data] (assoc data :a true :mycelium/halt true))
+       :schema {:input [:map] :output [:map]}})
+    (defmethod cell/cell-spec :store/rh-b [_]
+      {:id :store/rh-b
+       :handler (fn [_ data] (assoc data :b true :mycelium/halt true))
+       :schema {:input [:map] :output [:map]}})
+    (defmethod cell/cell-spec :store/rh-c [_]
+      {:id :store/rh-c
+       :handler (fn [_ data] (assoc data :c true))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/rh-a, :mid :store/rh-b, :fin :store/rh-c}
+                      :pipeline [:start :mid :fin]})
+          halted1 (store/run-with-store compiled {} {} s)
+          sid (:mycelium/session-id halted1)
+          halted2 (store/resume-with-store compiled {} sid s)]
+      (is (= sid (:mycelium/session-id halted2)) "Same session ID reused")
+      (is (some? (:mycelium/halt halted2)) "Re-halted")
+      (let [stored (store/load-workflow s sid)]
+        (is (true? (:a stored)) "First cell data present")
+        (is (true? (:b stored)) "Second cell data present"))
+      ;; Final resume completes
+      (let [result (store/resume-with-store compiled {} sid s)]
+        (is (true? (:c result)))
+        (is (nil? (store/load-workflow s sid)) "Cleaned up after completion")))))
+
+;; ===== Round 5: resume-with-store merge data =====
+
+(deftest resume-with-store-merge-data-test
+  (testing "Human input merged on resume"
+    (defmethod cell/cell-spec :store/ask [_]
+      {:id :store/ask
+       :handler (fn [_ data] (assoc data :question "Approve?" :mycelium/halt true))
+       :schema {:input [:map] :output [:map]}})
+    (defmethod cell/cell-spec :store/decide [_]
+      {:id :store/decide
+       :handler (fn [_ data] (assoc data :result (if (:approved data) "yes" "no")))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/ask, :next :store/decide}
+                      :edges {:start :next, :next :end}})
+          halted (store/run-with-store compiled {} {} s)
+          sid (:mycelium/session-id halted)
+          result (store/resume-with-store compiled {} sid s {:approved true})]
+      (is (= "yes" (:result result))))))
+
+;; ===== Round 6: Error cases =====
+
+(deftest resume-unknown-session-throws-test
+  (testing "Resuming unknown session throws"
+    (defmethod cell/cell-spec :store/dummy [_]
+      {:id :store/dummy
+       :handler (fn [_ data] (assoc data :x true))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [s (store/memory-store)
+          compiled (myc/pre-compile
+                     {:cells {:start :store/dummy}
+                      :edges {:start :end}})]
+      (is (thrown-with-msg? Exception #"not found"
+            (store/resume-with-store compiled {} "nonexistent" s))))))
+
+;; ===== Round 7: Custom store via reify =====
+
+(deftest custom-store-protocol-test
+  (testing "Custom store implementation works via protocol"
+    (defmethod cell/cell-spec :store/custom-cell [_]
+      {:id :store/custom-cell
+       :handler (fn [_ data] (assoc data :ran true :mycelium/halt true))
+       :schema {:input [:map] :output [:map]}})
+
+    (let [state (atom {})
+          custom-store (reify store/WorkflowStore
+                         (save-workflow! [_ session-id data]
+                           (swap! state assoc session-id data)
+                           session-id)
+                         (load-workflow [_ session-id]
+                           (get @state session-id))
+                         (delete-workflow! [_ session-id]
+                           (swap! state dissoc session-id)
+                           nil)
+                         (list-workflows [_]
+                           (keys @state)))
+          compiled (myc/pre-compile
+                     {:cells {:start :store/custom-cell}
+                      :edges {:start :end}})
+          result (store/run-with-store compiled {} {} custom-store)]
+      (is (string? (:mycelium/session-id result)))
+      (is (= 1 (count @state)) "Custom store received the data"))))


### PR DESCRIPTION
Formal persistence layer for halt/resume. `WorkflowStore` protocol with `save-workflow!`, `load-workflow`, `delete-workflow!`, `list-workflows`. Includes an in-memory implementation for dev/testing. Store-aware helpers (`run-with-store`, `resume-with-store`) auto-persist on halt, auto-delete on completion, and reuse session IDs across re-halts.