### PR TITLE
Add edge transforms for declarative data reshaping between cells

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -411,6 +411,55 @@ Each trace entry: `{:cell :name, :cell-id :ns/id, :transition :label, :duration-
 
 ---
 
+## Reshape Data Between Cells (Edge Transforms)
+
+**Problem:** Two cells don't share the same key names — one produces `:user-name` but the next expects `:name`. You don't want to modify either cell.
+
+```clojure
+(def workflow
+  {:cells {:start :user/lookup
+           :greet :user/greet}
+   :edges {:start :greet, :greet :end}
+   :transforms {:start {:output {:fn     (fn [data] (assoc data :name (:user-name data)))
+                                  :schema {:input  [:map [:user-name :string]]
+                                           :output [:map [:name :string]]}}}}})
+```
+
+The output transform runs after `:start`'s handler and output validation, before `:greet`'s input validation. The cell handlers stay untouched.
+
+### Branching Cells with Different Downstream Contracts
+
+When a branching cell feeds different cells that expect different key shapes:
+
+```clojure
+:transforms {:classify {:premium {:output {:fn     (fn [data] (assoc data :level (:tier data)))
+                                            :schema {:input  [:map [:tier :keyword]]
+                                                     :output [:map [:level :keyword]]}}}
+                         :basic   {:output {:fn     (fn [data] (assoc data :category (name (:tier data))))
+                                            :schema {:input  [:map [:tier :keyword]]
+                                                     :output [:map [:category :string]]}}}}}
+```
+
+Only the transform for the taken edge is applied. The schema chain validator checks each path independently.
+
+### Input Transform (reshape before cell runs)
+
+When a cell needs data in a different shape than what upstream produces:
+
+```clojure
+:transforms {:process {:input {:fn     (fn [data] (assoc data :score (:raw-value data)))
+                                :schema {:input  [:map [:raw-value :int]]
+                                         :output [:map [:score :int]]}}}}
+```
+
+Input transforms run before the cell's input schema validation.
+
+### When to Use Transforms vs. Adding a Cell
+
+Use **transforms** for mechanical reshaping (key renaming, type coercion, structural mapping). Use a **new cell** when the logic involves domain decisions, side effects, or is complex enough to deserve its own test coverage.
+
+---
+
 ## Handle Type Mismatches Between Cells
 
 **Problem:** One cell produces a `double` but the next expects an `int`.

--- a/docs/developing-workflows.md
+++ b/docs/developing-workflows.md
@@ -413,6 +413,28 @@ Once the core logic works, layer on operational concerns:
 
 These are declared in the workflow definition — cell handlers stay focused on domain logic.
 
+### Add Edge Transforms
+
+When integrating cells with mismatched key names — especially when reusing existing cells from different contexts — use edge transforms instead of modifying cell handlers or adding adapter cells:
+
+```clojure
+;; Cell A produces :user-name, Cell B expects :name
+:transforms {:cell-a {:output {:fn     (fn [data] (assoc data :name (:user-name data)))
+                                :schema {:input  [:map [:user-name :string]]
+                                         :output [:map [:name :string]]}}}}
+```
+
+Transforms are validated at compile time — their schemas participate in the schema chain validation, catching mismatches before runtime.
+
+For branching cells, apply different transforms per edge when downstream cells have different contracts:
+
+```clojure
+:transforms {:classify {:premium {:output {:fn ... :schema ...}}
+                         :basic   {:output {:fn ... :schema ...}}}}
+```
+
+**When to use transforms vs. cells:** Transforms are for mechanical reshaping (key renaming, structural mapping). If the reshaping involves domain logic or needs its own tests, make it a cell.
+
 ### Add Constraints
 
 Declare structural invariants once the graph is stable:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -213,6 +213,8 @@ Key propagation is on by default — cells can return only new/changed keys and 
  :input-schema [:map [:key :type]]                                ;; optional
  :interceptors [{:id :x :scope :all :pre (fn [d] d)}]            ;; optional
  :resilience  {:start {:timeout {:timeout-ms 5000}}}              ;; optional
+ :transforms  {:cell-name {:input  {:fn f :schema {:input [...] :output [...]}}  ;; optional
+                            :output {:fn f :schema {:input [...] :output [...]}}}}
 }
 ```
 
@@ -417,6 +419,74 @@ Scope forms:
 
 Interceptor `:pre`/`:post` receive and return the `data` map (not fsm-state).
 
+## Edge Transforms
+
+Declarative data reshaping at cell boundaries. Transforms run outside the cell handler — the cell stays pure while data is adapted between cells.
+
+### Input Transform (reshape before cell runs)
+
+```clojure
+:transforms {:greet {:input {:fn     (fn [data] (assoc data :name (:user-name data)))
+                              :schema {:input  [:map [:user-name :string]]
+                                       :output [:map [:name :string]]}}}}
+```
+
+The `:fn` runs before the cell's input schema validation. The `:schema` documents what the transform expects and produces, and is validated at compile time against the schema chain.
+
+### Output Transform (reshape after cell runs)
+
+```clojure
+:transforms {:start {:output {:fn     (fn [data] (assoc data :name (:user-name data)))
+                               :schema {:input  [:map [:user-name :string]]
+                                        :output [:map [:name :string]]}}}}
+```
+
+The `:fn` runs after the cell's output schema validation, before the next cell's input validation.
+
+### Edge-Specific Output Transforms (branching cells)
+
+When a cell dispatches to multiple edges, apply different transforms per edge:
+
+```clojure
+:transforms {:classify {:premium {:output {:fn     (fn [data] (assoc data :level (:tier data)))
+                                            :schema {:input  [:map [:tier :keyword]]
+                                                     :output [:map [:level :keyword]]}}}
+                         :basic   {:output {:fn     (fn [data] (assoc data :category (name (:tier data))))
+                                            :schema {:input  [:map [:tier :keyword]]
+                                                     :output [:map [:category :string]]}}}}}
+```
+
+Only the transform for the taken edge is applied.
+
+### Combining Input and Edge-Specific Output Transforms
+
+```clojure
+:transforms {:classify {:input   {:fn     (fn [data] (assoc data :score (:raw-value data)))
+                                   :schema {:input  [:map [:raw-value :int]]
+                                            :output [:map [:score :int]]}}
+                         :premium {:output {:fn     (fn [data] (assoc data :level (:tier data)))
+                                            :schema {:input  [:map [:tier :keyword]]
+                                                     :output [:map [:level :keyword]]}}}
+                         :basic   {:output {:fn     (fn [data] (assoc data :category (name (:tier data))))
+                                            :schema {:input  [:map [:tier :keyword]]
+                                                     :output [:map [:category :string]]}}}}}
+```
+
+### When to Use Transforms vs. Cells
+
+- **Transforms** — mechanical key renaming, type adaptation, or structural reshaping between cells that don't share a schema contract. Zero runtime overhead beyond the function call.
+- **New cell** — when the reshaping involves domain logic, side effects, or is complex enough to warrant its own schema and tests.
+
+### Transform Spec
+
+Each transform is `{:fn f, :schema {:input [...] :output [...]}}`:
+
+- `:fn` — `(fn [data] -> data)`, a pure function that reshapes the data map
+- `:schema :input` — Malli schema documenting what the transform expects
+- `:schema :output` — Malli schema documenting what the transform produces
+
+Both schemas are validated at compile time. The schema chain validator uses transform schemas to verify key availability across cells.
+
 ## Parameterized Cells
 
 Reuse the same handler with different config by passing a map instead of a bare keyword:
@@ -583,6 +653,7 @@ Declare compile-time path invariants that are checked against all enumerated pat
 - **Error groups** — grouped cells exist, error handler exists, no cell in multiple groups
 - **Resilience validation** — policy keys valid, referenced cells exist, timeout-ms positive
 - **Join validation** — member cells exist, no name collisions, members have no edges, output keys disjoint (or `:merge-fn` provided)
+- **Transform validation** — referenced cells exist, edge labels match cell's edges, each spec has `:fn` (function) and valid `:schema`
 
 ## Edge Targets
 

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -322,4 +322,5 @@
       (:joins manifest) (assoc :joins (:joins manifest))
       (:input-schema manifest) (assoc :input-schema (:input-schema manifest))
       (:interceptors manifest) (assoc :interceptors (:interceptors manifest))
-      (:resilience manifest) (assoc :resilience (:resilience manifest)))))
+      (:resilience manifest) (assoc :resilience (:resilience manifest))
+      (:transforms manifest) (assoc :transforms (:transforms manifest)))))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -224,36 +224,42 @@
   "Creates a Maestro pre-interceptor that validates input schemas.
    `state->cell` is a map of state-id → cell-spec.
    `opts` — optional map:
-     `:coerce?`      — when true, coerces data before validation.
-     `:state->names` — map of state-id → cell-name keyword for error messages.
+     `:coerce?`          — when true, coerces data before validation.
+     `:state->names`     — map of state-id → cell-name keyword for error messages.
+     `:input-transforms` — map of state-id → (fn [data] -> data), applied before validation.
    Skips terminal states."
   ([state->cell] (make-pre-interceptor state->cell {}))
   ([state->cell opts]
-   (let [coerce?      (:coerce? opts)
-         state->names (:state->names opts)]
+   (let [coerce?          (:coerce? opts)
+         state->names     (:state->names opts)
+         input-transforms (:input-transforms opts)]
      (fn [fsm-state _resources]
        (let [state-id (:current-state-id fsm-state)]
          (if (contains? terminal-states state-id)
            fsm-state
            (if-let [cell (get state->cell state-id)]
-             (if coerce?
-               (let [result (coerce-input cell (:data fsm-state))]
-                 (if (:error result)
+             (let [;; Apply input transform before validation
+                   fsm-state (if-let [xf (get input-transforms state-id)]
+                               (update fsm-state :data xf)
+                               fsm-state)]
+               (if coerce?
+                 (let [result (coerce-input cell (:data fsm-state))]
+                   (if (:error result)
+                     (-> fsm-state
+                         (assoc :current-state-id ::fsm/error)
+                         (assoc-in [:data :mycelium/schema-error]
+                                   (-> (:error result)
+                                       (attach-cell-path (:data fsm-state))
+                                       (attach-cell-name state-id state->names))))
+                     (assoc fsm-state :data (:data result))))
+                 (if-let [error (validate-input cell (:data fsm-state))]
                    (-> fsm-state
                        (assoc :current-state-id ::fsm/error)
                        (assoc-in [:data :mycelium/schema-error]
-                                 (-> (:error result)
+                                 (-> error
                                      (attach-cell-path (:data fsm-state))
                                      (attach-cell-name state-id state->names))))
-                   (assoc fsm-state :data (:data result))))
-               (if-let [error (validate-input cell (:data fsm-state))]
-                 (-> fsm-state
-                     (assoc :current-state-id ::fsm/error)
-                     (assoc-in [:data :mycelium/schema-error]
-                               (-> error
-                                   (attach-cell-path (:data fsm-state))
-                                   (attach-cell-name state-id state->names))))
-                 fsm-state))
+                   fsm-state)))
              fsm-state)))))))
 
 (defn make-post-interceptor
@@ -271,8 +277,9 @@
   ([state->cell state->edge-targets state->names]
    (make-post-interceptor state->cell state->edge-targets state->names {}))
   ([state->cell state->edge-targets state->names opts]
-   (let [coerce?  (:coerce? opts)
-         on-trace (:on-trace opts)]
+   (let [coerce?           (:coerce? opts)
+         on-trace          (:on-trace opts)
+         output-transforms (:output-transforms opts)]
      (fn [fsm-state _resources]
        (let [state-id (:last-state-id fsm-state)]
          (if (or (nil? state-id)
@@ -297,6 +304,15 @@
                    ;; Use coerced data when available
                    data (if (and coerce? (not skip-validation?) (not error))
                           (:data coerce-result)
+                          data)
+                   ;; Apply output transform if present (only on success)
+                   data (if (and (nil? error) (not skip-validation?))
+                          (if-let [xf-lookup (get output-transforms state-id)]
+                            (let [xf (if (map? xf-lookup)
+                                       (get xf-lookup transition)
+                                       xf-lookup)]
+                              (if xf (xf data) data))
+                            data)
                           data)
                    ;; Extract duration-ms from the latest Maestro trace segment
                    duration-ms (some-> (:trace fsm-state) last :duration-ms)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -419,90 +419,132 @@
           (or dispatches-map {})
           edges-map))
 
+(defn- get-transform-output-keys
+  "Extracts output keys from a transform spec's :schema :output, if present."
+  [transform-spec]
+  (when-let [schema (get-in transform-spec [:schema :output])]
+    (get-map-keys schema)))
+
+(defn- get-transform-input-keys
+  "Extracts input keys from a transform spec's :schema :input, if present."
+  [transform-spec]
+  (when-let [schema (get-in transform-spec [:schema :input])]
+    (get-map-keys schema)))
+
 (defn- validate-schema-chain!
   "Walks all paths from :start, accumulating output keys.
    For each cell, checks its input keys are available from upstream outputs or workflow input.
    For per-transition output schemas, only passes the keys from the matching transition's schema
    along each edge.
-   Join nodes: validates each member's inputs, then adds the union of all member outputs."
-  [edges-map cells-map joins-map]
-  (let [get-input-keys  (fn [cell-id]
-                          (let [cell   (cell/get-cell! cell-id)
-                                schema (get-in cell [:schema :input])]
-                            (get-map-keys schema)))
-        errors (atom [])
-        visit  (fn visit [cell-name available-keys visited]
-                 (when-not (or (contains? visited cell-name)
-                               (contains? #{:end :error :halt} cell-name))
-                   (if-let [join-def (get joins-map cell-name)]
-                     ;; This is a join node — validate member inputs and accumulate union of outputs
-                     (let [member-names (:cells join-def)]
-                       ;; Validate each member's input keys against available
-                       (doseq [member member-names]
-                         (let [cell-id    (get cells-map member)
-                               input-keys (get-input-keys cell-id)
-                               missing    (when input-keys
-                                            (set/difference input-keys available-keys))]
-                           (when (seq missing)
-                             (swap! errors conj
-                                    {:cell-name     member
-                                     :cell-id       cell-id
-                                     :missing-keys  missing
-                                     :available-keys available-keys}))))
-                       ;; Accumulate union of all member output keys
-                       (let [out-keys (build-join-output-keys join-def cells-map)
-                             new-keys (into available-keys out-keys)
-                             edge-def (get edges-map cell-name)]
-                         (if (keyword? edge-def)
-                           (visit edge-def new-keys (conj visited cell-name))
-                           (doseq [[_transition target] edge-def]
-                             (visit target new-keys (conj visited cell-name))))))
-                     ;; Regular cell
-                     (let [cell-id     (get cells-map cell-name)
-                           input-keys  (get-input-keys cell-id)
-                           missing     (when input-keys
-                                         (set/difference input-keys available-keys))]
-                       (when (seq missing)
-                         (swap! errors conj
-                                {:cell-name     cell-name
-                                 :cell-id       cell-id
-                                 :missing-keys  missing
-                                 :available-keys available-keys}))
-                       ;; Traverse edges, using per-transition output keys
-                       (let [edge-def (get edges-map cell-name)]
-                         (if (keyword? edge-def)
-                           ;; Unconditional edge — use union of all output keys
-                           (let [out-keys (get-all-output-keys cell-id)
-                                 new-keys (into available-keys (or out-keys #{}))]
-                             (visit edge-def new-keys (conj visited cell-name)))
-                           ;; Map edges — per-transition output keys
-                           (doseq [[transition target] edge-def]
-                             (let [out-keys (get-output-keys-for-transition cell-id transition)
-                                   new-keys (into available-keys (or out-keys #{}))]
-                               (visit target new-keys (conj visited cell-name))))))))))]
-    ;; Start with :start cell
-    (let [start-cell-id    (get cells-map :start)
-          start-input-keys (when start-cell-id (get-input-keys start-cell-id))
-          initial-keys     (or start-input-keys #{})
-          edge-def         (get edges-map :start)]
-      (if (keyword? edge-def)
-        (let [out-keys (get-all-output-keys start-cell-id)
-              new-keys (into initial-keys (or out-keys #{}))]
-          (visit edge-def new-keys #{:start}))
-        (doseq [[transition target] edge-def]
-          (let [out-keys (get-output-keys-for-transition start-cell-id transition)
-                new-keys (into initial-keys (or out-keys #{}))]
-            (visit target new-keys #{:start})))))
-    (when (seq @errors)
-      (let [msg (str "Schema chain error: "
-                     (str/join
-                      "; "
-                      (map (fn [{:keys [cell-name cell-id missing-keys available-keys]}]
-                             (str cell-id " at " cell-name
-                                  " requires keys " missing-keys
-                                  " but only " available-keys " available"))
-                           @errors)))]
-        (throw (ex-info msg {:errors @errors}))))))
+   Join nodes: validates each member's inputs, then adds the union of all member outputs.
+   When transforms are present, uses transform schemas instead of cell schemas for chain checks."
+  ([edges-map cells-map joins-map]
+   (validate-schema-chain! edges-map cells-map joins-map nil))
+  ([edges-map cells-map joins-map transforms]
+   (let [get-input-keys  (fn [cell-id]
+                           (let [cell   (cell/get-cell! cell-id)
+                                 schema (get-in cell [:schema :input])]
+                             (get-map-keys schema)))
+         errors (atom [])
+         visit  (fn visit [cell-name available-keys visited]
+                  (when-not (or (contains? visited cell-name)
+                                (contains? #{:end :error :halt} cell-name))
+                    (if-let [join-def (get joins-map cell-name)]
+                      ;; This is a join node — validate member inputs and accumulate union of outputs
+                      (let [member-names (:cells join-def)]
+                        ;; Validate each member's input keys against available
+                        (doseq [member member-names]
+                          (let [cell-id    (get cells-map member)
+                                input-keys (get-input-keys cell-id)
+                                missing    (when input-keys
+                                             (set/difference input-keys available-keys))]
+                            (when (seq missing)
+                              (swap! errors conj
+                                     {:cell-name     member
+                                      :cell-id       cell-id
+                                      :missing-keys  missing
+                                      :available-keys available-keys}))))
+                        ;; Accumulate union of all member output keys
+                        (let [out-keys (build-join-output-keys join-def cells-map)
+                              new-keys (into available-keys out-keys)
+                              edge-def (get edges-map cell-name)]
+                          (if (keyword? edge-def)
+                            (visit edge-def new-keys (conj visited cell-name))
+                            (doseq [[_transition target] edge-def]
+                              (visit target new-keys (conj visited cell-name))))))
+                      ;; Regular cell
+                      (let [cell-id     (get cells-map cell-name)
+                            ;; If cell has an input transform, check transform's input keys instead
+                            xf-def      (get transforms cell-name)
+                            input-xf    (when xf-def
+                                          (or (:input xf-def)
+                                              ;; For branching, :input is at top level
+                                              nil))
+                            effective-input-keys (if input-xf
+                                                   (get-transform-input-keys input-xf)
+                                                   (get-input-keys cell-id))
+                            missing     (when effective-input-keys
+                                          (set/difference effective-input-keys available-keys))]
+                        (when (seq missing)
+                          (swap! errors conj
+                                 {:cell-name     cell-name
+                                  :cell-id       cell-id
+                                  :missing-keys  missing
+                                  :available-keys available-keys}))
+                        ;; Traverse edges, using per-transition output keys
+                        (let [edge-def (get edges-map cell-name)]
+                          (if (keyword? edge-def)
+                            ;; Unconditional edge — use union of all output keys
+                            (let [out-keys (get-all-output-keys cell-id)
+                                  ;; Add output transform keys if present
+                                  xf-out-keys (when-let [xf (:output xf-def)]
+                                                (get-transform-output-keys xf))
+                                  new-keys (into available-keys
+                                                 (concat (or out-keys #{})
+                                                         (or xf-out-keys #{})))]
+                              (visit edge-def new-keys (conj visited cell-name)))
+                            ;; Map edges — per-transition output keys
+                            (doseq [[transition target] edge-def]
+                              (let [out-keys (get-output-keys-for-transition cell-id transition)
+                                    ;; Add per-edge output transform keys if present
+                                    xf-out-keys (when-let [edge-xf (get xf-def transition)]
+                                                  (get-transform-output-keys (:output edge-xf)))
+                                    new-keys (into available-keys
+                                                   (concat (or out-keys #{})
+                                                           (or xf-out-keys #{})))]
+                                (visit target new-keys (conj visited cell-name))))))))))]
+     ;; Start with :start cell
+     (let [start-cell-id    (get cells-map :start)
+           start-input-keys (when start-cell-id (get-input-keys start-cell-id))
+           initial-keys     (or start-input-keys #{})
+           edge-def         (get edges-map :start)
+           xf-def           (get transforms :start)]
+       (if (keyword? edge-def)
+         (let [out-keys (get-all-output-keys start-cell-id)
+               xf-out-keys (when-let [xf (:output xf-def)]
+                             (get-transform-output-keys xf))
+               new-keys (into initial-keys
+                              (concat (or out-keys #{})
+                                      (or xf-out-keys #{})))]
+           (visit edge-def new-keys #{:start}))
+         (doseq [[transition target] edge-def]
+           (let [out-keys (get-output-keys-for-transition start-cell-id transition)
+                 xf-out-keys (when-let [edge-xf (get xf-def transition)]
+                               (get-transform-output-keys (:output edge-xf)))
+                 new-keys (into initial-keys
+                                (concat (or out-keys #{})
+                                        (or xf-out-keys #{})))]
+             (visit target new-keys #{:start})))))
+     (when (seq @errors)
+       (let [msg (str "Schema chain error: "
+                      (str/join
+                       "; "
+                       (map (fn [{:keys [cell-name cell-id missing-keys available-keys]}]
+                              (str cell-id " at " cell-name
+                                   " requires keys " missing-keys
+                                   " but only " available-keys " available"))
+                            @errors)))]
+         (throw (ex-info msg {:errors @errors})))))))
 
 (def ^:private join-default-dispatches
   "Default dispatch predicates for join nodes.
@@ -836,6 +878,8 @@
         (when-let [error (check-constraint constraint paths)]
           (throw (ex-info error {:constraint constraint})))))))
 
+(declare validate-transforms!)
+
 (defn validate-workflow
   "Runs all validations on a workflow definition.
    Merges :default-dispatches from cell specs as fallback for cells without explicit dispatches."
@@ -885,13 +929,98 @@
                 effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
                                             join-dispatches)]
             (v/validate-dispatch-coverage! edges effective-dispatches))
-          (validate-schema-chain! edges cell-ids joins-map)
+          ;; Validate transforms before schema chain (transforms affect key availability)
+          (when-let [transforms (:transforms raw-workflow)]
+            (validate-transforms! transforms cells edges))
+          (validate-schema-chain! edges cell-ids joins-map (:transforms raw-workflow))
           ;; Validate graph-level timeouts
           (when-let [timeouts (:timeouts raw-workflow)]
             (validate-timeouts! timeouts cells edges))
           ;; Validate constraints (after all structural validations pass)
           (when-let [constraints (:constraints raw-workflow)]
             (validate-constraints! constraints edges)))))))
+
+;; ===== Edge transform validation & compilation =====
+
+(defn- validate-transform-spec!
+  "Validates a single transform spec {:fn f, :schema {:input [...] :output [...]}}."
+  [cell-name label spec]
+  (when-not (and (map? spec) (ifn? (:fn spec)))
+    (throw (ex-info (str "Transform " label " on cell " cell-name " must be a function (:fn key required)")
+                    {:cell-name cell-name :label label :spec spec})))
+  (when-let [schema (:schema spec)]
+    (when (:input schema)
+      (v/validate-malli-schema! (:input schema) (str "Transform " label " on " cell-name " :input")))
+    (when (:output schema)
+      (v/validate-malli-schema! (:output schema) (str "Transform " label " on " cell-name " :output")))))
+
+(defn- validate-transforms!
+  "Validates the :transforms map at compile time.
+   Each key must be a valid cell name, edge labels must match the cell's edges,
+   and transform specs must have :fn (function) and optional :schema."
+  [transforms cells edges]
+  (let [cell-names (set (keys cells))]
+    (doseq [[cell-name transform-def] transforms]
+      (when-not (contains? cell-names cell-name)
+        (throw (ex-info (str "Transform references nonexistent cell " cell-name)
+                        {:cell-name cell-name :valid-cells cell-names})))
+      (let [edge-def (get edges cell-name)]
+        (if (map? edge-def)
+          ;; Branching cell: keys are edge labels or :input
+          (doseq [[k v] transform-def]
+            (cond
+              (= k :input)
+              (validate-transform-spec! cell-name :input v)
+
+              (contains? edge-def k)
+              (do
+                (when-not (map? v)
+                  (throw (ex-info (str "Transform edge " k " on cell " cell-name
+                                       " must be a map with :input/:output keys")
+                                  {:cell-name cell-name :label k :value v})))
+                (when (:input v) (validate-transform-spec! cell-name (str k " :input") (:input v)))
+                (when (:output v) (validate-transform-spec! cell-name (str k " :output") (:output v))))
+
+              :else
+              (throw (ex-info (str "Transform on cell " cell-name " has invalid edge label " k
+                                   ". Valid edges: " (keys edge-def))
+                              {:cell-name cell-name :label k :valid-edges (keys edge-def)}))))
+          ;; Unconditional cell: keys are :input/:output
+          (let [invalid-keys (disj (set (keys transform-def)) :input :output)]
+            (when (seq invalid-keys)
+              (throw (ex-info (str "Transform on cell " cell-name " has invalid keys " invalid-keys
+                                   ". Unconditional cells only support :input and :output")
+                              {:cell-name cell-name :invalid-keys invalid-keys})))
+            (when (:input transform-def)
+              (validate-transform-spec! cell-name :input (:input transform-def)))
+            (when (:output transform-def)
+              (validate-transform-spec! cell-name :output (:output transform-def)))))))))
+
+(defn- build-transform-maps
+  "Builds input and output transform lookup maps from the :transforms workflow key.
+   Returns {:input {state-id -> fn}, :output {state-id -> fn-or-{transition -> fn}}}."
+  [transforms edges]
+  (reduce
+    (fn [acc [cell-name transform-def]]
+      (let [state-id (resolve-state-id cell-name)
+            edge-def (get edges cell-name)]
+        (if (map? edge-def)
+          ;; Branching cell: extract top-level :input and per-edge :output
+          (let [input-fn (some-> (:input transform-def) :fn)
+                output-map (into {}
+                                 (keep (fn [[k v]]
+                                         (when (and (not= k :input) (map? v) (:output v))
+                                           [k (get-in v [:output :fn])])))
+                                 transform-def)]
+            (cond-> acc
+              input-fn       (assoc-in [:input state-id] input-fn)
+              (seq output-map) (assoc-in [:output state-id] output-map)))
+          ;; Unconditional cell
+          (cond-> acc
+            (:input transform-def)  (assoc-in [:input state-id] (get-in transform-def [:input :fn]))
+            (:output transform-def) (assoc-in [:output state-id] (get-in transform-def [:output :fn]))))))
+    {:input {} :output {}}
+    transforms))
 
 ;; ===== Workflow-level interceptor matching =====
 
@@ -1149,9 +1278,15 @@
                                           :dispatches (compile-edges edge-def dispatch-vec)}])))
                                joins-map)
          fsm-states (merge fsm-cell-states fsm-join-states)
+         ;; Build transform maps from :transforms
+         transform-maps (when-let [transforms (:transforms workflow)]
+                          (build-transform-maps transforms edges))
          ;; Build interceptors — compose custom pre/post with schema interceptors
          schema-opts (-> (select-keys opts [:coerce? :on-trace])
-                        (assoc :state->names state->names))
+                        (assoc :state->names state->names)
+                        (cond->
+                          transform-maps (assoc :input-transforms  (:input transform-maps)
+                                                :output-transforms (:output transform-maps))))
          schema-pre  (schema/make-pre-interceptor state->cell schema-opts)
          schema-post (schema/make-post-interceptor state->cell state->edge-targets state->names schema-opts)
          pre  (if-let [custom-pre (:pre opts)]

--- a/test/mycelium/transform_test.clj
+++ b/test/mycelium/transform_test.clj
@@ -1,0 +1,319 @@
+(ns mycelium.transform-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.manifest :as manifest]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; --- Helper cells ---
+
+(defn- register-cells! []
+  ;; Cell that outputs :user-name but NOT :name
+  (defmethod cell/cell-spec :xf/lookup [_]
+    {:id      :xf/lookup
+     :handler (fn [_ data] {:user-name (str "user-" (:id data))})
+     :schema  {:input  [:map [:id :int]]
+               :output [:map [:user-name :string]]}})
+  ;; Cell that expects :name (not :user-name)
+  (defmethod cell/cell-spec :xf/greet [_]
+    {:id      :xf/greet
+     :handler (fn [_ data] {:greeting (str "Hello, " (:name data))})
+     :schema  {:input  [:map [:name :string]]
+               :output [:map [:greeting :string]]}})
+  ;; Cell with branching output
+  (defmethod cell/cell-spec :xf/classify [_]
+    {:id      :xf/classify
+     :handler (fn [_ data]
+                {:tier (if (> (:score data) 80) :premium :basic)
+                 :raw-score (:score data)})
+     :schema  {:input  [:map [:score :int]]
+               :output {:premium [:map [:tier [:= :premium]] [:raw-score :int]]
+                        :basic   [:map [:tier [:= :basic]] [:raw-score :int]]}}})
+  ;; Cell that expects :level (not :tier)
+  (defmethod cell/cell-spec :xf/premium-handler [_]
+    {:id      :xf/premium-handler
+     :handler (fn [_ data] {:result (str "Premium: " (:level data))})
+     :schema  {:input  [:map [:level :keyword]]
+               :output [:map [:result :string]]}})
+  ;; Cell that expects :category (not :tier)
+  (defmethod cell/cell-spec :xf/basic-handler [_]
+    {:id      :xf/basic-handler
+     :handler (fn [_ data] {:result (str "Basic: " (:category data))})
+     :schema  {:input  [:map [:category :string]]
+               :output [:map [:result :string]]}}))
+
+;; ===== 1. Input transform reshapes data before schema validation =====
+
+(deftest input-transform-reshapes-data-test
+  (testing "Input transform renames key so cell's input schema passes"
+    (register-cells!)
+    (let [result (myc/run-workflow
+                   {:cells      {:start :xf/lookup
+                                 :greet :xf/greet}
+                    :edges      {:start :greet
+                                 :greet :end}
+                    :transforms {:greet {:input {:fn     (fn [data]
+                                                          (assoc data :name (:user-name data)))
+                                                 :schema {:input  [:map [:user-name :string]]
+                                                          :output [:map [:name :string]]}}}}}
+                   {} {:id 42})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= "Hello, user-42" (:greeting result))))))
+
+;; ===== 2. Output transform reshapes data after handler =====
+
+(deftest output-transform-reshapes-data-test
+  (testing "Output transform renames key for the next cell"
+    (register-cells!)
+    (let [result (myc/run-workflow
+                   {:cells      {:start :xf/lookup
+                                 :greet :xf/greet}
+                    :edges      {:start :greet
+                                 :greet :end}
+                    :transforms {:start {:output {:fn     (fn [data]
+                                                           (assoc data :name (:user-name data)))
+                                                  :schema {:input  [:map [:user-name :string]]
+                                                           :output [:map [:name :string]]}}}}}
+                   {} {:id 42})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= "Hello, user-42" (:greeting result))))))
+
+;; ===== 3. Edge-specific output transforms on branching cells =====
+
+(deftest edge-specific-output-transforms-test
+  (testing "Different output transforms per edge on branching cell"
+    (register-cells!)
+    (let [wf {:cells      {:start   :xf/classify
+                           :premium :xf/premium-handler
+                           :basic   :xf/basic-handler}
+              :edges      {:start   {:premium :premium, :basic :basic}
+                           :premium :end
+                           :basic   :end}
+              :dispatches {:start [[:premium (fn [d] (= :premium (:tier d)))]
+                                   [:basic   (fn [d] (= :basic (:tier d)))]]}
+              :transforms {:start {:premium {:output {:fn     (fn [data]
+                                                                (assoc data :level (:tier data)))
+                                                      :schema {:input  [:map [:tier :keyword]]
+                                                               :output [:map [:level :keyword]]}}}
+                                   :basic   {:output {:fn     (fn [data]
+                                                                (assoc data :category (name (:tier data))))
+                                                      :schema {:input  [:map [:tier :keyword]]
+                                                               :output [:map [:category :string]]}}}}}}
+          ;; Premium path
+          result-p (myc/run-workflow wf {} {:score 90})
+          ;; Basic path
+          result-b (myc/run-workflow wf {} {:score 50})]
+      (is (nil? (myc/workflow-error result-p)))
+      (is (= "Premium: :premium" (:result result-p)))
+      (is (nil? (myc/workflow-error result-b)))
+      (is (= "Basic: basic" (:result result-b))))))
+
+;; ===== 4. Input transform on branching cell (top-level :input) =====
+
+(deftest input-transform-on-branching-cell-test
+  (testing "Input transform works alongside edge-specific output transforms"
+    (register-cells!)
+    (defmethod cell/cell-spec :xf/source [_]
+      {:id      :xf/source
+       :handler (fn [_ data] {:raw-value (:x data)})
+       :schema  {:input [:map [:x :int]] :output [:map [:raw-value :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start    :xf/source
+                                 :classify :xf/classify
+                                 :premium  :xf/premium-handler
+                                 :basic    :xf/basic-handler}
+                    :edges      {:start    :classify
+                                 :classify {:premium :premium, :basic :basic}
+                                 :premium  :end
+                                 :basic    :end}
+                    :dispatches {:classify [[:premium (fn [d] (= :premium (:tier d)))]
+                                           [:basic   (fn [d] (= :basic (:tier d)))]]}
+                    :transforms {:classify {:input   {:fn     (fn [data]
+                                                               (assoc data :score (:raw-value data)))
+                                                      :schema {:input  [:map [:raw-value :int]]
+                                                               :output [:map [:score :int]]}}
+                                            :premium {:output {:fn     (fn [data]
+                                                                         (assoc data :level (:tier data)))
+                                                               :schema {:input  [:map [:tier :keyword]]
+                                                                        :output [:map [:level :keyword]]}}}
+                                            :basic   {:output {:fn     (fn [data]
+                                                                         (assoc data :category (name (:tier data))))
+                                                               :schema {:input  [:map [:tier :keyword]]
+                                                                        :output [:map [:category :string]]}}}}}}
+                   {} {:x 90})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= "Premium: :premium" (:result result))))))
+
+;; ===== 5. Transforms compose with key propagation =====
+
+(deftest transforms-compose-with-key-propagation-test
+  (testing "Transforms see fully propagated data (input keys merged)"
+    (register-cells!)
+    (let [seen-keys (atom nil)
+          result (myc/run-workflow
+                   {:cells      {:start :xf/lookup
+                                 :greet :xf/greet}
+                    :edges      {:start :greet
+                                 :greet :end}
+                    :transforms {:start {:output {:fn     (fn [data]
+                                                           (reset! seen-keys (set (keys data)))
+                                                           (assoc data :name (:user-name data)))
+                                                  :schema {:input  [:map [:user-name :string]]
+                                                           :output [:map [:name :string]]}}}}}
+                   {} {:id 42})]
+      (is (nil? (myc/workflow-error result)))
+      ;; Output transform should see propagated keys (:id from input + :user-name from handler)
+      (is (contains? @seen-keys :id))
+      (is (contains? @seen-keys :user-name)))))
+
+;; ===== 6. Without :transforms, workflow runs unchanged =====
+
+(deftest no-transforms-backwards-compatible-test
+  (testing "Workflow without :transforms runs normally"
+    (register-cells!)
+    (defmethod cell/cell-spec :xf/simple-a [_]
+      {:id      :xf/simple-a
+       :handler (fn [_ data] {:y (* (:x data) 2)})
+       :schema  {:input [:map [:x :int]] :output [:map [:y :int]]}})
+    (defmethod cell/cell-spec :xf/simple-b [_]
+      {:id      :xf/simple-b
+       :handler (fn [_ data] {:z (+ (:y data) 1)})
+       :schema  {:input [:map [:y :int]] :output [:map [:z :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells {:start :xf/simple-a :step :xf/simple-b}
+                    :edges {:start :step :step :end}}
+                   {} {:x 5})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= 11 (:z result))))))
+
+;; ===== 7. Compile-time validation: invalid cell name in transforms =====
+
+(deftest validate-transforms-invalid-cell-test
+  (testing "Transforms referencing nonexistent cell throws at compile time"
+    (register-cells!)
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Transform references.*nonexistent"
+          (myc/pre-compile
+            {:cells      {:start :xf/lookup}
+             :edges      {:start :end}
+             :transforms {:bogus {:input {:fn identity
+                                          :schema {:input [:map] :output [:map]}}}}})))))
+
+;; ===== 8. Compile-time validation: invalid edge label in transforms =====
+
+(deftest validate-transforms-invalid-edge-label-test
+  (testing "Transforms with edge label not in cell's edges throws"
+    (register-cells!)
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Transform.*invalid edge"
+          (myc/pre-compile
+            {:cells      {:start   :xf/classify
+                          :premium :xf/premium-handler
+                          :basic   :xf/basic-handler}
+             :edges      {:start   {:premium :premium, :basic :basic}
+                          :premium :end
+                          :basic   :end}
+             :dispatches {:start [[:premium (fn [d] (= :premium (:tier d)))]
+                                  [:basic   (fn [d] (= :basic (:tier d)))]]}
+             :transforms {:start {:nonexistent {:output {:fn identity
+                                                         :schema {:input [:map] :output [:map]}}}}}})))))
+
+;; ===== 9. Compile-time validation: transform must have :fn =====
+
+(deftest validate-transforms-must-have-fn-test
+  (testing "Transform without :fn throws"
+    (register-cells!)
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Transform.*must be a function"
+          (myc/pre-compile
+            {:cells      {:start :xf/lookup}
+             :edges      {:start :end}
+             :transforms {:start {:input {:schema {:input [:map] :output [:map]}}}}})))))
+
+;; ===== 10. Transforms with coercion enabled =====
+
+(deftest transforms-with-coercion-test
+  (testing "Transforms compose correctly with :coerce? true"
+    (register-cells!)
+    (defmethod cell/cell-spec :xf/double-out [_]
+      {:id      :xf/double-out
+       :handler (fn [_ data] {:value (* (:x data) 1.0)})
+       :schema  {:input [:map [:x :int]] :output [:map [:value :double]]}})
+    (defmethod cell/cell-spec :xf/int-in [_]
+      {:id      :xf/int-in
+       :handler (fn [_ data] {:result (inc (:count data))})
+       :schema  {:input [:map [:count :int]] :output [:map [:result :int]]}})
+    (let [result (myc/run-workflow
+                   {:cells      {:start :xf/double-out
+                                 :step  :xf/int-in}
+                    :edges      {:start :step
+                                 :step  :end}
+                    :transforms {:step {:input {:fn     (fn [data]
+                                                         (assoc data :count (int (:value data))))
+                                                :schema {:input  [:map [:value :double]]
+                                                         :output [:map [:count :int]]}}}}}
+                   {} {:x 5} {:coerce? true})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= 6 (:result result))))))
+
+;; ===== 11. Output transform only applies to the specific edge taken =====
+
+(deftest output-transform-only-applies-to-taken-edge-test
+  (testing "Output transform for untaken edge is not applied"
+    (register-cells!)
+    (let [result (myc/run-workflow
+                   {:cells      {:start   :xf/classify
+                                 :premium :xf/premium-handler
+                                 :basic   :xf/basic-handler}
+                    :edges      {:start   {:premium :premium, :basic :basic}
+                                 :premium :end
+                                 :basic   :end}
+                    :dispatches {:start [[:premium (fn [d] (= :premium (:tier d)))]
+                                        [:basic   (fn [d] (= :basic (:tier d)))]]}
+                    :transforms {:start {:premium {:output {:fn     (fn [data]
+                                                                      (assoc data :level (:tier data)))
+                                                            :schema {:input  [:map [:tier :keyword]]
+                                                                     :output [:map [:level :keyword]]}}}
+                                         :basic   {:output {:fn     (fn [data]
+                                                                      (assoc data :category (name (:tier data))))
+                                                            :schema {:input  [:map [:tier :keyword]]
+                                                                     :output [:map [:category :string]]}}}}}}
+                   {} {:score 90})]
+      ;; Premium path taken — :level should exist, :category should NOT
+      (is (nil? (myc/workflow-error result)))
+      (is (some? (:level result)))
+      (is (nil? (:category result))))))
+
+;; ===== 12. Manifest with :transforms passes through =====
+
+(deftest manifest-transforms-passthrough-test
+  (testing "Manifest with :transforms passes through to workflow"
+    (let [xf {:fn identity :schema {:input [:map] :output [:map]}}
+          m {:id :test/xf-manifest
+             :cells {:start {:id     :xf/m-cell
+                              :schema {:input [:map [:x :int]]
+                                       :output [:map [:y :int]]}}}
+             :edges {:start {:done :end}}
+             :dispatches {:start [[:done (constantly true)]]}
+             :transforms {:start {:done {:output xf}}}}
+          wf-def (manifest/manifest->workflow m)]
+      (is (= (:transforms m) (:transforms wf-def))))))
+
+;; ===== 13. Transform schema is validated at compile time =====
+
+(deftest validate-transform-schema-test
+  (testing "Transform with invalid Malli schema throws at compile time"
+    (register-cells!)
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Invalid.*schema"
+          (myc/pre-compile
+            {:cells      {:start :xf/lookup}
+             :edges      {:start :end}
+             :transforms {:start {:output {:fn identity
+                                           :schema {:input [:not-a-valid-schema]
+                                                    :output [:map]}}}}})))))


### PR DESCRIPTION
Transforms allow data to be reshaped at cell boundaries without modifying cell handlers. Supports input transforms (before validation), output transforms (after validation), and edge-specific output transforms for branching cells. Transform schemas participate in compile-time schema chain validation. Includes 13 tests and documentation updates.