### PR TITLE
Feature/better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ Automatic numeric type coercion via `:coerce? true` in compilation options. Elim
 
 Fractional values like `949.5` are never silently truncated — only whole-valued doubles (`949.0`) are coerced. Uses Malli's built-in `json-transformer` under the hood. New public functions in `mycelium.schema`: `coerce-input`, `coerce-output`.
 
+### Improved Schema Error Messages
+
+Schema validation errors now include enriched diagnostics:
+
+- **`:failed-keys`** — per-key map showing the actual `:value`, its Java `:type`, and the error `:message`
+- **`:cell-path`** — vector of cell names that executed before the failure
+- **`:data`** — stripped of `:mycelium/*` internal keys to reduce noise
+
+```clojure
+;; Before:
+{:cell-id :step-b, :phase :input,
+ :errors {:count ["should be an integer"]},
+ :data {:count 42.5, :mycelium/trace [...200 lines...]}}
+
+;; After:
+{:cell-id :step-b, :phase :input,
+ :errors {:count ["should be an integer"]},
+ :data {:count 42.5},
+ :failed-keys {:count {:value 42.5, :type "java.lang.Double",
+                        :message "should be an integer"}},
+ :cell-path [:start]}
+```
+
 ## 2026-03-06
 
 ### WorkflowStore Persistence Protocol

--- a/README.md
+++ b/README.md
@@ -528,7 +528,21 @@ Pre and post interceptors validate every transition automatically:
 - **Pre**: validates input data against the cell's `:input` schema before the handler runs
 - **Post**: validates output data against `:output` schema, using the dispatch target to select per-transition schemas
 
-Schema violations redirect to the error state with detailed diagnostics attached at `:mycelium/schema-error`.
+Schema violations redirect to the error state with diagnostics attached at `:mycelium/schema-error`:
+
+```clojure
+{:cell-id     :order/compute-tax
+ :phase       :input
+ :errors      {:amount ["should be an integer"]}
+ :failed-keys {:amount {:value 42.5, :type "java.lang.Double",
+                         :message "should be an integer"}}
+ :cell-path   [:validate :expand-items :apply-promotions]
+ :data        {:amount 42.5, :order-id "ORD-1"}}
+```
+
+- **`:failed-keys`** shows the actual value, its type, and the error for each failing key
+- **`:cell-path`** lists which cells ran before the failure
+- **`:data`** excludes internal `:mycelium/*` keys to reduce noise
 
 ### Schema Coercion
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -823,7 +823,7 @@ Implement the protocol for your persistence backend (DB, Redis, etc.):
 |-----|-------------|
 | `:mycelium/trace` | Vector of execution trace entries (see Workflow Trace) |
 | `:mycelium/input-error` | Input schema validation failure (workflow didn't run) |
-| `:mycelium/schema-error` | Runtime schema violation details |
+| `:mycelium/schema-error` | Runtime schema violation details (includes `:failed-keys`, `:cell-path`, clean `:data`) |
 | `:mycelium/join-error` | Join node error details |
 | `:mycelium/timeout` | `true` when a cell exceeded its graph-level timeout |
 | `:mycelium/error` | Error group error details (`{:cell :name, :message "..."}`) |

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -117,10 +117,7 @@
       {:data data}
       (let [coerced (m/decode schema data number-coercion-transformer)]
         (if-let [explanation (m/explain schema coerced)]
-          {:error {:cell-id (:id cell)
-                   :phase   :input
-                   :errors  (me/humanize explanation)
-                   :data    data}}
+          {:error (build-error-map (:id cell) :input explanation data)}
           {:data coerced})))))
 
 (defn coerce-output
@@ -140,10 +137,7 @@
          (if-let [schema (get output transition)]
            (let [coerced (m/decode schema data number-coercion-transformer)]
              (if-let [explanation (m/explain schema coerced)]
-               {:error {:cell-id (:id cell)
-                        :phase   :output
-                        :errors  (me/humanize explanation)
-                        :data    data}}
+               {:error (build-error-map (:id cell) :output explanation data)}
                {:data coerced}))
            {:data data})
          ;; No transition — try each schema, use first that matches after coercion
@@ -156,15 +150,12 @@
              {:error {:cell-id (:id cell)
                       :phase   :output
                       :errors  (str "Data does not match any output schema for " (:id cell))
-                      :data    data}})))
+                      :data    (strip-mycelium-keys data)}})))
 
        :else
        (let [coerced (m/decode output data number-coercion-transformer)]
          (if-let [explanation (m/explain output coerced)]
-           {:error {:cell-id (:id cell)
-                    :phase   :output
-                    :errors  (me/humanize explanation)
-                    :data    data}}
+           {:error (build-error-map (:id cell) :output explanation data)}
            {:data coerced}))))))
 
 (defn- compile-schema-value

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -10,6 +10,36 @@
 (def ^:private terminal-states
   #{::fsm/end ::fsm/error ::fsm/halt})
 
+(defn- strip-mycelium-keys
+  "Removes :mycelium/* keys from a data map to reduce error payload noise."
+  [data]
+  (into {} (remove (fn [[k _]] (and (keyword? k)
+                                     (= "mycelium" (namespace k)))))
+        data))
+
+(defn- build-failed-keys
+  "Builds a map of {key {:value v, :type type-name, :message msg}} from
+   Malli's humanized errors and the original data."
+  [humanized data]
+  (when (map? humanized)
+    (into {}
+          (map (fn [[k msgs]]
+                 (let [v (get data k)]
+                   [k {:value   v
+                       :type    (when (some? v) (.getName (class v)))
+                       :message (first msgs)}])))
+          humanized)))
+
+(defn- build-error-map
+  "Builds a schema error map with enriched diagnostics."
+  [cell-id phase explanation data]
+  (let [humanized (me/humanize explanation)]
+    (cond-> {:cell-id     cell-id
+             :phase       phase
+             :errors      humanized
+             :data        (strip-mycelium-keys data)}
+      (map? humanized) (assoc :failed-keys (build-failed-keys humanized data)))))
+
 (defn validate-input
   "Validates data against the cell's input schema.
    Returns nil if valid (or if no input schema is defined), or an error map if invalid.
@@ -17,10 +47,7 @@
   [cell data]
   (when-let [schema (get-in cell [:schema :input])]
     (when-let [explanation (m/explain schema data)]
-      {:cell-id (:id cell)
-       :phase   :input
-       :errors  (me/humanize explanation)
-       :data    data})))
+      (build-error-map (:id cell) :input explanation data))))
 
 (defn output-schema-for-transition
   "Returns the output schema for a specific transition of a cell.
@@ -55,10 +82,7 @@
          ;; Validate against the specific transition's schema
          (when-let [schema (get output transition)]
            (when-let [explanation (m/explain schema data)]
-             {:cell-id (:id cell)
-              :phase   :output
-              :errors  (me/humanize explanation)
-              :data    data}))
+             (build-error-map (:id cell) :output explanation data)))
          ;; No transition known — validate against all schemas, pass if any matches
          (let [schemas (vals output)]
            (when (every? (fn [schema]
@@ -67,15 +91,12 @@
              {:cell-id (:id cell)
               :phase   :output
               :errors  (str "Data does not match any output schema for " (:id cell))
-              :data    data})))
+              :data    (strip-mycelium-keys data)})))
 
        ;; Single schema (vector or keyword)
        :else
        (when-let [explanation (m/explain output data)]
-         {:cell-id (:id cell)
-          :phase   :output
-          :errors  (me/humanize explanation)
-          :data    data})))))
+         (build-error-map (:id cell) :output explanation data))))))
 
 ;; ===== Schema coercion =====
 
@@ -178,6 +199,18 @@
                  [state-id updated-cell])))
         state->cell))
 
+(defn- extract-cell-path
+  "Extracts a vector of cell names from the :mycelium/trace in data."
+  [data]
+  (mapv :cell (:mycelium/trace data)))
+
+(defn- attach-cell-path
+  "Attaches :cell-path to an error map based on the current trace."
+  [error data]
+  (let [path (extract-cell-path data)]
+    (cond-> error
+      (seq path) (assoc :cell-path path))))
+
 (defn make-pre-interceptor
   "Creates a Maestro pre-interceptor that validates input schemas.
    `state->cell` is a map of state-id → cell-spec.
@@ -196,12 +229,14 @@
                  (if (:error result)
                    (-> fsm-state
                        (assoc :current-state-id ::fsm/error)
-                       (assoc-in [:data :mycelium/schema-error] (:error result)))
+                       (assoc-in [:data :mycelium/schema-error]
+                                 (attach-cell-path (:error result) (:data fsm-state))))
                    (assoc fsm-state :data (:data result))))
                (if-let [error (validate-input cell (:data fsm-state))]
                  (-> fsm-state
                      (assoc :current-state-id ::fsm/error)
-                     (assoc-in [:data :mycelium/schema-error] error))
+                     (assoc-in [:data :mycelium/schema-error]
+                               (attach-cell-path error (:data fsm-state))))
                  fsm-state))
              fsm-state)))))))
 
@@ -265,7 +300,8 @@
                      (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
                      (update :data dissoc :mycelium/join-traces :mycelium/params)
                      (assoc :current-state-id ::fsm/error)
-                     (assoc-in [:data :mycelium/schema-error] error))
+                     (assoc-in [:data :mycelium/schema-error]
+                               (attach-cell-path error (:data fsm-state))))
 
                  halted?
                  (-> fsm-state

--- a/test/mycelium/error_messages_test.clj
+++ b/test/mycelium/error_messages_test.clj
@@ -1,0 +1,156 @@
+(ns mycelium.error-messages-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.schema :as schema]
+            [mycelium.core :as myc]
+            [maestro.core :as fsm]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== validate-input: enriched error details =====
+
+(deftest validate-input-shows-actual-values-test
+  (testing "validate-input error includes actual value and type for each failing key"
+    (defmethod cell/cell-spec :test/typed [_]
+      {:id      :test/typed
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:amount :int] [:name :string]]
+                 :output [:map]}})
+    (let [cell  (cell/get-cell! :test/typed)
+          error (schema/validate-input cell {:amount 949.5 :name 42})]
+      (is (some? error))
+      ;; New :failed-keys field shows per-key diagnostics
+      (let [fk (:failed-keys error)]
+        (is (map? fk))
+        ;; :amount — got a double, expected int
+        (is (= 949.5 (get-in fk [:amount :value])))
+        (is (= "java.lang.Double" (get-in fk [:amount :type])))
+        ;; :name — got an int, expected string
+        (is (= 42 (get-in fk [:name :value])))
+        (is (= "java.lang.Long" (get-in fk [:name :type])))))))
+
+(deftest validate-input-shows-missing-keys-test
+  (testing "validate-input error shows missing keys with nil value"
+    (defmethod cell/cell-spec :test/typed [_]
+      {:id      :test/typed
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:amount :int] [:name :string]]
+                 :output [:map]}})
+    (let [cell  (cell/get-cell! :test/typed)
+          error (schema/validate-input cell {:amount 42})]
+      (is (some? error))
+      (let [fk (:failed-keys error)]
+        ;; :name is missing
+        (is (contains? fk :name))
+        (is (nil? (get-in fk [:name :value])))))))
+
+(deftest validate-output-shows-actual-values-test
+  (testing "validate-output error includes actual value and type for each failing key"
+    (defmethod cell/cell-spec :test/typed [_]
+      {:id      :test/typed
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map]
+                 :output [:map [:result :int]]}})
+    (let [cell  (cell/get-cell! :test/typed)
+          error (schema/validate-output cell {:result "not-int"})]
+      (is (some? error))
+      (let [fk (:failed-keys error)]
+        (is (= "not-int" (get-in fk [:result :value])))
+        (is (= "java.lang.String" (get-in fk [:result :type])))))))
+
+;; ===== Error data excludes mycelium internal keys =====
+
+(deftest error-data-excludes-internal-keys-test
+  (testing "Error :data field excludes :mycelium/* keys to reduce noise"
+    (defmethod cell/cell-spec :test/typed [_]
+      {:id      :test/typed
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map]}})
+    (let [cell (cell/get-cell! :test/typed)
+          data {:x "bad"
+                :mycelium/trace [{:cell :prev :data {}}]
+                :mycelium/params {:factor 3}
+                :user-key "kept"}
+          error (schema/validate-input cell data)]
+      (is (some? error))
+      ;; :data should not contain :mycelium/* keys
+      (is (not (contains? (:data error) :mycelium/trace)))
+      (is (not (contains? (:data error) :mycelium/params)))
+      ;; but user keys are preserved
+      (is (= "kept" (get-in error [:data :user-key]))))))
+
+;; ===== Post-interceptor includes cell-path =====
+
+(deftest post-interceptor-error-includes-cell-path-test
+  (testing "Post-interceptor schema error includes :cell-path from execution trace"
+    (defmethod cell/cell-spec :test/step-a [_]
+      {:id      :test/step-a
+       :handler (fn [_ data] (assoc data :a-done true))
+       :schema  {:input [:map [:x :int]] :output [:map [:a-done :boolean]]}})
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] data)
+       :schema  {:input [:map [:a-done :boolean]] :output [:map [:result :int]]}})
+    (let [state->cell {:test/step-b (cell/get-cell! :test/step-b)}
+          state->names {:test/step-b :step-b}
+          post (schema/make-post-interceptor state->cell nil state->names)
+          ;; Simulate: step-a already ran (its trace entry is in data)
+          fsm-state {:last-state-id    :test/step-b
+                     :current-state-id :some/next
+                     :data {:a-done true
+                            :mycelium/trace [{:cell :start :cell-id :test/step-a :transition :done}]}
+                     :trace []}
+          result (post fsm-state {})]
+      ;; Should redirect to error
+      (is (= ::fsm/error (:current-state-id result)))
+      ;; Schema error should include cell-path
+      (let [schema-error (get-in result [:data :mycelium/schema-error])]
+        (is (= [:start] (:cell-path schema-error)))))))
+
+(deftest pre-interceptor-error-includes-cell-path-test
+  (testing "Pre-interceptor schema error includes :cell-path from execution trace"
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] data)
+       :schema  {:input [:map [:x :int]] :output [:map]}})
+    (let [state->cell {:test/step-b (cell/get-cell! :test/step-b)}
+          pre (schema/make-pre-interceptor state->cell)
+          fsm-state {:current-state-id :test/step-b
+                     :data {:x "bad"
+                            :mycelium/trace [{:cell :start :cell-id :test/step-a :transition :done}
+                                             {:cell :validate :cell-id :test/validate :transition :ok}]}
+                     :trace []}
+          result (pre fsm-state {})]
+      (is (= ::fsm/error (:current-state-id result)))
+      (let [schema-error (get-in result [:data :mycelium/schema-error])]
+        (is (= [:start :validate] (:cell-path schema-error)))))))
+
+;; ===== End-to-end: workflow error messages =====
+
+(deftest workflow-error-has-enriched-diagnostics-test
+  (testing "Workflow schema error has failed-keys, cell-path, and clean data"
+    (defmethod cell/cell-spec :test/step-a [_]
+      {:id      :test/step-a
+       :handler (fn [_ data] (assoc data :count 42.5))
+       :schema  {:input [:map [:x :int]] :output [:map [:count :double]]}})
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] (assoc data :result (:count data)))
+       :schema  {:input [:map [:count :int]] :output [:map [:result :int]]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells      {:start  :test/step-a
+                                 :step-b :test/step-b}
+                    :edges      {:start  {:done :step-b}
+                                 :step-b {:done :end}}
+                    :dispatches {:start  [[:done (constantly true)]]
+                                 :step-b [[:done (constantly true)]]}}
+                   {} {:x 42} {:on-error on-error})
+          schema-error (:mycelium/schema-error result)]
+      ;; Should have cell-path showing :start ran before the failure
+      (is (= [:start] (:cell-path schema-error)))
+      ;; Should have failed-keys with actual value
+      (is (= 42.5 (get-in schema-error [:failed-keys :count :value])))
+      ;; :data should not contain :mycelium/trace
+      (is (not (contains? (:data schema-error) :mycelium/trace))))))


### PR DESCRIPTION
Schema validation errors now include enriched diagnostics that make debugging faster:

- :failed-keys — per-key map with the actual value, its Java type, and the error message. Instead of seeing {:amount ["should be an integer"]} and hunting through a massive data map, you immediately see {:amount
  {:value 42.5, :type "java.lang.Double", :message "should be an integer"}}.
- :cell-path — vector of cell names that executed before the failure, e.g. [:validate :expand-items :apply-promotions]. Shows exactly where in the workflow the error occurred without cross-referencing the trace.
- :data — stripped of :mycelium/* internal keys (trace, params, etc.) so the error payload shows only domain data instead of hundreds of lines of framework internals.