### PR TITLE
Feature/auto key propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Auto Key Propagation
 
-Opt-in key propagation via `:propagate-keys? true`. When enabled, each cell's output is automatically merged with its input — cells only need to return new or changed keys. Eliminates the boilerplate of explicitly passing through all upstream keys in every cell's output and output schema.
+Automatic key propagation, enabled by default. Each cell's output is automatically merged with its input — cells only need to return new or changed keys. Eliminates the boilerplate of explicitly passing through all upstream keys in every cell's output and output schema. Disable with `:propagate-keys? false` if needed.
 
 ```clojure
 ;; Before: handler must include ALL keys downstream cells need
@@ -18,10 +18,11 @@ Opt-in key propagation via `:propagate-keys? true`. When enabled, each cell's ou
   {:handler (fn [_ data] {:tax (* (:subtotal data) 0.1)})
    :schema {:output [:map [:tax :double]]}})
 
-(myc/run-workflow workflow-def resources data {:propagate-keys? true})
+;; Key propagation is on by default — no opt-in needed
+(myc/run-workflow workflow-def resources data)
 ```
 
-Handler output takes precedence over input keys (explicit override). Internal `:mycelium/*` keys are excluded from propagation. Works with both sync and async cells, and combines with `:coerce? true`.
+Handler output takes precedence over input keys (explicit override). Internal `:mycelium/*` keys are excluded from propagation. Works with both sync and async cells, and combines with `:coerce? true`. Disable with `{:propagate-keys? false}`.
 
 ### Schema Coercion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 2026-03-07
 
+### Auto Key Propagation
+
+Opt-in key propagation via `:propagate-keys? true`. When enabled, each cell's output is automatically merged with its input — cells only need to return new or changed keys. Eliminates the boilerplate of explicitly passing through all upstream keys in every cell's output and output schema.
+
+```clojure
+;; Before: handler must include ALL keys downstream cells need
+(defmethod cell/cell-spec :process/compute-tax [_]
+  {:handler (fn [_ data]
+              (assoc data :tax (* (:subtotal data) 0.1)))
+   :schema {:output [:map [:subtotal :double] [:items :any] [:tax :double]]}})
+
+;; After: handler returns only new/changed keys
+(defmethod cell/cell-spec :process/compute-tax [_]
+  {:handler (fn [_ data] {:tax (* (:subtotal data) 0.1)})
+   :schema {:output [:map [:tax :double]]}})
+
+(myc/run-workflow workflow-def resources data {:propagate-keys? true})
+```
+
+Handler output takes precedence over input keys (explicit override). Internal `:mycelium/*` keys are excluded from propagation. Works with both sync and async cells, and combines with `:coerce? true`.
+
 ### Schema Coercion
 
 Automatic numeric type coercion via `:coerce? true` in compilation options. Eliminates `int` vs `double` mismatches — when a cell produces `949.0` (double) but the next cell's schema expects `:int`, coercion converts it automatically. Handles both `double→int` and `int→double`. Non-numeric values still fail validation normally.

--- a/README.md
+++ b/README.md
@@ -558,6 +558,31 @@ Enable automatic numeric type coercion with `:coerce? true` in compilation optio
 
 Coercion handles `double→int` and `int→double` conversions automatically. Only whole-valued doubles are coerced to int (`949.0 → 949`); fractional values like `949.5` are left unconverted and fail validation normally. Non-numeric values are unaffected — a string where an int is expected still fails. Extra keys are preserved.
 
+### Auto Key Propagation
+
+Enable automatic key propagation with `:propagate-keys? true`. When enabled, each cell's handler output is merged on top of its input data — cells only need to return new or changed keys. This eliminates the boilerplate of explicitly passing through all upstream keys:
+
+```clojure
+;; Without propagation: handler must include ALL keys downstream cells need
+(defmethod cell/cell-spec :compute-tax [_]
+  {:handler (fn [_ data]
+              (assoc data :tax (* (:subtotal data) 0.1)))
+   :schema {:output [:map [:subtotal :double] [:items :any] [:tax :double]]}})
+
+;; With propagation: handler returns only new keys
+(defmethod cell/cell-spec :compute-tax [_]
+  {:handler (fn [_ data] {:tax (* (:subtotal data) 0.1)})
+   :schema {:output [:map [:tax :double]]}})
+
+(myc/run-workflow workflow-def resources data {:propagate-keys? true})
+```
+
+Handler output takes precedence over input keys. Internal `:mycelium/*` keys are excluded from propagation. Combines with `:coerce? true`:
+
+```clojure
+(myc/run-workflow workflow-def resources data {:propagate-keys? true :coerce? true})
+```
+
 ## Workflow Trace
 
 Every workflow run produces a `:mycelium/trace` vector in the result data — a step-by-step record of which cells ran, what transition was taken, and what the data looked like after each step.

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Coercion handles `double→int` and `int→double` conversions automatically. On
 
 ### Auto Key Propagation
 
-Enable automatic key propagation with `:propagate-keys? true`. When enabled, each cell's handler output is merged on top of its input data — cells only need to return new or changed keys. This eliminates the boilerplate of explicitly passing through all upstream keys:
+Key propagation is enabled by default. Each cell's handler output is merged on top of its input data — cells only need to return new or changed keys. This eliminates the boilerplate of explicitly passing through all upstream keys:
 
 ```clojure
 ;; Without propagation: handler must include ALL keys downstream cells need
@@ -574,14 +574,11 @@ Enable automatic key propagation with `:propagate-keys? true`. When enabled, eac
   {:handler (fn [_ data] {:tax (* (:subtotal data) 0.1)})
    :schema {:output [:map [:tax :double]]}})
 
-(myc/run-workflow workflow-def resources data {:propagate-keys? true})
+;; Key propagation is on by default — no opt-in needed
+(myc/run-workflow workflow-def resources data)
 ```
 
-Handler output takes precedence over input keys. Internal `:mycelium/*` keys are excluded from propagation. Combines with `:coerce? true`:
-
-```clojure
-(myc/run-workflow workflow-def resources data {:propagate-keys? true :coerce? true})
-```
+Handler output takes precedence over input keys. Internal `:mycelium/*` keys are excluded from propagation. Disable with `{:propagate-keys? false}` if needed.
 
 ## Workflow Trace
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -152,7 +152,7 @@ mentally reconstruct the architecture from.
  :on-error (fn [resources fsm-state] data)        ;; runs when FSM enters error state
  :on-end   (fn [resources fsm-state] data)        ;; runs when FSM enters end state
  :coerce?  true                                    ;; auto-coerce numeric types (int↔double)
- :propagate-keys? true}                            ;; auto-merge input keys into handler output
+ :propagate-keys? false}                            ;; disable auto key propagation (on by default)
 ```
 
 ## Accumulating Data Model
@@ -166,7 +166,7 @@ start → validate → fetch-profile → fetch-orders → render
 
 A cell can depend on data produced several steps earlier without special wiring — keys persist through intermediate cells. The schema chain validator walks each path and confirms required keys are available from upstream outputs.
 
-With `:propagate-keys? true`, cells can return only new/changed keys — input keys are automatically merged into the output. This eliminates the `(assoc data ...)` boilerplate:
+Key propagation is on by default — cells can return only new/changed keys and input keys are automatically merged into the output. This eliminates the `(assoc data ...)` boilerplate:
 
 ```clojure
 ;; Without propagation: (fn [_ data] (assoc data :tax (* (:subtotal data) 0.1)))

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -151,7 +151,8 @@ mentally reconstruct the architecture from.
  :post     (fn [fsm-state resources] fsm-state)  ;; post-interceptor for every state
  :on-error (fn [resources fsm-state] data)        ;; runs when FSM enters error state
  :on-end   (fn [resources fsm-state] data)        ;; runs when FSM enters end state
- :coerce?  true}                                  ;; auto-coerce numeric types (int↔double)
+ :coerce?  true                                    ;; auto-coerce numeric types (int↔double)
+ :propagate-keys? true}                            ;; auto-merge input keys into handler output
 ```
 
 ## Accumulating Data Model
@@ -164,6 +165,13 @@ start → validate → fetch-profile → fetch-orders → render
 ```
 
 A cell can depend on data produced several steps earlier without special wiring — keys persist through intermediate cells. The schema chain validator walks each path and confirms required keys are available from upstream outputs.
+
+With `:propagate-keys? true`, cells can return only new/changed keys — input keys are automatically merged into the output. This eliminates the `(assoc data ...)` boilerplate:
+
+```clojure
+;; Without propagation: (fn [_ data] (assoc data :tax (* (:subtotal data) 0.1)))
+;; With propagation:    (fn [_ data] {:tax (* (:subtotal data) 0.1)})
+```
 
 ## Cell Registration
 

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -424,10 +424,8 @@
    For each cell, checks its input keys are available from upstream outputs or workflow input.
    For per-transition output schemas, only passes the keys from the matching transition's schema
    along each edge.
-   Join nodes: validates each member's inputs, then adds the union of all member outputs.
-   When `propagate-keys?` is true, available keys pass through cells even if not
-   declared in the cell's output schema."
-  [edges-map cells-map joins-map & {:keys [propagate-keys?]}]
+   Join nodes: validates each member's inputs, then adds the union of all member outputs."
+  [edges-map cells-map joins-map]
   (let [get-input-keys  (fn [cell-id]
                           (let [cell   (cell/get-cell! cell-id)
                                 schema (get-in cell [:schema :input])]

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -424,8 +424,10 @@
    For each cell, checks its input keys are available from upstream outputs or workflow input.
    For per-transition output schemas, only passes the keys from the matching transition's schema
    along each edge.
-   Join nodes: validates each member's inputs, then adds the union of all member outputs."
-  [edges-map cells-map joins-map]
+   Join nodes: validates each member's inputs, then adds the union of all member outputs.
+   When `propagate-keys?` is true, available keys pass through cells even if not
+   declared in the cell's output schema."
+  [edges-map cells-map joins-map & {:keys [propagate-keys?]}]
   (let [get-input-keys  (fn [cell-id]
                           (let [cell   (cell/get-cell! cell-id)
                                 schema (get-in cell [:schema :input])]
@@ -924,6 +926,27 @@
 
     :else false))
 
+(defn- strip-mycelium-keys
+  "Removes :mycelium/* keys from a data map for key propagation."
+  [data]
+  (into {} (remove (fn [[k _]] (and (keyword? k) (= "mycelium" (namespace k))))) data))
+
+(defn- wrap-handler-with-propagation
+  "Wraps a cell handler so that input keys automatically propagate to output.
+   Output = (merge (strip-mycelium-keys input) (handler resources input)).
+   Handler output takes precedence over input keys.
+   Handles both sync (2-arity) and async (4-arity) handlers."
+  [handler]
+  (fn
+    ([resources data]
+     (let [result (handler resources data)]
+       (merge (strip-mycelium-keys data) result)))
+    ([resources data callback error-callback]
+     (handler resources data
+              (fn [result]
+                (callback (merge (strip-mycelium-keys data) result)))
+              error-callback))))
+
 (defn- wrap-handler-with-params
   "Wraps a cell handler to inject :mycelium/params into data before invocation.
    Handles both sync (2-arity) and async (4-arity) handlers."
@@ -1084,6 +1107,12 @@
          ;; Apply workflow-level interceptors (wraps cell handlers)
          wf-interceptors (:interceptors workflow)
          state->cell (apply-workflow-interceptors state->cell cell-ids wf-interceptors)
+         ;; Apply key propagation wrapping (merge input → output)
+         state->cell (if (:propagate-keys? opts)
+                       (into {} (map (fn [[state-id cell]]
+                                       [state-id (update cell :handler wrap-handler-with-propagation)]))
+                             state->cell)
+                       state->cell)
          ;; Build state->edge-targets for post-interceptor transition lookup
          state->edge-targets (build-edge-targets edges)
          ;; Build state->names for human-readable trace entries

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -1106,7 +1106,9 @@
          wf-interceptors (:interceptors workflow)
          state->cell (apply-workflow-interceptors state->cell cell-ids wf-interceptors)
          ;; Apply key propagation wrapping (merge input → output)
-         state->cell (if (:propagate-keys? opts)
+         ;; Enabled by default — aligns runtime with schema chain validator's
+         ;; key accumulation assumption. Disable with :propagate-keys? false.
+         state->cell (if (not (false? (:propagate-keys? opts)))
                        (into {} (map (fn [[state-id cell]]
                                        [state-id (update cell :handler wrap-handler-with-propagation)]))
                              state->cell)

--- a/test/mycelium/propagate_keys_test.clj
+++ b/test/mycelium/propagate_keys_test.clj
@@ -5,13 +5,13 @@
 
 (use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
 
-;; ===== Basic key propagation =====
+;; ===== Default behavior (enabled) =====
 
 (deftest propagate-keys-merges-input-into-output-test
-  (testing "With :propagate-keys? true, input keys automatically appear in output"
+  (testing "Input keys automatically appear in output (default behavior)"
     (defmethod cell/cell-spec :test/add-b [_]
       {:id      :test/add-b
-       ;; Handler returns ONLY :b — without propagation, :a is lost
+       ;; Handler returns ONLY :b — :a propagates automatically
        :handler (fn [_ data] {:b (inc (:a data))})
        :schema  {:input  [:map [:a :int]]
                  :output [:map [:b :int]]}})
@@ -27,8 +27,7 @@
                                  :use   {:done :end}}
                     :dispatches {:start [[:done (constantly true)]]
                                  :use   [[:done (constantly true)]]}}
-                   {} {:a 10} {:propagate-keys? true})]
-      ;; :a should propagate through :test/add-b to :test/use-both
+                   {} {:a 10})]
       (is (= 21 (:result result))))))
 
 (deftest propagate-keys-handler-output-takes-precedence-test
@@ -50,15 +49,39 @@
                                  :read  {:done :end}}
                     :dispatches {:start [[:done (constantly true)]]
                                  :read  [[:done (constantly true)]]}}
-                   {} {:x 10} {:propagate-keys? true})]
+                   {} {:x 10})]
       ;; handler output :x=11 should override input :x=10
       (is (= 110 (:result result))))))
 
-(deftest propagate-keys-disabled-by-default-test
-  (testing "Without :propagate-keys?, cells must explicitly include keys in output"
+(deftest propagate-keys-enabled-by-default-test
+  (testing "Key propagation is on by default — no opt-in needed"
     (defmethod cell/cell-spec :test/add-b [_]
       {:id      :test/add-b
-       ;; Handler returns ONLY :b — :a is lost
+       :handler (fn [_ data] {:b (inc (:a data))})
+       :schema  {:input  [:map [:a :int]]
+                 :output [:map [:b :int]]}})
+    (defmethod cell/cell-spec :test/use-both [_]
+      {:id      :test/use-both
+       :handler (fn [_ data] {:result (+ (:a data) (:b data))})
+       :schema  {:input  [:map [:a :int] [:b :int]]
+                 :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :test/add-b
+                                 :use   :test/use-both}
+                    :edges      {:start {:done :use}
+                                 :use   {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :use   [[:done (constantly true)]]}}
+                   {} {:a 10})]
+      ;; :a propagates even without explicit :propagate-keys? true
+      (is (= 21 (:result result))))))
+
+;; ===== Opt-out =====
+
+(deftest propagate-keys-can-be-disabled-test
+  (testing "With :propagate-keys? false, keys are not propagated"
+    (defmethod cell/cell-spec :test/add-b [_]
+      {:id      :test/add-b
        :handler (fn [_ data] {:b (inc (:a data))})
        :schema  {:input  [:map [:a :int]]
                  :output [:map [:b :int]]}})
@@ -67,8 +90,6 @@
        :handler (fn [_ data] {:result (+ (or (:a data) 0) (:b data))})
        :schema  {:input  [:map [:a :int] [:b :int]]
                  :output [:map [:result :int]]}})
-    ;; Without propagate-keys?, input validation on :use will fail
-    ;; because :a is not in the data (only :b is)
     (let [on-error (fn [_resources fsm-state] (:data fsm-state))
           result (myc/run-workflow
                    {:cells      {:start :test/add-b
@@ -77,8 +98,8 @@
                                  :use   {:done :end}}
                     :dispatches {:start [[:done (constantly true)]]
                                  :use   [[:done (constantly true)]]}}
-                   {} {:a 10} {:on-error on-error})]
-      ;; :a was lost because propagation is off — input validation on :use should fail
+                   {} {:a 10} {:propagate-keys? false :on-error on-error})]
+      ;; :a is lost — input validation on :use fails
       (is (some? (:mycelium/schema-error result)))
       (is (= :input (:phase (:mycelium/schema-error result)))))))
 
@@ -112,14 +133,14 @@
                     :dispatches {:start [[:done (constantly true)]]
                                  :b     [[:done (constantly true)]]
                                  :c     [[:done (constantly true)]]}}
-                   {} {:x 100} {:propagate-keys? true})]
+                   {} {:x 100})]
       ;; :x propagates through all cells, :a-out through step-b and step-c
       (is (= 103 (:result result))))))
 
-;; ===== Pre-compile with propagate-keys? =====
+;; ===== Pre-compile =====
 
 (deftest propagate-keys-with-pre-compile-test
-  (testing "propagate-keys? works with pre-compile"
+  (testing "Key propagation works with pre-compile (default on)"
     (defmethod cell/cell-spec :test/add-b [_]
       {:id      :test/add-b
        :handler (fn [_ data] {:b (inc (:a data))})
@@ -136,15 +157,14 @@
                       :edges      {:start {:done :use}
                                    :use   {:done :end}}
                       :dispatches {:start [[:done (constantly true)]]
-                                   :use   [[:done (constantly true)]]}}
-                     {:propagate-keys? true})
+                                   :use   [[:done (constantly true)]]}})
           result (myc/run-compiled compiled {} {:a 10})]
       (is (= 21 (:result result))))))
 
 ;; ===== Schema validation still works =====
 
 (deftest propagate-keys-schema-validation-still-enforced-test
-  (testing "Output schema validation still catches bad handler output with propagate-keys?"
+  (testing "Output schema validation still catches bad handler output"
     (defmethod cell/cell-spec :test/bad-output [_]
       {:id      :test/bad-output
        :handler (fn [_ data] {:count "not-an-int"})
@@ -163,14 +183,13 @@
                                  :next  {:done :end}}
                     :dispatches {:start [[:done (constantly true)]]
                                  :next  [[:done (constantly true)]]}}
-                   {} {:x 42} {:propagate-keys? true :on-error on-error})]
-      ;; Output schema validation should still catch "not-an-int" for :count
+                   {} {:x 42} {:on-error on-error})]
       (is (some? (:mycelium/schema-error result))))))
 
-;; ===== Coercion + propagate-keys? combined =====
+;; ===== Coercion + propagation combined =====
 
 (deftest propagate-keys-with-coercion-test
-  (testing "propagate-keys? and coerce? work together"
+  (testing "Key propagation and coercion work together"
     (defmethod cell/cell-spec :test/produce-double [_]
       {:id      :test/produce-double
        :handler (fn [_ data] {:count 10.0})
@@ -188,7 +207,7 @@
                                  :use   {:done :end}}
                     :dispatches {:start [[:done (constantly true)]]
                                  :use   [[:done (constantly true)]]}}
-                   {} {:x 5} {:propagate-keys? true :coerce? true})]
+                   {} {:x 5} {:coerce? true})]
       (is (= 15 (:result result))))))
 
 ;; ===== Propagated keys visible in final result =====
@@ -203,7 +222,7 @@
     (let [result (myc/run-workflow
                    {:cells      {:start :test/add-tag}
                     :edges      {:start :end}}
-                   {} {:x 42} {:propagate-keys? true})]
+                   {} {:x 42})]
       ;; Both :x (propagated) and :tag (handler output) should be present
       (is (= 42 (:x result)))
       (is (= "processed" (:tag result))))))

--- a/test/mycelium/propagate_keys_test.clj
+++ b/test/mycelium/propagate_keys_test.clj
@@ -1,0 +1,209 @@
+(ns mycelium.propagate-keys-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== Basic key propagation =====
+
+(deftest propagate-keys-merges-input-into-output-test
+  (testing "With :propagate-keys? true, input keys automatically appear in output"
+    (defmethod cell/cell-spec :test/add-b [_]
+      {:id      :test/add-b
+       ;; Handler returns ONLY :b — without propagation, :a is lost
+       :handler (fn [_ data] {:b (inc (:a data))})
+       :schema  {:input  [:map [:a :int]]
+                 :output [:map [:b :int]]}})
+    (defmethod cell/cell-spec :test/use-both [_]
+      {:id      :test/use-both
+       :handler (fn [_ data] {:result (+ (:a data) (:b data))})
+       :schema  {:input  [:map [:a :int] [:b :int]]
+                 :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :test/add-b
+                                 :use   :test/use-both}
+                    :edges      {:start {:done :use}
+                                 :use   {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :use   [[:done (constantly true)]]}}
+                   {} {:a 10} {:propagate-keys? true})]
+      ;; :a should propagate through :test/add-b to :test/use-both
+      (is (= 21 (:result result))))))
+
+(deftest propagate-keys-handler-output-takes-precedence-test
+  (testing "Handler output keys override input keys (handler wins)"
+    (defmethod cell/cell-spec :test/override [_]
+      {:id      :test/override
+       :handler (fn [_ data] {:x (inc (:x data)) :y 99})
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:x :int] [:y :int]]}})
+    (defmethod cell/cell-spec :test/read-xy [_]
+      {:id      :test/read-xy
+       :handler (fn [_ data] {:result (+ (:x data) (:y data))})
+       :schema  {:input  [:map [:x :int] [:y :int]]
+                 :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :test/override
+                                 :read  :test/read-xy}
+                    :edges      {:start {:done :read}
+                                 :read  {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :read  [[:done (constantly true)]]}}
+                   {} {:x 10} {:propagate-keys? true})]
+      ;; handler output :x=11 should override input :x=10
+      (is (= 110 (:result result))))))
+
+(deftest propagate-keys-disabled-by-default-test
+  (testing "Without :propagate-keys?, cells must explicitly include keys in output"
+    (defmethod cell/cell-spec :test/add-b [_]
+      {:id      :test/add-b
+       ;; Handler returns ONLY :b — :a is lost
+       :handler (fn [_ data] {:b (inc (:a data))})
+       :schema  {:input  [:map [:a :int]]
+                 :output [:map [:b :int]]}})
+    (defmethod cell/cell-spec :test/use-both [_]
+      {:id      :test/use-both
+       :handler (fn [_ data] {:result (+ (or (:a data) 0) (:b data))})
+       :schema  {:input  [:map [:a :int] [:b :int]]
+                 :output [:map [:result :int]]}})
+    ;; Without propagate-keys?, input validation on :use will fail
+    ;; because :a is not in the data (only :b is)
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells      {:start :test/add-b
+                                 :use   :test/use-both}
+                    :edges      {:start {:done :use}
+                                 :use   {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :use   [[:done (constantly true)]]}}
+                   {} {:a 10} {:on-error on-error})]
+      ;; :a was lost because propagation is off — input validation on :use should fail
+      (is (some? (:mycelium/schema-error result)))
+      (is (= :input (:phase (:mycelium/schema-error result)))))))
+
+;; ===== Three-cell chain =====
+
+(deftest propagate-keys-through-chain-test
+  (testing "Keys propagate through a multi-cell chain"
+    (defmethod cell/cell-spec :test/step-a [_]
+      {:id      :test/step-a
+       :handler (fn [_ data] {:a-out 1})
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:a-out :int]]}})
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] {:b-out 2})
+       :schema  {:input  [:map [:a-out :int]]
+                 :output [:map [:b-out :int]]}})
+    (defmethod cell/cell-spec :test/step-c [_]
+      {:id      :test/step-c
+       :handler (fn [_ data]
+                  {:result (+ (:x data) (:a-out data) (:b-out data))})
+       :schema  {:input  [:map [:x :int] [:a-out :int] [:b-out :int]]
+                 :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :test/step-a
+                                 :b     :test/step-b
+                                 :c     :test/step-c}
+                    :edges      {:start {:done :b}
+                                 :b     {:done :c}
+                                 :c     {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :b     [[:done (constantly true)]]
+                                 :c     [[:done (constantly true)]]}}
+                   {} {:x 100} {:propagate-keys? true})]
+      ;; :x propagates through all cells, :a-out through step-b and step-c
+      (is (= 103 (:result result))))))
+
+;; ===== Pre-compile with propagate-keys? =====
+
+(deftest propagate-keys-with-pre-compile-test
+  (testing "propagate-keys? works with pre-compile"
+    (defmethod cell/cell-spec :test/add-b [_]
+      {:id      :test/add-b
+       :handler (fn [_ data] {:b (inc (:a data))})
+       :schema  {:input  [:map [:a :int]]
+                 :output [:map [:b :int]]}})
+    (defmethod cell/cell-spec :test/use-both [_]
+      {:id      :test/use-both
+       :handler (fn [_ data] {:result (+ (:a data) (:b data))})
+       :schema  {:input  [:map [:a :int] [:b :int]]
+                 :output [:map [:result :int]]}})
+    (let [compiled (myc/pre-compile
+                     {:cells      {:start :test/add-b
+                                   :use   :test/use-both}
+                      :edges      {:start {:done :use}
+                                   :use   {:done :end}}
+                      :dispatches {:start [[:done (constantly true)]]
+                                   :use   [[:done (constantly true)]]}}
+                     {:propagate-keys? true})
+          result (myc/run-compiled compiled {} {:a 10})]
+      (is (= 21 (:result result))))))
+
+;; ===== Schema validation still works =====
+
+(deftest propagate-keys-schema-validation-still-enforced-test
+  (testing "Output schema validation still catches bad handler output with propagate-keys?"
+    (defmethod cell/cell-spec :test/bad-output [_]
+      {:id      :test/bad-output
+       :handler (fn [_ data] {:count "not-an-int"})
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:count :int]]}})
+    (defmethod cell/cell-spec :test/next [_]
+      {:id      :test/next
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:count :int]]
+                 :output [:map]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells      {:start :test/bad-output
+                                 :next  :test/next}
+                    :edges      {:start {:done :next}
+                                 :next  {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :next  [[:done (constantly true)]]}}
+                   {} {:x 42} {:propagate-keys? true :on-error on-error})]
+      ;; Output schema validation should still catch "not-an-int" for :count
+      (is (some? (:mycelium/schema-error result))))))
+
+;; ===== Coercion + propagate-keys? combined =====
+
+(deftest propagate-keys-with-coercion-test
+  (testing "propagate-keys? and coerce? work together"
+    (defmethod cell/cell-spec :test/produce-double [_]
+      {:id      :test/produce-double
+       :handler (fn [_ data] {:count 10.0})
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:count :double]]}})
+    (defmethod cell/cell-spec :test/consume-int [_]
+      {:id      :test/consume-int
+       :handler (fn [_ data] {:result (+ (:x data) (:count data))})
+       :schema  {:input  [:map [:x :int] [:count :int]]
+                 :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :test/produce-double
+                                 :use   :test/consume-int}
+                    :edges      {:start {:done :use}
+                                 :use   {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :use   [[:done (constantly true)]]}}
+                   {} {:x 5} {:propagate-keys? true :coerce? true})]
+      (is (= 15 (:result result))))))
+
+;; ===== Propagated keys visible in final result =====
+
+(deftest propagated-keys-in-final-result-test
+  (testing "Propagated keys appear in the workflow result"
+    (defmethod cell/cell-spec :test/add-tag [_]
+      {:id      :test/add-tag
+       :handler (fn [_ data] {:tag "processed"})
+       :schema  {:input  [:map [:x :int]]
+                 :output [:map [:tag :string]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :test/add-tag}
+                    :edges      {:start :end}}
+                   {} {:x 42} {:propagate-keys? true})]
+      ;; Both :x (propagated) and :tag (handler output) should be present
+      (is (= 42 (:x result)))
+      (is (= "processed" (:tag result))))))


### PR DESCRIPTION

Automatic key propagation, enabled by default. Each cell's output is automatically merged with its input — cells only need to return new or changed keys. Eliminates the boilerplate of explicitly passing through all upstream keys in every cell's output and output schema. Disable with `:propagate-keys? false` if needed.