### PR TITLE
Add enhanced error messages with cell name and failing keys

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -273,7 +273,7 @@ Graph-level timeouts **route** to a fallback cell. Resilience timeouts **error**
 ```clojure
 (let [result (myc/run-workflow wf resources data)]
   (if (myc/error? result)
-    (let [{:keys [error-type cell-id cell message details]} (myc/workflow-error result)]
+    (let [{:keys [error-type cell-id cell-name cell message details]} (myc/workflow-error result)]
       (case error-type
         :schema/input   (log/warn "Bad input at" cell-id)
         :schema/output  (log/warn "Bad output at" cell-id)
@@ -286,7 +286,7 @@ Graph-level timeouts **route** to a fallback cell. Resilience timeouts **error**
     (handle-success result)))
 ```
 
-`workflow-error` returns nil on success, or a map with `:error-type`, `:message`, `:details` (plus `:cell-id`, `:cell`, `:cell-path`, `:failed-keys` where applicable).
+`workflow-error` returns nil on success, or a map with `:error-type`, `:message`, `:details` (plus `:cell-id`, `:cell-name`, `:cell`, `:cell-path`, `:failed-keys` where applicable). The `:message` includes the cell name and specific failing keys for easy diagnosis.
 
 ---
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -832,7 +832,7 @@ Implement the protocol for your persistence backend (DB, Redis, etc.):
 |-----|-------------|
 | `:mycelium/trace` | Vector of execution trace entries (see Workflow Trace) |
 | `:mycelium/input-error` | Input schema validation failure (workflow didn't run) |
-| `:mycelium/schema-error` | Runtime schema violation details (includes `:failed-keys`, `:cell-path`, clean `:data`) |
+| `:mycelium/schema-error` | Runtime schema violation details (includes `:message`, `:cell-name`, `:failed-keys`, `:cell-path`, clean `:data`) |
 | `:mycelium/join-error` | Join node error details |
 | `:mycelium/timeout` | `true` when a cell exceeded its graph-level timeout |
 | `:mycelium/error` | Error group error details (`{:cell :name, :message "..."}`) |
@@ -849,7 +849,9 @@ Instead of checking individual keys, use `workflow-error` and `error?`:
 ```clojure
 (myc/error? result)           ;; => true/false
 (myc/workflow-error result)   ;; => {:error-type :schema/output, :cell-id :app/step,
-                              ;;     :message "...", :details {...}} or nil
+                              ;;     :cell-name :step, :failed-keys {:x {...}},
+                              ;;     :message "Schema output validation failed at step (:app/step) — failing keys: (:x)",
+                              ;;     :details {...}} or nil
 ```
 
 Error types: `:schema/input`, `:schema/output`, `:handler`, `:resilience/timeout`, `:resilience/circuit-open`, `:resilience/bulkhead-full`, `:resilience/rate-limited`, `:join`, `:timeout`, `:input`.

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -242,14 +242,24 @@
 
     ;; Schema validation error (input or output)
     (:mycelium/schema-error result)
-    (let [err (:mycelium/schema-error result)]
-      {:error-type (keyword "schema" (name (:phase err)))
-       :cell-id    (:cell-id err)
-       :cell-path  (:cell-path err)
-       :failed-keys (:failed-keys err)
-       :message    (str "Schema " (name (:phase err)) " validation failed at "
-                        (:cell-id err) ": " (:errors err))
-       :details    err})
+    (let [err       (:mycelium/schema-error result)
+          cell-name (:cell-name err)
+          cell-id   (:cell-id err)
+          fk        (:failed-keys err)
+          key-names (when fk (keys fk))
+          cell-label (if cell-name
+                       (str cell-name " (" cell-id ")")
+                       (str cell-id))]
+      (cond-> {:error-type  (keyword "schema" (name (:phase err)))
+               :cell-id     cell-id
+               :cell-path   (:cell-path err)
+               :failed-keys fk
+               :message     (str "Schema " (name (:phase err)) " validation failed at "
+                                 cell-label
+                                 (when (seq key-names)
+                                   (str " — failing keys: " (pr-str key-names))))
+               :details     err}
+        cell-name (assoc :cell-name cell-name)))
 
     ;; Handler exception (error groups)
     (:mycelium/error result)

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -31,14 +31,21 @@
           humanized)))
 
 (defn- build-error-map
-  "Builds a schema error map with enriched diagnostics."
+  "Builds a schema error map with enriched diagnostics.
+   Includes a human-readable :message with cell-id, phase, and failing key names."
   [cell-id phase explanation data]
-  (let [humanized (me/humanize explanation)]
+  (let [humanized   (me/humanize explanation)
+        failed-keys (when (map? humanized) (build-failed-keys humanized data))
+        key-names   (when failed-keys (keys failed-keys))
+        message     (str "Schema " (name phase) " validation failed at " cell-id
+                         (when (seq key-names)
+                           (str " — failing keys: " (pr-str key-names))))]
     (cond-> {:cell-id     cell-id
              :phase       phase
+             :message     message
              :errors      humanized
              :data        (strip-mycelium-keys data)}
-      (map? humanized) (assoc :failed-keys (build-failed-keys humanized data)))))
+      failed-keys (assoc :failed-keys failed-keys))))
 
 (defn validate-input
   "Validates data against the cell's input schema.
@@ -88,10 +95,12 @@
            (when (every? (fn [schema]
                            (some? (m/explain schema data)))
                          schemas)
-             {:cell-id (:id cell)
-              :phase   :output
-              :errors  (str "Data does not match any output schema for " (:id cell))
-              :data    (strip-mycelium-keys data)})))
+             (let [msg (str "Data does not match any output schema for " (:id cell))]
+               {:cell-id (:id cell)
+                :phase   :output
+                :message msg
+                :errors  msg
+                :data    (strip-mycelium-keys data)}))))
 
        ;; Single schema (vector or keyword)
        :else
@@ -147,10 +156,12 @@
                              coerced)))]
            (if-let [coerced (first (filter some? results))]
              {:data coerced}
-             {:error {:cell-id (:id cell)
-                      :phase   :output
-                      :errors  (str "Data does not match any output schema for " (:id cell))
-                      :data    (strip-mycelium-keys data)}})))
+             (let [msg (str "Data does not match any output schema for " (:id cell))]
+               {:error {:cell-id (:id cell)
+                        :phase   :output
+                        :message msg
+                        :errors  msg
+                        :data    (strip-mycelium-keys data)}}))))
 
        :else
        (let [coerced (m/decode output data number-coercion-transformer)]
@@ -202,14 +213,24 @@
     (cond-> error
       (seq path) (assoc :cell-path path))))
 
+(defn- attach-cell-name
+  "Attaches :cell-name to an error map from state->names lookup."
+  [error state-id state->names]
+  (if-let [cell-name (get state->names state-id)]
+    (assoc error :cell-name cell-name)
+    error))
+
 (defn make-pre-interceptor
   "Creates a Maestro pre-interceptor that validates input schemas.
    `state->cell` is a map of state-id → cell-spec.
-   `opts` — optional map. When `:coerce?` is true, coerces data before validation.
+   `opts` — optional map:
+     `:coerce?`      — when true, coerces data before validation.
+     `:state->names` — map of state-id → cell-name keyword for error messages.
    Skips terminal states."
   ([state->cell] (make-pre-interceptor state->cell {}))
   ([state->cell opts]
-   (let [coerce? (:coerce? opts)]
+   (let [coerce?      (:coerce? opts)
+         state->names (:state->names opts)]
      (fn [fsm-state _resources]
        (let [state-id (:current-state-id fsm-state)]
          (if (contains? terminal-states state-id)
@@ -221,13 +242,17 @@
                    (-> fsm-state
                        (assoc :current-state-id ::fsm/error)
                        (assoc-in [:data :mycelium/schema-error]
-                                 (attach-cell-path (:error result) (:data fsm-state))))
+                                 (-> (:error result)
+                                     (attach-cell-path (:data fsm-state))
+                                     (attach-cell-name state-id state->names))))
                    (assoc fsm-state :data (:data result))))
                (if-let [error (validate-input cell (:data fsm-state))]
                  (-> fsm-state
                      (assoc :current-state-id ::fsm/error)
                      (assoc-in [:data :mycelium/schema-error]
-                               (attach-cell-path error (:data fsm-state))))
+                               (-> error
+                                   (attach-cell-path (:data fsm-state))
+                                   (attach-cell-name state-id state->names))))
                  fsm-state))
              fsm-state)))))))
 
@@ -296,7 +321,9 @@
                      (update :data dissoc :mycelium/join-traces :mycelium/params)
                      (assoc :current-state-id ::fsm/error)
                      (assoc-in [:data :mycelium/schema-error]
-                               (attach-cell-path error (:data fsm-state))))
+                               (-> error
+                                   (attach-cell-path (:data fsm-state))
+                                   (attach-cell-name state-id state->names))))
 
                  halted?
                  (-> fsm-state

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -1150,7 +1150,8 @@
                                joins-map)
          fsm-states (merge fsm-cell-states fsm-join-states)
          ;; Build interceptors — compose custom pre/post with schema interceptors
-         schema-opts (select-keys opts [:coerce? :on-trace])
+         schema-opts (-> (select-keys opts [:coerce? :on-trace])
+                        (assoc :state->names state->names))
          schema-pre  (schema/make-pre-interceptor state->cell schema-opts)
          schema-post (schema/make-post-interceptor state->cell state->edge-targets state->names schema-opts)
          pre  (if-let [custom-pre (:pre opts)]

--- a/test/mycelium/error_messages_test.clj
+++ b/test/mycelium/error_messages_test.clj
@@ -126,6 +126,77 @@
       (let [schema-error (get-in result [:data :mycelium/schema-error])]
         (is (= [:start :validate] (:cell-path schema-error)))))))
 
+;; ===== build-error-map includes :message with cell-id and failing keys =====
+
+(deftest build-error-map-includes-message-test
+  (testing "build-error-map :message includes cell-id, phase, and specific failing key names"
+    (defmethod cell/cell-spec :test/typed [_]
+      {:id      :test/typed
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map [:amount :int] [:name :string]]
+                 :output [:map]}})
+    (let [cell  (cell/get-cell! :test/typed)
+          error (schema/validate-input cell {:amount 949.5 :name 42})]
+      (is (some? error))
+      ;; :message should be a string containing cell-id and the failing key names
+      (is (string? (:message error)))
+      (is (re-find #":test/typed" (:message error)))
+      (is (re-find #":amount" (:message error)))
+      (is (re-find #":name" (:message error)))
+      (is (re-find #"input" (:message error))))))
+
+(deftest build-error-map-output-message-test
+  (testing "build-error-map :message for output phase includes cell-id and failing keys"
+    (defmethod cell/cell-spec :test/typed [_]
+      {:id      :test/typed
+       :handler (fn [_ data] data)
+       :schema  {:input  [:map]
+                 :output [:map [:result :int]]}})
+    (let [cell  (cell/get-cell! :test/typed)
+          error (schema/validate-output cell {:result "not-int"})]
+      (is (some? error))
+      (is (string? (:message error)))
+      (is (re-find #":test/typed" (:message error)))
+      (is (re-find #":result" (:message error)))
+      (is (re-find #"output" (:message error))))))
+
+;; ===== Interceptor errors include :cell-name =====
+
+(deftest post-interceptor-error-includes-cell-name-test
+  (testing "Post-interceptor schema error includes :cell-name from state->names"
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] data)
+       :schema  {:input [:map [:a-done :boolean]] :output [:map [:result :int]]}})
+    (let [state->cell {:test/step-b (cell/get-cell! :test/step-b)}
+          state->names {:test/step-b :step-b}
+          post (schema/make-post-interceptor state->cell nil state->names)
+          fsm-state {:last-state-id    :test/step-b
+                     :current-state-id :some/next
+                     :data {:a-done true}
+                     :trace []}
+          result (post fsm-state {})]
+      (is (= ::fsm/error (:current-state-id result)))
+      (let [schema-error (get-in result [:data :mycelium/schema-error])]
+        (is (= :step-b (:cell-name schema-error)))))))
+
+(deftest pre-interceptor-error-includes-cell-name-test
+  (testing "Pre-interceptor schema error includes :cell-name from state->names"
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] data)
+       :schema  {:input [:map [:x :int]] :output [:map]}})
+    (let [state->cell {:test/step-b (cell/get-cell! :test/step-b)}
+          state->names {:test/step-b :step-b}
+          pre (schema/make-pre-interceptor state->cell {:state->names state->names})
+          fsm-state {:current-state-id :test/step-b
+                     :data {:x "bad"}
+                     :trace []}
+          result (pre fsm-state {})]
+      (is (= ::fsm/error (:current-state-id result)))
+      (let [schema-error (get-in result [:data :mycelium/schema-error])]
+        (is (= :step-b (:cell-name schema-error)))))))
+
 ;; ===== End-to-end: workflow error messages =====
 
 (deftest workflow-error-has-enriched-diagnostics-test
@@ -154,3 +225,30 @@
       (is (= 42.5 (get-in schema-error [:failed-keys :count :value])))
       ;; :data should not contain :mycelium/trace
       (is (not (contains? (:data schema-error) :mycelium/trace))))))
+
+(deftest workflow-error-message-includes-cell-name-and-keys-test
+  (testing "workflow-error :message includes cell-name and specific failing keys"
+    (defmethod cell/cell-spec :test/step-a [_]
+      {:id      :test/step-a
+       :handler (fn [_ data] (assoc data :count 42.5))
+       :schema  {:input [:map [:x :int]] :output [:map [:count :double]]}})
+    (defmethod cell/cell-spec :test/step-b [_]
+      {:id      :test/step-b
+       :handler (fn [_ data] (assoc data :result (:count data)))
+       :schema  {:input [:map [:count :int]] :output [:map [:result :int]]}})
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result (myc/run-workflow
+                   {:cells      {:start  :test/step-a
+                                 :step-b :test/step-b}
+                    :edges      {:start  {:done :step-b}
+                                 :step-b {:done :end}}
+                    :dispatches {:start  [[:done (constantly true)]]
+                                 :step-b [[:done (constantly true)]]}}
+                   {} {:x 42} {:on-error on-error})
+          we (myc/workflow-error result)]
+      ;; workflow-error message should mention the cell name and the failing key
+      (is (string? (:message we)))
+      (is (re-find #"step-b" (:message we)))
+      (is (re-find #":count" (:message we)))
+      ;; Should also surface :cell-name
+      (is (= :step-b (:cell-name we))))))


### PR DESCRIPTION
Schema validation errors now include a human-readable :message with the cell-id, phase, and specific failing key names. Both pre and post interceptors attach :cell-name (the workflow cell name) to errors. workflow-error surfaces :cell-name and failing keys in its message for easy diagnosis.