### PR TITLE
Feature/unified error taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
     (handle-success result)))
 ```
 
-Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/timeout`, `:resilience/circuit-open`, `:join`, `:timeout`, `:input`. All return a consistent map with `:error-type`, `:message`, and `:details`.
+Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/timeout`, `:resilience/circuit-open`, `:resilience/bulkhead-full`, `:resilience/rate-limited`, `:join`, `:timeout`, `:input`. All return a consistent map with `:error-type`, `:message`, and `:details`.
 
 ### Live Execution Tracing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 2026-03-07
 
+### Unified Error Inspection
+
+`workflow-error` and `error?` functions for consistent error handling. Instead of checking 6 different `:mycelium/*` keys with different shapes, use one function:
+
+```clojure
+(let [result (myc/run-workflow wf resources data opts)]
+  (if (myc/error? result)
+    (let [{:keys [error-type cell-id message details]} (myc/workflow-error result)]
+      (log/error error-type cell-id message))
+    (handle-success result)))
+```
+
+Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/timeout`, `:resilience/circuit-open`, `:join`, `:timeout`, `:input`. All return a consistent map with `:error-type`, `:message`, and `:details`.
+
 ### Live Execution Tracing
 
 `:on-trace` callback for real-time observation of workflow execution. Called after each cell completes with the trace entry (cell name, cell-id, transition, duration, data snapshot, errors). No more `println` in handlers.

--- a/README.md
+++ b/README.md
@@ -580,6 +580,33 @@ Key propagation is enabled by default. Each cell's handler output is merged on t
 
 Handler output takes precedence over input keys. Internal `:mycelium/*` keys are excluded from propagation. Disable with `{:propagate-keys? false}` if needed.
 
+## Error Inspection
+
+Use `workflow-error` and `error?` for consistent error handling instead of checking individual `:mycelium/*` keys:
+
+```clojure
+(let [result (myc/run-workflow wf resources data opts)]
+  (if (myc/error? result)
+    (let [{:keys [error-type cell-id message details]} (myc/workflow-error result)]
+      (println error-type "-" message))
+    (handle-success result)))
+```
+
+`workflow-error` returns a unified map with `:error-type`, `:message`, and `:details` regardless of the error source:
+
+| `:error-type` | Source |
+|---------------|--------|
+| `:schema/input` | Cell input schema validation failed |
+| `:schema/output` | Cell output schema validation failed |
+| `:handler` | Cell handler threw an exception (error groups) |
+| `:resilience/timeout` | Resilience timeout policy triggered |
+| `:resilience/circuit-open` | Circuit breaker is open |
+| `:join` | One or more join members failed |
+| `:timeout` | Graph-level timeout |
+| `:input` | Workflow-level input schema validation failed |
+
+Returns `nil` (and `error?` returns `false`) when no error is present.
+
 ## Workflow Trace
 
 Every workflow run produces a `:mycelium/trace` vector in the result data — a step-by-step record of which cells ran, what transition was taken, and what the data looked like after each step.

--- a/README.md
+++ b/README.md
@@ -601,6 +601,8 @@ Use `workflow-error` and `error?` for consistent error handling instead of check
 | `:handler` | Cell handler threw an exception (error groups) |
 | `:resilience/timeout` | Resilience timeout policy triggered |
 | `:resilience/circuit-open` | Circuit breaker is open |
+| `:resilience/bulkhead-full` | Bulkhead capacity exhausted |
+| `:resilience/rate-limited` | Rate limiter rejected the call |
 | `:join` | One or more join members failed |
 | `:timeout` | Graph-level timeout |
 | `:input` | Workflow-level input schema validation failed |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -852,4 +852,4 @@ Instead of checking individual keys, use `workflow-error` and `error?`:
                               ;;     :message "...", :details {...}} or nil
 ```
 
-Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/*`, `:join`, `:timeout`, `:input`.
+Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/timeout`, `:resilience/circuit-open`, `:resilience/bulkhead-full`, `:resilience/rate-limited`, `:join`, `:timeout`, `:input`.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -841,3 +841,15 @@ Implement the protocol for your persistence backend (DB, Redis, etc.):
 | `:mycelium/halt` | Halt context (true or map) — present when workflow is halted |
 | `:mycelium/resume` | Resume state token — present when workflow is halted |
 | `:mycelium/session-id` | Store session ID — present when using `run-with-store`/`resume-with-store` on halt |
+
+### Unified Error Inspection
+
+Instead of checking individual keys, use `workflow-error` and `error?`:
+
+```clojure
+(myc/error? result)           ;; => true/false
+(myc/workflow-error result)   ;; => {:error-type :schema/output, :cell-id :app/step,
+                              ;;     :message "...", :details {...}} or nil
+```
+
+Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/*`, `:join`, `:timeout`, `:input`.

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -221,3 +221,67 @@
   "Walks a workflow and reports accumulated schema keys at each cell.
    See mycelium.dev/infer-workflow-schema."
   dev/infer-workflow-schema)
+
+;; --- Error inspection ---
+
+(defn workflow-error
+  "Extracts a unified error map from a workflow result.
+   Returns nil if no error is present, or a map with:
+     :error-type — keyword identifying the error category
+     :message    — human-readable error description
+     :details    — original error data for programmatic access
+   Plus error-specific keys like :cell-id, :cell, :cell-path, :failed-keys."
+  [result]
+  (cond
+    ;; Workflow-level input schema validation
+    (:mycelium/input-error result)
+    (let [err (:mycelium/input-error result)]
+      {:error-type :input
+       :message    (str "Workflow input validation failed: " (:errors err))
+       :details    err})
+
+    ;; Schema validation error (input or output)
+    (:mycelium/schema-error result)
+    (let [err (:mycelium/schema-error result)]
+      {:error-type (keyword "schema" (name (:phase err)))
+       :cell-id    (:cell-id err)
+       :cell-path  (:cell-path err)
+       :failed-keys (:failed-keys err)
+       :message    (str "Schema " (name (:phase err)) " validation failed at "
+                        (:cell-id err) ": " (:errors err))
+       :details    err})
+
+    ;; Handler exception (error groups)
+    (:mycelium/error result)
+    (let [err (:mycelium/error result)]
+      {:error-type :handler
+       :cell       (:cell err)
+       :message    (or (:message err) (str "Handler error at " (:cell err)))
+       :details    err})
+
+    ;; Resilience error (timeout, circuit breaker, etc.)
+    (:mycelium/resilience-error result)
+    (let [err (:mycelium/resilience-error result)]
+      {:error-type (keyword "resilience" (name (:type err)))
+       :cell       (:cell err)
+       :message    (or (:message err)
+                       (str "Resilience " (name (:type err)) " at " (:cell err)))
+       :details    err})
+
+    ;; Join error
+    (:mycelium/join-error result)
+    (let [errs (:mycelium/join-error result)]
+      {:error-type :join
+       :message    (str "Join failed: " (count errs) " member(s) errored")
+       :details    errs})
+
+    ;; Graph-level timeout (bare flag)
+    (:mycelium/timeout result)
+    {:error-type :timeout
+     :message    "Cell timed out"
+     :details    {:timeout true}}))
+
+(defn error?
+  "Returns true if the workflow result contains any error."
+  [result]
+  (some? (workflow-error result)))

--- a/test/mycelium/error_taxonomy_test.clj
+++ b/test/mycelium/error_taxonomy_test.clj
@@ -1,0 +1,148 @@
+(ns mycelium.error-taxonomy-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== workflow-error extracts unified error =====
+
+(deftest workflow-error-nil-on-success-test
+  (testing "workflow-error returns nil for successful workflows"
+    (defmethod cell/cell-spec :test/ok [_]
+      {:id :test/ok
+       :handler (fn [_ data] {:result 42})
+       :schema {:input [:map] :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/ok}
+                    :edges {:start :end}}
+                   {} {})]
+      (is (nil? (myc/workflow-error result))))))
+
+(deftest workflow-error-predicate-test
+  (testing "error? returns true/false based on workflow-error"
+    (defmethod cell/cell-spec :test/ok [_]
+      {:id :test/ok
+       :handler (fn [_ data] {:result 42})
+       :schema {:input [:map] :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/ok}
+                    :edges {:start :end}}
+                   {} {})]
+      (is (false? (myc/error? result))))))
+
+;; ===== Schema errors =====
+
+(deftest workflow-error-schema-output-test
+  (testing "workflow-error normalizes output schema errors"
+    (defmethod cell/cell-spec :test/bad [_]
+      {:id :test/bad
+       :handler (fn [_ data] {:count "not-int"})
+       :schema {:input [:map] :output [:map [:count :int]]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells {:start :test/bad}
+                    :edges {:start :end}}
+                   {} {} {:on-error on-error})
+          err (myc/workflow-error result)]
+      (is (some? err))
+      (is (= :schema/output (:error-type err)))
+      (is (= :test/bad (:cell-id err)))
+      (is (string? (:message err)))
+      (is (map? (:details err))))))
+
+(deftest workflow-error-schema-input-test
+  (testing "workflow-error normalizes input schema errors"
+    (defmethod cell/cell-spec :test/strict [_]
+      {:id :test/strict
+       :handler (fn [_ data] data)
+       :schema {:input [:map [:x :int]] :output [:map]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells {:start :test/strict}
+                    :edges {:start :end}}
+                   {} {:x "bad"} {:on-error on-error})
+          err (myc/workflow-error result)]
+      (is (some? err))
+      (is (= :schema/input (:error-type err)))
+      (is (= :test/strict (:cell-id err))))))
+
+;; ===== Workflow input-schema errors =====
+
+(deftest workflow-error-input-schema-test
+  (testing "workflow-error normalizes workflow-level input-schema errors"
+    (defmethod cell/cell-spec :test/step [_]
+      {:id :test/step
+       :handler (fn [_ data] data)
+       :schema {:input [:map [:x :int]] :output [:map]}})
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/step}
+                    :edges {:start :end}
+                    :input-schema [:map [:x :int]]}
+                   {} {:x "not-int"})
+          err (myc/workflow-error result)]
+      (is (some? err))
+      (is (= :input (:error-type err)))
+      (is (string? (:message err)))
+      (is (map? (:details err))))))
+
+;; ===== Error group errors =====
+
+(deftest workflow-error-handler-exception-test
+  (testing "workflow-error normalizes handler exceptions from error groups"
+    (defmethod cell/cell-spec :test/throws [_]
+      {:id :test/throws
+       :handler (fn [_ data] (throw (ex-info "boom" {:reason :test})))
+       :schema {:input [:map] :output [:map]}})
+    (defmethod cell/cell-spec :test/err-handler [_]
+      {:id :test/err-handler
+       :handler (fn [_ data] data)
+       :schema {:input [:map] :output [:map]}})
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/throws
+                            :err   :test/err-handler}
+                    :edges {:start {:done :end :on-error :err}
+                            :err   :end}
+                    :dispatches {:start [[:done (constantly true)]]}
+                    :error-groups {:pipeline {:cells [:start]
+                                              :on-error :err}}}
+                   {} {})
+          err (myc/workflow-error result)]
+      (is (some? err))
+      (is (= :handler (:error-type err)))
+      (is (= :start (:cell err)))
+      (is (string? (:message err))))))
+
+;; ===== Unified error has consistent shape =====
+
+(deftest workflow-error-consistent-shape-test
+  (testing "All error types have :error-type :message :details"
+    (defmethod cell/cell-spec :test/bad [_]
+      {:id :test/bad
+       :handler (fn [_ data] {:count "not-int"})
+       :schema {:input [:map] :output [:map [:count :int]]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells {:start :test/bad}
+                    :edges {:start :end}}
+                   {} {} {:on-error on-error})
+          err (myc/workflow-error result)]
+      ;; All errors have these three keys
+      (is (keyword? (:error-type err)))
+      (is (string? (:message err)))
+      (is (some? (:details err))))))
+
+;; ===== error? predicate =====
+
+(deftest error-predicate-on-error-test
+  (testing "error? returns true for error results"
+    (defmethod cell/cell-spec :test/bad [_]
+      {:id :test/bad
+       :handler (fn [_ data] {:count "not-int"})
+       :schema {:input [:map] :output [:map [:count :int]]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells {:start :test/bad}
+                    :edges {:start :end}}
+                   {} {} {:on-error on-error})]
+      (is (true? (myc/error? result))))))


### PR DESCRIPTION
`workflow-error` and `error?` functions for consistent error handling. Instead of checking 6 different `:mycelium/*` keys with different shapes, use one function.