### PR TITLE
Add schema coercion to eliminate int/double mismatch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Automatic numeric type coercion via `:coerce? true` in compilation options. Elim
 (def compiled (myc/pre-compile workflow-def {:coerce? true}))
 ```
 
-New public functions in `mycelium.schema`: `coerce-input`, `coerce-output`, `number-coercion-transformer`.
+Fractional values like `949.5` are never silently truncated — only whole-valued doubles (`949.0`) are coerced. Uses Malli's built-in `json-transformer` under the hood. New public functions in `mycelium.schema`: `coerce-input`, `coerce-output`.
 
 ## 2026-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-03-07
+
+### Schema Coercion
+
+Automatic numeric type coercion via `:coerce? true` in compilation options. Eliminates `int` vs `double` mismatches — when a cell produces `949.0` (double) but the next cell's schema expects `:int`, coercion converts it automatically. Handles both `double→int` and `int→double`. Non-numeric values still fail validation normally.
+
+```clojure
+(myc/run-workflow workflow-def resources data {:coerce? true})
+
+;; Or with pre-compile:
+(def compiled (myc/pre-compile workflow-def {:coerce? true}))
+```
+
+New public functions in `mycelium.schema`: `coerce-input`, `coerce-output`, `number-coercion-transformer`.
+
 ## 2026-03-06
 
 ### WorkflowStore Persistence Protocol

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Enable automatic numeric type coercion with `:coerce? true` in compilation optio
 (myc/run-compiled compiled resources initial-data)
 ```
 
-Coercion handles `double→int` and `int→double` conversions automatically. Non-numeric values are unaffected — a string where an int is expected still fails validation. Extra keys are preserved.
+Coercion handles `double→int` and `int→double` conversions automatically. Only whole-valued doubles are coerced to int (`949.0 → 949`); fractional values like `949.5` are left unconverted and fail validation normally. Non-numeric values are unaffected — a string where an int is expected still fails. Extra keys are preserved.
 
 ## Workflow Trace
 

--- a/README.md
+++ b/README.md
@@ -530,6 +530,20 @@ Pre and post interceptors validate every transition automatically:
 
 Schema violations redirect to the error state with detailed diagnostics attached at `:mycelium/schema-error`.
 
+### Schema Coercion
+
+Enable automatic numeric type coercion with `:coerce? true` in compilation options. This eliminates `int` vs `double` mismatches — a common source of schema validation errors when one cell produces `949.0` (double) but the next expects `:int`:
+
+```clojure
+(myc/run-workflow workflow-def resources initial-data {:coerce? true})
+
+;; Or with pre-compile:
+(def compiled (myc/pre-compile workflow-def {:coerce? true}))
+(myc/run-compiled compiled resources initial-data)
+```
+
+Coercion handles `double→int` and `int→double` conversions automatically. Non-numeric values are unaffected — a string where an int is expected still fails validation. Extra keys are preserved.
+
 ## Workflow Trace
 
 Every workflow run produces a `:mycelium/trace` vector in the result data — a step-by-step record of which cells ran, what transition was taken, and what the data looked like after each step.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -150,7 +150,8 @@ mentally reconstruct the architecture from.
 {:pre      (fn [fsm-state resources] fsm-state)  ;; pre-interceptor for every state
  :post     (fn [fsm-state resources] fsm-state)  ;; post-interceptor for every state
  :on-error (fn [resources fsm-state] data)        ;; runs when FSM enters error state
- :on-end   (fn [resources fsm-state] data)}       ;; runs when FSM enters end state
+ :on-end   (fn [resources fsm-state] data)        ;; runs when FSM enters end state
+ :coerce?  true}                                  ;; auto-coerce numeric types (int↔double)
 ```
 
 ## Accumulating Data Model

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -80,17 +80,11 @@
 ;; ===== Schema coercion =====
 
 (def number-coercion-transformer
-  "Malli transformer that coerces between numeric types.
-   double→int: only when the value has no fractional part (949.0 → 949, but 949.5 is left as-is
-   so that schema validation catches it). int→double: always safe."
-  (mt/transformer
-   {:name     :number-coercion
-    :decoders {:int    {:compile (fn [_ _]
-                                  (fn [x]
-                                    (if (and (number? x) (== x (Math/floor (double x))))
-                                      (int x)
-                                      x)))}
-               :double {:compile (fn [_ _] (fn [x] (if (number? x) (double x) x)))}}}))
+  "Malli's json-transformer handles numeric coercion safely:
+   double→int only when the value has no fractional part (949.0 → 949,
+   but 949.5 is left unconverted so validation catches it).
+   int→double always converts."
+  mt/json-transformer)
 
 (defn coerce-input
   "Coerces data to match the cell's input schema using number coercion.

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -4,6 +4,7 @@
    and async callback wrappers for async cells."
   (:require [malli.core :as m]
             [malli.error :as me]
+            [malli.transform :as mt]
             [maestro.core :as fsm]))
 
 (def ^:private terminal-states
@@ -76,6 +77,76 @@
           :errors  (me/humanize explanation)
           :data    data})))))
 
+;; ===== Schema coercion =====
+
+(def number-coercion-transformer
+  "Malli transformer that coerces between numeric types.
+   Converts double→int when schema expects :int, and int→double when schema expects :double."
+  (mt/transformer
+   {:name     :number-coercion
+    :decoders {:int    {:compile (fn [_ _] (fn [x] (if (number? x) (int x) x)))}
+               :double {:compile (fn [_ _] (fn [x] (if (number? x) (double x) x)))}}}))
+
+(defn coerce-input
+  "Coerces data to match the cell's input schema using number coercion.
+   Returns {:data coerced-data} on success, {:error error-map} on failure.
+   If no input schema exists, returns {:data data} unchanged."
+  [cell data]
+  (let [schema (get-in cell [:schema :input])]
+    (if-not schema
+      {:data data}
+      (let [coerced (m/decode schema data number-coercion-transformer)]
+        (if-let [explanation (m/explain schema coerced)]
+          {:error {:cell-id (:id cell)
+                   :phase   :input
+                   :errors  (me/humanize explanation)
+                   :data    data}}
+          {:data coerced})))))
+
+(defn coerce-output
+  "Coerces data to match the cell's output schema using number coercion.
+   Returns {:data coerced-data} on success, {:error error-map} on failure.
+   Handles single schemas and per-transition schema maps."
+  ([cell data]
+   (coerce-output cell data nil))
+  ([cell data transition]
+   (let [output (get-in cell [:schema :output])]
+     (cond
+       (nil? output)
+       {:data data}
+
+       (map? output)
+       (if transition
+         (if-let [schema (get output transition)]
+           (let [coerced (m/decode schema data number-coercion-transformer)]
+             (if-let [explanation (m/explain schema coerced)]
+               {:error {:cell-id (:id cell)
+                        :phase   :output
+                        :errors  (me/humanize explanation)
+                        :data    data}}
+               {:data coerced}))
+           {:data data})
+         ;; No transition — try each schema, use first that matches after coercion
+         (let [results (for [[_label schema] output]
+                         (let [coerced (m/decode schema data number-coercion-transformer)]
+                           (when-not (m/explain schema coerced)
+                             coerced)))]
+           (if-let [coerced (first (filter some? results))]
+             {:data coerced}
+             {:error {:cell-id (:id cell)
+                      :phase   :output
+                      :errors  (str "Data does not match any output schema for " (:id cell))
+                      :data    data}})))
+
+       :else
+       (let [coerced (m/decode output data number-coercion-transformer)]
+         (if-let [explanation (m/explain output coerced)]
+           {:error {:cell-id (:id cell)
+                    :phase   :output
+                    :errors  (me/humanize explanation)
+                    :data    data}}
+           {:data coerced}))))))
+
 (defn- compile-schema-value
   "Compiles a single schema value to a Malli schema object if it's a raw form.
    Returns the value unchanged if it's already compiled or nil."
@@ -111,19 +182,29 @@
 (defn make-pre-interceptor
   "Creates a Maestro pre-interceptor that validates input schemas.
    `state->cell` is a map of state-id → cell-spec.
+   `opts` — optional map. When `:coerce?` is true, coerces data before validation.
    Skips terminal states."
-  [state->cell]
-  (fn [fsm-state _resources]
-    (let [state-id (:current-state-id fsm-state)]
-      (if (contains? terminal-states state-id)
-        fsm-state
-        (if-let [cell (get state->cell state-id)]
-          (if-let [error (validate-input cell (:data fsm-state))]
-            (-> fsm-state
-                (assoc :current-state-id ::fsm/error)
-                (assoc-in [:data :mycelium/schema-error] error))
-            fsm-state)
-          fsm-state)))))
+  ([state->cell] (make-pre-interceptor state->cell {}))
+  ([state->cell opts]
+   (let [coerce? (:coerce? opts)]
+     (fn [fsm-state _resources]
+       (let [state-id (:current-state-id fsm-state)]
+         (if (contains? terminal-states state-id)
+           fsm-state
+           (if-let [cell (get state->cell state-id)]
+             (if coerce?
+               (let [result (coerce-input cell (:data fsm-state))]
+                 (if (:error result)
+                   (-> fsm-state
+                       (assoc :current-state-id ::fsm/error)
+                       (assoc-in [:data :mycelium/schema-error] (:error result)))
+                   (assoc fsm-state :data (:data result))))
+               (if-let [error (validate-input cell (:data fsm-state))]
+                 (-> fsm-state
+                     (assoc :current-state-id ::fsm/error)
+                     (assoc-in [:data :mycelium/schema-error] error))
+                 fsm-state))
+             fsm-state)))))))
 
 (defn make-post-interceptor
   "Creates a Maestro post-interceptor that validates output schemas and appends
@@ -133,61 +214,74 @@
    used to infer which transition was taken from :current-state-id (set by Maestro
    after dispatch evaluation).
    `state->names` maps resolved-state-id → cell-name keyword for human-readable traces.
+   `opts` — optional map. When `:coerce?` is true, coerces output data before validation.
    Skips terminal states."
-  [state->cell state->edge-targets state->names]
-  (fn [fsm-state _resources]
-    (let [state-id (:last-state-id fsm-state)]
-      (if (or (nil? state-id)
-              (contains? terminal-states state-id))
-        fsm-state
-        (if-let [cell (get state->cell state-id)]
-          (let [transition (when state->edge-targets
-                             (get-in state->edge-targets
-                                     [state-id (:current-state-id fsm-state)]))
-                data       (:data fsm-state)
-                ;; Skip output validation when resilience error or timeout is present
-                ;; (the handler was short-circuited)
-                error      (when-not (or (:mycelium/resilience-error data)
-                                         (:mycelium/timeout data)
-                                         (:mycelium/error data))
-                             (validate-output cell data transition))
-                ;; Extract duration-ms from the latest Maestro trace segment
-                duration-ms (some-> (:trace fsm-state) last :duration-ms)
-                ;; Extract join sub-traces if present
-                join-traces (:mycelium/join-traces data)
-                halted?     (some? (:mycelium/halt data))
-                timed-out?  (some? (:mycelium/timeout data))
-                trace-entry (cond-> {:cell       (get state->names state-id)
-                                     :cell-id    (:id cell)
-                                     :transition transition
-                                     :data       (dissoc data :mycelium/trace :mycelium/join-traces)}
-                              duration-ms   (assoc :duration-ms duration-ms)
-                              join-traces   (assoc :join-traces join-traces)
-                              halted?       (assoc :halted true)
-                              timed-out?    (assoc :timeout? true)
-                              error         (assoc :error error))]
-            (cond
-              error
-              (-> fsm-state
-                  (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
-                  (update :data dissoc :mycelium/join-traces :mycelium/params)
-                  (assoc :current-state-id ::fsm/error)
-                  (assoc-in [:data :mycelium/schema-error] error))
+  ([state->cell state->edge-targets state->names]
+   (make-post-interceptor state->cell state->edge-targets state->names {}))
+  ([state->cell state->edge-targets state->names opts]
+   (let [coerce? (:coerce? opts)]
+     (fn [fsm-state _resources]
+       (let [state-id (:last-state-id fsm-state)]
+         (if (or (nil? state-id)
+                 (contains? terminal-states state-id))
+           fsm-state
+           (if-let [cell (get state->cell state-id)]
+             (let [transition (when state->edge-targets
+                                (get-in state->edge-targets
+                                        [state-id (:current-state-id fsm-state)]))
+                   data       (:data fsm-state)
+                   skip-validation? (or (:mycelium/resilience-error data)
+                                        (:mycelium/timeout data)
+                                        (:mycelium/error data))
+                   ;; When coercing, get both error and coerced data
+                   coerce-result (when (and coerce? (not skip-validation?))
+                                   (coerce-output cell data transition))
+                   ;; When not coercing, just validate
+                   error (cond
+                           skip-validation?               nil
+                           coerce?                        (:error coerce-result)
+                           :else                          (validate-output cell data transition))
+                   ;; Use coerced data when available
+                   data (if (and coerce? (not skip-validation?) (not error))
+                          (:data coerce-result)
+                          data)
+                   ;; Extract duration-ms from the latest Maestro trace segment
+                   duration-ms (some-> (:trace fsm-state) last :duration-ms)
+                   ;; Extract join sub-traces if present
+                   join-traces (:mycelium/join-traces data)
+                   halted?     (some? (:mycelium/halt data))
+                   timed-out?  (some? (:mycelium/timeout data))
+                   trace-entry (cond-> {:cell       (get state->names state-id)
+                                        :cell-id    (:id cell)
+                                        :transition transition
+                                        :data       (dissoc data :mycelium/trace :mycelium/join-traces)}
+                                 duration-ms   (assoc :duration-ms duration-ms)
+                                 join-traces   (assoc :join-traces join-traces)
+                                 halted?       (assoc :halted true)
+                                 timed-out?    (assoc :timeout? true)
+                                 error         (assoc :error error))]
+               (cond
+                 error
+                 (-> fsm-state
+                     (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
+                     (update :data dissoc :mycelium/join-traces :mycelium/params)
+                     (assoc :current-state-id ::fsm/error)
+                     (assoc-in [:data :mycelium/schema-error] error))
 
-              halted?
-              (-> fsm-state
-                  (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
-                  (update :data dissoc :mycelium/join-traces)
-                  ;; Save resume point (where dispatches resolved to)
-                  (assoc-in [:data :mycelium/resume] (:current-state-id fsm-state))
-                  ;; Redirect to halt
-                  (assoc :current-state-id ::fsm/halt))
+                 halted?
+                 (-> fsm-state
+                     (assoc :data data)
+                     (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
+                     (update :data dissoc :mycelium/join-traces)
+                     (assoc-in [:data :mycelium/resume] (:current-state-id fsm-state))
+                     (assoc :current-state-id ::fsm/halt))
 
-              :else
-              (-> fsm-state
-                  (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
-                  (update :data dissoc :mycelium/join-traces :mycelium/params :mycelium/timeout))))
-          fsm-state)))))
+                 :else
+                 (-> fsm-state
+                     (assoc :data data)
+                     (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
+                     (update :data dissoc :mycelium/join-traces :mycelium/params :mycelium/timeout))))
+             fsm-state)))))))
 
 (defn wrap-async-callback
   "Wraps an async cell's callback to validate output before forwarding.

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -81,10 +81,15 @@
 
 (def number-coercion-transformer
   "Malli transformer that coerces between numeric types.
-   Converts double→int when schema expects :int, and int→double when schema expects :double."
+   double→int: only when the value has no fractional part (949.0 → 949, but 949.5 is left as-is
+   so that schema validation catches it). int→double: always safe."
   (mt/transformer
    {:name     :number-coercion
-    :decoders {:int    {:compile (fn [_ _] (fn [x] (if (number? x) (int x) x)))}
+    :decoders {:int    {:compile (fn [_ _]
+                                  (fn [x]
+                                    (if (and (number? x) (== x (Math/floor (double x))))
+                                      (int x)
+                                      x)))}
                :double {:compile (fn [_ _] (fn [x] (if (number? x) (double x) x)))}}}))
 
 (defn coerce-input

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -1124,8 +1124,9 @@
                                joins-map)
          fsm-states (merge fsm-cell-states fsm-join-states)
          ;; Build interceptors — compose custom pre/post with schema interceptors
-         schema-pre  (schema/make-pre-interceptor state->cell)
-         schema-post (schema/make-post-interceptor state->cell state->edge-targets state->names)
+         schema-opts (select-keys opts [:coerce?])
+         schema-pre  (schema/make-pre-interceptor state->cell schema-opts)
+         schema-post (schema/make-post-interceptor state->cell state->edge-targets state->names schema-opts)
          pre  (if-let [custom-pre (:pre opts)]
                 (fn [fsm-state resources]
                   (-> (schema-pre fsm-state resources)

--- a/test/mycelium/coercion_test.clj
+++ b/test/mycelium/coercion_test.clj
@@ -56,6 +56,17 @@
           result (schema/coerce-input cell {:x "not-a-number"})]
       (is (some? (:error result))))))
 
+(deftest coerce-input-rejects-fractional-double-to-int-test
+  (testing "coerce-input rejects fractional double when schema expects :int (no silent truncation)"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int]]}})
+    (let [cell   (cell/get-cell! :test/int-cell)
+          result (schema/coerce-input cell {:x 949.5})]
+      (is (some? (:error result)) "949.5 should NOT silently truncate to 949"))))
+
 (deftest coerce-input-preserves-extra-keys-test
   (testing "coerce-input preserves keys not in the schema"
     (defmethod cell/cell-spec :test/int-cell [_]

--- a/test/mycelium/coercion_test.clj
+++ b/test/mycelium/coercion_test.clj
@@ -1,0 +1,272 @@
+(ns mycelium.coercion-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.schema :as schema]
+            [mycelium.core :as myc]
+            [maestro.core :as fsm]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== coerce-input tests =====
+
+(deftest coerce-input-double-to-int-test
+  (testing "coerce-input coerces double to int when schema expects :int"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int]]}})
+    (let [cell   (cell/get-cell! :test/int-cell)
+          result (schema/coerce-input cell {:x 42.0})]
+      (is (nil? (:error result)))
+      (is (= 42 (get-in result [:data :x])))
+      (is (int? (get-in result [:data :x]))))))
+
+(deftest coerce-input-int-to-double-test
+  (testing "coerce-input coerces int to double when schema expects :double"
+    (defmethod cell/cell-spec :test/double-cell [_]
+      {:id      :test/double-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :double]]
+                 :output [:map [:x :double]]}})
+    (let [cell   (cell/get-cell! :test/double-cell)
+          result (schema/coerce-input cell {:x 42})]
+      (is (nil? (:error result)))
+      (is (= 42.0 (get-in result [:data :x])))
+      (is (float? (get-in result [:data :x]))))))
+
+(deftest coerce-input-no-schema-passthrough-test
+  (testing "coerce-input returns data unchanged when no input schema"
+    (defmethod cell/cell-spec :test/no-schema [_]
+      {:id      :test/no-schema
+       :handler (fn [_ data] data)})
+    (let [cell   (cell/get-cell! :test/no-schema)
+          result (schema/coerce-input cell {:x 42})]
+      (is (nil? (:error result)))
+      (is (= {:x 42} (:data result))))))
+
+(deftest coerce-input-fails-non-coercible-test
+  (testing "coerce-input returns error when data can't be coerced"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int]]}})
+    (let [cell   (cell/get-cell! :test/int-cell)
+          result (schema/coerce-input cell {:x "not-a-number"})]
+      (is (some? (:error result))))))
+
+(deftest coerce-input-preserves-extra-keys-test
+  (testing "coerce-input preserves keys not in the schema"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int]]}})
+    (let [cell   (cell/get-cell! :test/int-cell)
+          result (schema/coerce-input cell {:x 42.0 :extra "kept"})]
+      (is (nil? (:error result)))
+      (is (= "kept" (get-in result [:data :extra]))))))
+
+;; ===== coerce-output tests =====
+
+(deftest coerce-output-double-to-int-test
+  (testing "coerce-output coerces double to int when schema expects :int"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:y :int]]}})
+    (let [cell   (cell/get-cell! :test/int-cell)
+          result (schema/coerce-output cell {:y 949.0})]
+      (is (nil? (:error result)))
+      (is (= 949 (get-in result [:data :y])))
+      (is (int? (get-in result [:data :y]))))))
+
+(deftest coerce-output-per-transition-test
+  (testing "coerce-output works with per-transition schemas"
+    (defmethod cell/cell-spec :test/pt-coerce [_]
+      {:id      :test/pt-coerce
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output {:success [:map [:y :int]]
+                          :failure [:map [:error-message :string]]}}})
+    (let [cell   (cell/get-cell! :test/pt-coerce)
+          result (schema/coerce-output cell {:y 42.0} :success)]
+      (is (nil? (:error result)))
+      (is (= 42 (get-in result [:data :y])))
+      (is (int? (get-in result [:data :y]))))))
+
+(deftest coerce-output-per-transition-no-label-test
+  (testing "coerce-output with per-transition schema and no label tries all schemas"
+    (defmethod cell/cell-spec :test/pt-coerce [_]
+      {:id      :test/pt-coerce
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output {:success [:map [:y :int]]
+                          :failure [:map [:error-message :string]]}}})
+    (let [cell   (cell/get-cell! :test/pt-coerce)
+          result (schema/coerce-output cell {:y 42.0})]
+      (is (nil? (:error result)))
+      (is (= 42 (get-in result [:data :y]))))))
+
+(deftest coerce-output-fails-non-coercible-test
+  (testing "coerce-output returns error when data can't be coerced"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:y :int]]}})
+    (let [cell   (cell/get-cell! :test/int-cell)
+          result (schema/coerce-output cell {:y "not-a-number"})]
+      (is (some? (:error result))))))
+
+;; ===== Pre-interceptor with coercion =====
+
+(deftest pre-interceptor-coerces-data-test
+  (testing "Pre-interceptor with coercion coerces data and passes it downstream"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int]]}})
+    (let [state->cell {:test/int-cell (cell/get-cell! :test/int-cell)}
+          pre         (schema/make-pre-interceptor state->cell {:coerce? true})
+          fsm-state   {:current-state-id :test/int-cell
+                       :data             {:x 42.0}
+                       :trace            []}
+          result      (pre fsm-state {})]
+      ;; Should NOT redirect to error
+      (is (= :test/int-cell (:current-state-id result)))
+      ;; Data should be coerced
+      (is (= 42 (get-in result [:data :x])))
+      (is (int? (get-in result [:data :x]))))))
+
+(deftest pre-interceptor-coercion-rejects-invalid-test
+  (testing "Pre-interceptor with coercion still rejects non-coercible data"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int]]}})
+    (let [state->cell {:test/int-cell (cell/get-cell! :test/int-cell)}
+          pre         (schema/make-pre-interceptor state->cell {:coerce? true})
+          fsm-state   {:current-state-id :test/int-cell
+                       :data             {:x "bad"}
+                       :trace            []}
+          result      (pre fsm-state {})]
+      (is (= ::fsm/error (:current-state-id result)))
+      (is (some? (get-in result [:data :mycelium/schema-error]))))))
+
+;; ===== Post-interceptor with coercion =====
+
+(deftest post-interceptor-coerces-output-test
+  (testing "Post-interceptor with coercion coerces output data"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:y :int]]}})
+    (let [state->cell {:test/int-cell (cell/get-cell! :test/int-cell)}
+          post        (schema/make-post-interceptor state->cell nil nil {:coerce? true})
+          fsm-state   {:last-state-id    :test/int-cell
+                       :current-state-id :some/next
+                       :data             {:y 949.0}
+                       :trace            []}
+          result      (post fsm-state {})]
+      ;; Should NOT redirect to error
+      (is (= :some/next (:current-state-id result)))
+      ;; Data should be coerced in trace and in data
+      (is (int? (get-in result [:data :y])))
+      (is (= 949 (get-in result [:data :y]))))))
+
+(deftest post-interceptor-coercion-rejects-invalid-test
+  (testing "Post-interceptor with coercion still rejects non-coercible data"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:y :int]]}})
+    (let [state->cell {:test/int-cell (cell/get-cell! :test/int-cell)}
+          post        (schema/make-post-interceptor state->cell nil nil {:coerce? true})
+          fsm-state   {:last-state-id    :test/int-cell
+                       :current-state-id :some/next
+                       :data             {:y "bad"}
+                       :trace            []}
+          result      (post fsm-state {})]
+      (is (= ::fsm/error (:current-state-id result))))))
+
+;; ===== Coercion works with pre-compiled schemas =====
+
+(deftest coerce-with-precompiled-schemas-test
+  (testing "Coercion works with pre-compiled Malli schema objects"
+    (defmethod cell/cell-spec :test/int-cell [_]
+      {:id      :test/int-cell
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:y :int]]}})
+    (let [state->cell {:test/int-cell (cell/get-cell! :test/int-cell)}
+          compiled    (schema/pre-compile-schemas state->cell)
+          cell        (get compiled :test/int-cell)]
+      ;; coerce-input with compiled schema
+      (let [result (schema/coerce-input cell {:x 42.0})]
+        (is (nil? (:error result)))
+        (is (= 42 (get-in result [:data :x]))))
+      ;; coerce-output with compiled schema
+      (let [result (schema/coerce-output cell {:y 949.0})]
+        (is (nil? (:error result)))
+        (is (= 949 (get-in result [:data :y])))))))
+
+;; ===== End-to-end: compile-workflow with :coerce? =====
+
+(deftest workflow-coercion-end-to-end-test
+  (testing "Workflow compiled with :coerce? true handles numeric type mismatches"
+    (defmethod cell/cell-spec :test/producer [_]
+      {:id      :test/producer
+       :handler (fn [_ data]
+                  ;; Returns a double where downstream expects int
+                  (assoc data :amount 949.0))
+       :schema  {:input  [:map [:order-id :string]]
+                 :output [:map [:order-id :string] [:amount :double]]}})
+    (defmethod cell/cell-spec :test/consumer [_]
+      {:id      :test/consumer
+       :handler (fn [_ data]
+                  ;; Expects :amount as int
+                  (assoc data :result (str "processed-" (:amount data))))
+       :schema  {:input  [:map [:amount :int]]
+                 :output [:map [:amount :int] [:result :string]]}})
+    (let [workflow {:cells      {:start    :test/producer
+                                 :consumer :test/consumer}
+                    :edges      {:start    {:done :consumer}
+                                 :consumer {:done :end}}
+                    :dispatches {:start    [[:done (constantly true)]]
+                                 :consumer [[:done (constantly true)]]}}
+          result (myc/run-workflow workflow {} {:order-id "ORD-1"} {:coerce? true})]
+      ;; Without coercion this would fail because :amount is 949.0 (double) but consumer expects :int
+      (is (not (contains? result :mycelium/schema-error)))
+      (is (= "processed-949" (:result result))))))
+
+(deftest workflow-without-coercion-fails-on-mismatch-test
+  (testing "Workflow without :coerce? fails on numeric type mismatch (baseline)"
+    (defmethod cell/cell-spec :test/producer [_]
+      {:id      :test/producer
+       :handler (fn [_ data]
+                  (assoc data :amount 949.0))
+       :schema  {:input  [:map [:order-id :string]]
+                 :output [:map [:order-id :string] [:amount :double]]}})
+    (defmethod cell/cell-spec :test/consumer [_]
+      {:id      :test/consumer
+       :handler (fn [_ data]
+                  (assoc data :result (str "processed-" (:amount data))))
+       :schema  {:input  [:map [:amount :int]]
+                 :output [:map [:amount :int] [:result :string]]}})
+    (let [workflow {:cells      {:start    :test/producer
+                                 :consumer :test/consumer}
+                    :edges      {:start    {:done :consumer}
+                                 :consumer {:done :end}}
+                    :dispatches {:start    [[:done (constantly true)]]
+                                 :consumer [[:done (constantly true)]]}}
+          on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow workflow {} {:order-id "ORD-1"} {:on-error on-error})]
+      ;; Without coercion, schema validation should fail
+      (is (some? (:mycelium/schema-error result))))))


### PR DESCRIPTION
When :coerce? true is passed in compilation options, the framework automatically coerces between numeric types (double→int, int→double) at cell boundaries. This eliminates the most common class of schema validation failures where one cell produces 949.0 but the next expects :int.

Coercion is opt-in and backward-compatible — existing workflows without :coerce? behave identically. Non-numeric values still fail validation.