### PR TITLE
Feature/execution tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 2026-03-07
 
+### Live Execution Tracing
+
+`:on-trace` callback for real-time observation of workflow execution. Called after each cell completes with the trace entry (cell name, cell-id, transition, duration, data snapshot, errors). No more `println` in handlers.
+
+```clojure
+;; Custom callback
+(myc/run-workflow wf resources data
+  {:on-trace (fn [entry] (log/info (:cell entry) (:duration-ms entry)))})
+
+;; Built-in logger for REPL debugging
+(myc/run-workflow wf resources data {:on-trace (dev/trace-logger)})
+```
+
+Also adds `dev/format-trace` to pretty-print a `:mycelium/trace` vector after the fact.
+
 ### Auto Key Propagation
 
 Automatic key propagation, enabled by default. Each cell's output is automatically merged with its input — cells only need to return new or changed keys. Eliminates the boilerplate of explicitly passing through all upstream keys in every cell's output and output schema. Disable with `:propagate-keys? false` if needed.

--- a/README.md
+++ b/README.md
@@ -611,6 +611,24 @@ Each trace entry contains:
 
 Data snapshots exclude `:mycelium/trace` itself to avoid recursive nesting.
 
+### Live Tracing with `:on-trace`
+
+Pass an `:on-trace` callback to observe execution in real time — no more `println` in handlers:
+
+```clojure
+;; Custom callback — receives each trace entry as it's produced
+(myc/run-workflow workflow-def resources data
+  {:on-trace (fn [{:keys [cell cell-id transition duration-ms]}]
+               (println cell "->" transition (str "[" duration-ms "ms]")))})
+
+;; Built-in logger for quick REPL debugging
+(require '[mycelium.dev :as dev])
+(myc/run-workflow workflow-def resources data {:on-trace (dev/trace-logger)})
+
+;; Format a completed trace for display
+(println (dev/format-trace (:mycelium/trace result)))
+```
+
 ### Asserting on Traces in Tests
 
 ```clojure

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -152,7 +152,8 @@ mentally reconstruct the architecture from.
  :on-error (fn [resources fsm-state] data)        ;; runs when FSM enters error state
  :on-end   (fn [resources fsm-state] data)        ;; runs when FSM enters end state
  :coerce?  true                                    ;; auto-coerce numeric types (int↔double)
- :propagate-keys? false}                            ;; disable auto key propagation (on by default)
+ :propagate-keys? false                             ;; disable auto key propagation (on by default)
+ :on-trace (fn [entry] ...)}                        ;; callback after each cell completes
 ```
 
 ## Accumulating Data Model

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -57,7 +57,10 @@
      :pre  — additional pre-interceptor (fn [fsm-state resources] -> fsm-state)
      :post — additional post-interceptor (fn [fsm-state resources] -> fsm-state)
      :on-error — custom error handler
-     :on-end   — custom end handler"
+     :on-end   — custom end handler
+     :coerce?  — auto-coerce numeric types (int↔double)
+     :propagate-keys? — auto-merge input keys into handler output (default true)
+     :on-trace — callback (fn [trace-entry]) called after each cell completes"
   ([workflow-def] (pre-compile workflow-def {}))
   ([workflow-def opts]
    (let [compiled-fsm (compile-workflow workflow-def opts)
@@ -153,7 +156,10 @@
      :pre  — additional pre-interceptor (fn [fsm-state resources] -> fsm-state)
      :post — additional post-interceptor (fn [fsm-state resources] -> fsm-state)
      :on-error — custom error handler
-     :on-end   — custom end handler"
+     :on-end   — custom end handler
+     :coerce?  — auto-coerce numeric types (int↔double)
+     :propagate-keys? — auto-merge input keys into handler output (default true)
+     :on-trace — callback (fn [trace-entry]) called after each cell completes"
   ([workflow-def]
    (run-workflow workflow-def {} {} {}))
   ([workflow-def resources]

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -404,5 +404,6 @@
    Use with :on-trace opt in run-workflow or pre-compile.
    Example: (myc/run-workflow wf res data {:on-trace (dev/trace-logger)})"
   []
-  (fn [entry]
-    (println (format-trace-entry 0 entry))))
+  (let [counter (atom -1)]
+    (fn [entry]
+      (println (format-trace-entry (swap! counter inc) entry)))))

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -372,3 +372,37 @@
                             (swap! queue conj [target after])))))))))))
         (recur)))
     @result))
+
+(defn- format-trace-entry
+  "Formats a single trace entry as a human-readable string."
+  [idx entry]
+  (let [cell      (:cell entry)
+        cell-id   (:cell-id entry)
+        transition (:transition entry)
+        dur       (:duration-ms entry)
+        error     (:error entry)
+        halted    (:halted entry)
+        timed-out (:timeout? entry)]
+    (str (inc idx) ". " cell " (" cell-id ")"
+         (when transition (str " -> " transition))
+         (when dur (str " [" (format "%.2f" (double dur)) "ms]"))
+         (when halted " [HALTED]")
+         (when timed-out " [TIMEOUT]")
+         (when error
+           (str "\n   ERROR: " (:errors error))))))
+
+(defn format-trace
+  "Formats a :mycelium/trace vector into a human-readable string.
+   Each step shows: cell name, cell-id, transition, duration, and errors."
+  [trace]
+  (if (seq trace)
+    (str/join "\n" (map-indexed format-trace-entry trace))
+    "(empty trace)"))
+
+(defn trace-logger
+  "Returns an :on-trace callback that prints each trace entry to stdout.
+   Use with :on-trace opt in run-workflow or pre-compile.
+   Example: (myc/run-workflow wf res data {:on-trace (dev/trace-logger)})"
+  []
+  (fn [entry]
+    (println (format-trace-entry 0 entry))))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -239,12 +239,15 @@
    used to infer which transition was taken from :current-state-id (set by Maestro
    after dispatch evaluation).
    `state->names` maps resolved-state-id → cell-name keyword for human-readable traces.
-   `opts` — optional map. When `:coerce?` is true, coerces output data before validation.
+   `opts` — optional map:
+     `:coerce?`  — when true, coerces output data before validation.
+     `:on-trace` — callback `(fn [trace-entry])` called after each cell completes.
    Skips terminal states."
   ([state->cell state->edge-targets state->names]
    (make-post-interceptor state->cell state->edge-targets state->names {}))
   ([state->cell state->edge-targets state->names opts]
-   (let [coerce? (:coerce? opts)]
+   (let [coerce?  (:coerce? opts)
+         on-trace (:on-trace opts)]
      (fn [fsm-state _resources]
        (let [state-id (:last-state-id fsm-state)]
          (if (or (nil? state-id)
@@ -285,6 +288,7 @@
                                  halted?       (assoc :halted true)
                                  timed-out?    (assoc :timeout? true)
                                  error         (assoc :error error))]
+               (when on-trace (on-trace trace-entry))
                (cond
                  error
                  (-> fsm-state

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -1153,7 +1153,7 @@
                                joins-map)
          fsm-states (merge fsm-cell-states fsm-join-states)
          ;; Build interceptors — compose custom pre/post with schema interceptors
-         schema-opts (select-keys opts [:coerce?])
+         schema-opts (select-keys opts [:coerce? :on-trace])
          schema-pre  (schema/make-pre-interceptor state->cell schema-opts)
          schema-post (schema/make-post-interceptor state->cell state->edge-targets state->names schema-opts)
          pre  (if-let [custom-pre (:pre opts)]

--- a/test/mycelium/execution_tracing_test.clj
+++ b/test/mycelium/execution_tracing_test.clj
@@ -1,0 +1,143 @@
+(ns mycelium.execution-tracing-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.dev :as dev]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== :on-trace callback =====
+
+(deftest on-trace-called-for-each-cell-test
+  (testing ":on-trace callback receives trace entry after each cell"
+    (defmethod cell/cell-spec :test/step-a [_]
+      {:id      :test/step-a
+       :handler (fn [_ data] {:a 1})
+       :schema  {:input [:map] :output [:map [:a :int]]}})
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] {:b 2})
+       :schema  {:input [:map [:a :int]] :output [:map [:b :int]]}})
+    (let [entries (atom [])
+          result (myc/run-workflow
+                   {:cells      {:start :test/step-a
+                                 :b     :test/step-b}
+                    :edges      {:start {:done :b}
+                                 :b     {:done :end}}
+                    :dispatches {:start [[:done (constantly true)]]
+                                 :b     [[:done (constantly true)]]}}
+                   {} {} {:on-trace #(swap! entries conj %)})]
+      ;; Callback should have been called twice (once per cell)
+      (is (= 2 (count @entries)))
+      ;; First entry is step-a
+      (is (= :start (:cell (first @entries))))
+      (is (= :test/step-a (:cell-id (first @entries))))
+      (is (= :done (:transition (first @entries))))
+      ;; Second entry is step-b
+      (is (= :b (:cell (second @entries))))
+      (is (= :test/step-b (:cell-id (second @entries))))
+      ;; Each entry has duration
+      (is (number? (:duration-ms (first @entries)))))))
+
+(deftest on-trace-includes-data-snapshot-test
+  (testing ":on-trace entry contains data snapshot"
+    (defmethod cell/cell-spec :test/add-x [_]
+      {:id      :test/add-x
+       :handler (fn [_ data] {:result (* 2 (:x data))})
+       :schema  {:input [:map [:x :int]] :output [:map [:result :int]]}})
+    (let [entries (atom [])
+          result (myc/run-workflow
+                   {:cells      {:start :test/add-x}
+                    :edges      {:start :end}}
+                   {} {:x 21} {:on-trace #(swap! entries conj %)})]
+      (is (= 1 (count @entries)))
+      ;; Data snapshot should have the handler output
+      (is (= 42 (get-in (first @entries) [:data :result]))))))
+
+(deftest on-trace-with-pre-compile-test
+  (testing ":on-trace works with pre-compiled workflows"
+    (defmethod cell/cell-spec :test/step [_]
+      {:id      :test/step
+       :handler (fn [_ data] {:done true})
+       :schema  {:input [:map] :output [:map [:done :boolean]]}})
+    (let [entries (atom [])
+          compiled (myc/pre-compile
+                     {:cells {:start :test/step}
+                      :edges {:start :end}}
+                     {:on-trace #(swap! entries conj %)})]
+      (myc/run-compiled compiled {} {})
+      (is (= 1 (count @entries)))
+      (is (= :start (:cell (first @entries)))))))
+
+(deftest on-trace-on-error-test
+  (testing ":on-trace is called even when a cell triggers a schema error"
+    (defmethod cell/cell-spec :test/bad [_]
+      {:id      :test/bad
+       :handler (fn [_ data] {:count "not-int"})
+       :schema  {:input [:map] :output [:map [:count :int]]}})
+    (let [entries (atom [])
+          on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells {:start :test/bad}
+                    :edges {:start :end}}
+                   {} {} {:on-trace #(swap! entries conj %)
+                          :on-error on-error})]
+      ;; Should still get a trace entry (with :error)
+      (is (= 1 (count @entries)))
+      (is (some? (:error (first @entries)))))))
+
+;; ===== format-trace =====
+
+(deftest format-trace-test
+  (testing "format-trace produces human-readable output"
+    (let [trace [{:cell :start :cell-id :app/validate
+                  :transition :done :duration-ms 1.5
+                  :data {:user-id 42}}
+                 {:cell :process :cell-id :app/process
+                  :transition :done :duration-ms 3.2
+                  :data {:user-id 42 :result "ok"}}]
+          formatted (dev/format-trace trace)]
+      ;; Should be a string
+      (is (string? formatted))
+      ;; Should contain cell names
+      (is (str/includes? formatted ":start"))
+      (is (str/includes? formatted ":process"))
+      ;; Should contain duration info
+      (is (str/includes? formatted "1.5"))
+      (is (str/includes? formatted "3.2"))
+      ;; Should contain transitions
+      (is (str/includes? formatted ":done")))))
+
+(deftest format-trace-with-error-test
+  (testing "format-trace shows errors"
+    (let [trace [{:cell :start :cell-id :app/step
+                  :transition :done :duration-ms 0.5
+                  :data {:x 1}
+                  :error {:cell-id :app/step :phase :output
+                          :errors {:count ["should be an integer"]}}}]
+          formatted (dev/format-trace trace)]
+      (is (str/includes? formatted "ERROR"))
+      (is (str/includes? formatted "should be an integer")))))
+
+(deftest format-trace-empty-test
+  (testing "format-trace handles empty trace"
+    (is (string? (dev/format-trace [])))
+    (is (string? (dev/format-trace nil)))))
+
+;; ===== trace-logger =====
+
+(deftest trace-logger-test
+  (testing "trace-logger returns a callback that prints trace entries"
+    (defmethod cell/cell-spec :test/step [_]
+      {:id      :test/step
+       :handler (fn [_ data] {:done true})
+       :schema  {:input [:map] :output [:map [:done :boolean]]}})
+    (let [output (with-out-str
+                   (myc/run-workflow
+                     {:cells {:start :test/step}
+                      :edges {:start :end}}
+                     {} {} {:on-trace (dev/trace-logger)}))]
+      ;; Should have printed something about the cell
+      (is (str/includes? output ":start"))
+      (is (str/includes? output ":test/step")))))


### PR DESCRIPTION
`:on-trace` callback for real-time observation of workflow execution. Called after each cell completes with the trace entry (cell name, cell-id, transition, duration, data snapshot, errors). No more `println` in handlers.