### PR TITLE
Add defcell, generate-stubs, and LLM implementation guide

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -297,13 +297,12 @@ Graph-level timeouts **route** to a fallback cell. Resilience timeouts **error**
 ```clojure
 (require '[mycelium.cell :as cell])
 
-(defmethod cell/cell-spec :order/compute-tax [_]
-  {:id      :order/compute-tax
-   :handler (fn [resources data]
-              ;; With key propagation (default): return only new keys
-              {:tax (* (:subtotal data) (:tax-rate data))})
-   :schema  {:input  [:map [:subtotal :double] [:tax-rate :double]]
-             :output [:map [:tax :double]]}})
+(cell/defcell :order/compute-tax
+  {:input  [:map [:subtotal :double] [:tax-rate :double]]
+   :output [:map [:tax :double]]}
+  (fn [resources data]
+    ;; With key propagation (default): return only new keys
+    {:tax (* (:subtotal data) (:tax-rate data))}))
 ```
 
 Key propagation is on by default — handler output is merged with input, so you only return new or changed keys. To return all keys explicitly, disable with `{:propagate-keys? false}`.
@@ -311,27 +310,25 @@ Key propagation is on by default — handler output is merged with input, so you
 ### Async Cell
 
 ```clojure
-(defmethod cell/cell-spec :api/fetch [_]
-  {:id      :api/fetch
-   :async?  true
-   :handler (fn [resources data callback error-callback]
-              (http/get (:url data)
-                {:on-success (fn [resp] (callback {:response-body (:body resp)}))
-                 :on-error   (fn [err] (error-callback err))}))
-   :schema  {:input  [:map [:url :string]]
-             :output [:map [:response-body :string]]}})
+(cell/defcell :api/fetch
+  {:input  [:map [:url :string]]
+   :output [:map [:response-body :string]]
+   :async? true}
+  (fn [resources data callback error-callback]
+    (http/get (:url data)
+      {:on-success (fn [resp] (callback {:response-body (:body resp)}))
+       :on-error   (fn [err] (error-callback err))})))
 ```
 
 ### Parameterized Cell
 
 ```clojure
 ;; Register once, use with different params
-(defmethod cell/cell-spec :math/multiply [_]
-  {:id      :math/multiply
-   :handler (fn [_ data]
-              (let [factor (get-in data [:mycelium/params :factor])]
-                {:result (* (:value data) factor)}))
-   :schema  {:input [:map [:value number?]] :output [:map [:result number?]]}})
+(cell/defcell :math/multiply
+  {:input [:map [:value number?]] :output [:map [:result number?]]}
+  (fn [_ data]
+    (let [factor (get-in data [:mycelium/params :factor])]
+      {:result (* (:value data) factor)})))
 
 ;; Use in workflow
 {:cells {:triple {:id :math/multiply :params {:factor 3}}
@@ -596,6 +593,46 @@ Violations throw at compile time with the specific path that breaks the constrai
 ;; Generate DOT graph for visualization
 (dev/workflow->dot workflow-def)
 ```
+
+---
+
+## Scaffold a Workflow from Its Definition
+
+**Problem:** You've designed the workflow structure (cells, edges, schemas) and want to generate cell stubs to fill in.
+
+```clojure
+(require '[mycelium.dev :as dev])
+
+(def workflow
+  {:cells {:start   :order/validate
+           :process :order/compute
+           :render  :order/format}
+   :pipeline [:start :process :render]})
+
+;; Generate stubs
+(println (dev/generate-stubs workflow))
+```
+
+Output:
+
+```clojure
+(cell/defcell :order/compute
+  (fn [_resources data]
+    ;; TODO: implement :process
+    data))
+
+(cell/defcell :order/format
+  (fn [_resources data]
+    ;; TODO: implement :render
+    data))
+
+(cell/defcell :order/validate
+  (fn [_resources data]
+    ;; TODO: implement :start
+    data))
+```
+
+If cells are already registered with schemas, the stubs include their schemas. For manifest-style definitions (maps with `:id` and `:schema`), inline schemas are used.
 
 ---
 

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -1,0 +1,254 @@
+# Mycelium Implementation Guide
+
+A concise reference for implementing workflows with Mycelium. Designed for use as LLM context — include this file when prompting an agent to build Mycelium applications.
+
+---
+
+## Workflow in 60 Seconds
+
+A Mycelium workflow is a directed graph of **cells** (pure data transformations) connected by **edges** (routing). Data accumulates through the graph — each cell receives all keys from every upstream cell.
+
+```clojure
+(require '[mycelium.cell :as cell]
+         '[mycelium.core :as myc])
+
+;; 1. Define cells
+(cell/defcell :app/validate
+  {:input  [:map [:name :string]]
+   :output [:map [:valid :boolean]]}
+  (fn [_resources data]
+    {:valid (not (empty? (:name data)))}))
+
+(cell/defcell :app/greet
+  {:input  [:map [:name :string]]
+   :output [:map [:greeting :string]]}
+  (fn [_resources data]
+    {:greeting (str "Hello, " (:name data) "!")}))
+
+;; 2. Define workflow
+(def workflow
+  {:cells {:start :app/validate
+           :greet :app/greet}
+   :edges {:start :greet
+           :greet :end}})
+
+;; 3. Run it
+(myc/run-workflow workflow {} {:name "Alice"})
+;; => {:name "Alice", :valid true, :greeting "Hello, Alice!", :mycelium/trace [...]}
+```
+
+---
+
+## Cell Definition
+
+Use `cell/defcell` to register cells. The ID is specified once (no duplication).
+
+```clojure
+;; Minimal — no schema
+(cell/defcell :ns/cell-id
+  (fn [resources data]
+    {:result-key "value"}))
+
+;; With schema (recommended)
+(cell/defcell :ns/cell-id
+  {:input  [:map [:x :int]]
+   :output [:map [:y :int]]}
+  (fn [resources data]
+    {:y (* 2 (:x data))}))
+
+;; With schema + options
+(cell/defcell :ns/cell-id
+  {:input    [:map [:x :int]]
+   :output   [:map [:y :int]]
+   :doc      "Doubles the input"
+   :requires [:db]}
+  (fn [{:keys [db]} data]
+    {:y (* 2 (:x data))}))
+```
+
+### Cell Rules
+
+1. **Handler signature:** `(fn [resources data] -> data-map)`
+2. **Return only new keys.** Key propagation is on by default — input keys are merged automatically. Don't `(assoc data ...)`, just return `{:new-key value}`.
+3. **Resources for infrastructure.** Database connections, HTTP clients, config go in `resources`. Data map is for workflow state only.
+4. **Errors are data.** Set a key (`:status :failed`) and let dispatch predicates route it. Don't throw for expected failures.
+5. **Schemas use [Malli](https://github.com/metosin/malli) syntax.** `[:map [:key :type]]` for maps. Types: `:string`, `:int`, `:double`, `:boolean`, `:keyword`, `:uuid`, `[:enum :a :b]`, `[:vector :type]`, etc.
+
+---
+
+## Workflow Patterns
+
+### Linear Pipeline
+
+```clojure
+{:cells    {:start :app/a, :step2 :app/b, :step3 :app/c}
+ :pipeline [:start :step2 :step3]}
+;; Expands to: :edges {:start :step2, :step2 :step3, :step3 :end}
+```
+
+### Branching
+
+```clojure
+{:cells {:start :app/check
+         :ok    :app/process
+         :err   :app/error}
+ :edges {:start {:pass :ok, :fail :err}
+         :ok :end, :err :end}
+ :dispatches {:start [[:pass (fn [d] (:valid d))]
+                       [:fail (fn [d] (not (:valid d)))]]}}
+```
+
+Handlers compute data. Dispatch predicates choose the route. Separate concerns.
+
+### Per-Transition Output Schema
+
+When a cell branches, declare output per edge:
+
+```clojure
+(cell/defcell :app/check
+  {:input  [:map [:value :int]]
+   :output {:pass [:map [:status [:= :ok]]]
+            :fail [:map [:status [:= :error]] [:reason :string]]}}
+  (fn [_ data]
+    (if (pos? (:value data))
+      {:status :ok}
+      {:status :error :reason "must be positive"})))
+```
+
+### Parallel Join
+
+```clojure
+{:cells {:start :app/validate
+         :tax   :app/calc-tax        ;; join member — no edges entry
+         :ship  :app/calc-shipping   ;; join member — no edges entry
+         :total :app/compute-total}
+ :joins {:fees {:cells [:tax :ship] :strategy :parallel}}
+ :edges {:start :fees
+         :fees  {:done :total, :failure :end}
+         :total :end}}
+```
+
+Join members have **no entries in `:edges`**. Each gets the same input snapshot. Output keys must not overlap.
+
+### Default Fallback
+
+```clojure
+:edges {:start {:success :ok, :default :fallback}}
+:dispatches {:start [[:success (fn [d] (:valid d))]]}
+;; :default auto-generates (constantly true) as last predicate
+```
+
+---
+
+## Development Workflow
+
+### 1. Write the Manifest First
+
+Define cells, edges, schemas. Compilation validates everything:
+
+```clojure
+(myc/pre-compile workflow-def) ;; Throws on invalid structure
+```
+
+### 2. Generate Stubs
+
+```clojure
+(println (myc/generate-stubs workflow-def))
+;; Prints defcell forms with schemas and TODO handlers
+```
+
+Copy the output, fill in handler logic. Schemas and wiring are pre-validated.
+
+### 3. Test Cells in Isolation
+
+```clojure
+(require '[mycelium.dev :as dev])
+
+(dev/test-cell :app/validate {:input {:name "Alice"}})
+;; => {:pass? true, :output {:valid true}, :errors [], :duration-ms 0.1}
+```
+
+### 4. Test the Workflow
+
+```clojure
+(let [result (myc/run-workflow workflow {} {:name "Alice"})]
+  (is (nil? (myc/workflow-error result)))
+  (is (= "Hello, Alice!" (:greeting result))))
+```
+
+### 5. Check Errors
+
+```clojure
+(when-let [err (myc/workflow-error result)]
+  ;; err has :error-type, :cell-name, :cell-id, :message, :failed-keys
+  (println (:message err)))
+```
+
+---
+
+## Common Mistakes
+
+### 1. Returning the full data map
+
+```clojure
+;; WRONG — don't thread the full map
+(fn [_ data] (assoc data :y (* 2 (:x data))))
+
+;; RIGHT — return only new keys (key propagation merges input)
+(fn [_ data] {:y (* 2 (:x data))})
+```
+
+Both work, but the second is idiomatic. Key propagation is on by default.
+
+### 2. Wrong items format
+
+If the spec says items are `[{"laptop" 1} {"shirt" 2}]`, keep that format. Mycelium doesn't impose any format on your data — it flows whatever you put in. Match the domain spec exactly.
+
+### 3. Forgetting to round
+
+Use explicit rounding for financial calculations:
+
+```clojure
+(defn round2 [x]
+  (.doubleValue (.setScale (bigdec x) 2 java.math.RoundingMode/HALF_UP)))
+```
+
+Malli schemas don't check decimal precision. Round explicitly in handlers.
+
+### 4. Non-atomic state mutations
+
+When multiple items need updating (e.g., inventory), use a single `swap!`:
+
+```clojure
+;; WRONG — partial failure leaves inconsistent state
+(doseq [[id qty] items] (swap! inventory update id - qty))
+
+;; RIGHT — atomic update
+(swap! inventory (fn [inv] (reduce (fn [m [id qty]] (update m id - qty)) inv items)))
+```
+
+### 5. Returning nil from a cell
+
+Cell handlers must return a map. Returning `nil` causes downstream failures. If a cell has nothing to add, return `{}`.
+
+### 6. Using exact equality for floats in tests
+
+Use exact equality (`=`) not tolerance-based comparison. With explicit `round2`, results are deterministic.
+
+---
+
+## Quick Reference
+
+| Concept | Syntax |
+|---------|--------|
+| Register cell | `(cell/defcell :ns/id schema-map handler-fn)` |
+| Linear pipeline | `{:pipeline [:a :b :c]}` |
+| Branching edges | `{:edges {:start {:label :target}}}` |
+| Dispatch | `{:dispatches {:start [[:label (fn [d] pred)]]}}` |
+| Parallel join | `{:joins {:name {:cells [:a :b] :strategy :parallel}}}` |
+| Run workflow | `(myc/run-workflow wf resources data)` |
+| Pre-compile | `(def c (myc/pre-compile wf))` then `(myc/run-compiled c res data)` |
+| Check error | `(myc/workflow-error result)` |
+| Test cell | `(dev/test-cell :ns/id {:input {...}})` |
+| Generate stubs | `(println (myc/generate-stubs wf))` |
+| Coerce types | `(myc/pre-compile wf {:coerce? true})` |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -176,20 +176,44 @@ Key propagation is on by default — cells can return only new/changed keys and 
 
 ## Cell Registration
 
+### defcell (recommended)
+
 ```clojure
 (require '[mycelium.cell :as cell])
 
+;; Minimal — no schema
+(cell/defcell :namespace/cell-id
+  (fn [resources data] {:result "value"}))
+
+;; With schema
+(cell/defcell :namespace/cell-id
+  {:input  [:map [:key :type]]
+   :output [:map [:result :string]]}
+  (fn [resources data] {:result "value"}))
+
+;; With schema + options
+(cell/defcell :namespace/cell-id
+  {:input    [:map [:key :type]]
+   :output   [:map [:result :string]]
+   :doc      "..."
+   :requires [:db]
+   :async?   true}
+  (fn [resources data callback error-callback] ...))
+```
+
+`defcell` eliminates ID duplication — the cell-id is specified once. Schema, `:doc`, `:requires`, and `:async?` are passed in the opts map. The handler function is always the last argument.
+
+### defmethod (low-level)
+
+```clojure
 (defmethod cell/cell-spec :namespace/cell-id [_]
   {:id       :namespace/cell-id
-   :handler  (fn [resources data] (assoc data :result "value"))
+   :handler  (fn [resources data] {:result "value"})
    :schema   {:input  [:map [:key :type]]
               :output [:map [:result :string]]}
-   :requires [:db]         ;; optional — resource dependencies
-   :async?   true          ;; optional — async handler signature
-   :doc      "..."})       ;; optional
-
-;; Async handler signature (4-arity with callbacks):
-;; (fn [resources data callback error-callback] ...)
+   :requires [:db]
+   :async?   true
+   :doc      "..."})
 ```
 
 ### Cell Registry Helpers
@@ -734,7 +758,14 @@ Declare compile-time path invariants that are checked against all enumerated pat
 ;;     :step2  {:available-before #{:x :result}, :adds #{:total}, ...}}
 ```
 
-`analyze-workflow` and `infer-workflow-schema` are also available as `myc/analyze-workflow` and `myc/infer-workflow-schema`.
+```clojure
+;; Generate cell stubs from a workflow definition
+(dev/generate-stubs workflow-def)
+;; => prints defcell forms with schemas and TODO handlers
+;; Useful for scaffolding — fill in handler logic after generating
+```
+
+`analyze-workflow`, `infer-workflow-schema`, and `generate-stubs` are also available via `myc/`.
 
 ## Agent Orchestration
 

--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -74,3 +74,50 @@
   "Returns a seq of all registered cell IDs."
   []
   (keys (dissoc (methods cell-spec) :default)))
+
+(defn defcell
+  "Registers a cell with less boilerplate than the raw defmethod.
+   Eliminates ID duplication — the cell-id is specified once.
+
+   Arities:
+     (defcell :ns/id handler-fn)
+     (defcell :ns/id schema-map handler-fn)
+
+   schema-map is {:input [...] :output [...]} with optional :doc, :requires, :async?.
+   The :input/:output keys become the cell's :schema. Extra keys (:doc, :requires,
+   :async?) are lifted to the top-level spec.
+
+   Examples:
+     ;; Minimal — no schema
+     (defcell :order/compute-tax
+       (fn [resources data] {:tax (* (:subtotal data) 0.1)}))
+
+     ;; With schema
+     (defcell :order/compute-tax
+       {:input  [:map [:subtotal :double]]
+        :output [:map [:tax :double]]}
+       (fn [resources data] {:tax (* (:subtotal data) 0.1)}))
+
+     ;; With schema + opts
+     (defcell :order/compute-tax
+       {:input    [:map [:subtotal :double]]
+        :output   [:map [:tax :double]]
+        :doc      \"Computes tax\"
+        :requires [:tax-rates]}
+       (fn [resources data] {:tax (* (:subtotal data) 0.1)}))"
+  ([cell-id handler-fn]
+   (defcell cell-id nil handler-fn))
+  ([cell-id opts handler-fn]
+   (let [schema-keys #{:input :output}
+         opt-keys    #{:doc :requires :async?}
+         schema      (when opts
+                       (let [s (select-keys opts schema-keys)]
+                         (when (seq s) s)))
+         extra       (when opts (select-keys opts opt-keys))
+         spec        (cond-> {:id cell-id :handler handler-fn}
+                       schema (assoc :schema schema)
+                       (:doc extra) (assoc :doc (:doc extra))
+                       (:requires extra) (assoc :requires (:requires extra))
+                       (:async? extra) (assoc :async? (:async? extra)))]
+     (.addMethod cell-spec cell-id (constantly spec))
+     spec)))

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -19,6 +19,11 @@
    See mycelium.cell/cell-spec."
   cell/cell-spec)
 
+(def defcell
+  "Registers a cell with less boilerplate. Eliminates ID duplication.
+   See mycelium.cell/defcell."
+  cell/defcell)
+
 ;; --- Workflow compilation ---
 
 (def compile-workflow
@@ -221,6 +226,11 @@
   "Walks a workflow and reports accumulated schema keys at each cell.
    See mycelium.dev/infer-workflow-schema."
   dev/infer-workflow-schema)
+
+(def generate-stubs
+  "Generates defcell stub code from a workflow definition.
+   See mycelium.dev/generate-stubs."
+  dev/generate-stubs)
 
 ;; --- Error inspection ---
 

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -371,6 +371,76 @@
         (recur)))
     @result))
 
+;; ===== Stub generation =====
+
+(defn- resolve-cell-info
+  "Resolves cell ID and schema from a workflow cell entry.
+   Handles both bare keyword (:app/id) and map ({:id :app/id :schema ...}) forms.
+   Falls back to registry lookup when schema not inline."
+  [cell-entry]
+  (let [cell-id (if (map? cell-entry) (:id cell-entry) cell-entry)
+        ;; Try inline schema first (manifest-style), then registry
+        inline-schema (when (map? cell-entry) (:schema cell-entry))
+        reg-cell (cell/get-cell cell-id)
+        schema (or inline-schema (:schema reg-cell))
+        doc (or (when (map? cell-entry) (:doc cell-entry)) (:doc reg-cell))
+        requires (or (when (map? cell-entry) (:requires cell-entry)) (:requires reg-cell))]
+    {:cell-id  cell-id
+     :schema   schema
+     :doc      doc
+     :requires requires}))
+
+(defn- format-schema-value
+  "Formats a schema value as a readable string."
+  [schema-val]
+  (if (map? schema-val)
+    ;; Per-transition output schema
+    (str "{" (str/join "\n                "
+                       (map (fn [[k v]] (str k " " (pr-str v)))
+                            (sort-by first schema-val))) "}")
+    (pr-str schema-val)))
+
+(defn generate-stubs
+  "Generates defcell stub code from a workflow definition.
+   For each cell, produces a defcell form with schema and a TODO handler.
+   Cells already registered get their schema from the registry.
+   Manifest-style cell entries (maps with :id and :schema) use inline schemas.
+
+   Returns a string of Clojure code.
+
+   Usage:
+     (println (dev/generate-stubs workflow-def))
+     (spit \"stubs.clj\" (dev/generate-stubs workflow-def))"
+  [{:keys [cells]}]
+  (str/join "\n\n"
+            (map (fn [[cell-name cell-entry]]
+                   (let [{:keys [cell-id schema doc requires]} (resolve-cell-info cell-entry)
+                         has-schema? (some? schema)
+                         input-schema (:input schema)
+                         output-schema (:output schema)
+                         opts-parts (cond-> []
+                                      input-schema
+                                      (conj (str " :input  " (pr-str input-schema)))
+                                      output-schema
+                                      (conj (str " :output " (format-schema-value output-schema)))
+                                      doc
+                                      (conj (str " :doc    " (pr-str doc)))
+                                      requires
+                                      (conj (str " :requires " (pr-str (vec requires)))))
+                         opts-str (when (seq opts-parts)
+                                    (str "\n  {" (str/join "\n   " opts-parts) "}"))
+                         handler-str (if requires
+                                       (str "(fn [{:keys ["
+                                            (str/join " " (map name requires))
+                                            "]} data]\n    ;; TODO: implement " cell-name
+                                            "\n    data)")
+                                       (str "(fn [_resources data]\n    ;; TODO: implement " cell-name
+                                            "\n    data)"))]
+                     (str "(cell/defcell " cell-id
+                          (or opts-str "")
+                          "\n  " handler-str ")")))
+                 (sort-by first cells))))
+
 (defn- format-trace-entry
   "Formats a single trace entry as a human-readable string."
   [idx entry]

--- a/test/mycelium/defcell_test.clj
+++ b/test/mycelium/defcell_test.clj
@@ -1,0 +1,124 @@
+(ns mycelium.defcell-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== 1. Basic defcell registers cell with correct spec =====
+
+(deftest defcell-basic-registration-test
+  (testing "defcell registers a cell retrievable from registry"
+    (cell/defcell :test/basic
+      {:input  [:map [:x :int]]
+       :output [:map [:y :int]]}
+      (fn [_ data] {:y (* 2 (:x data))}))
+    (let [spec (cell/get-cell :test/basic)]
+      (is (some? spec))
+      (is (= :test/basic (:id spec)))
+      (is (= [:map [:x :int]] (get-in spec [:schema :input])))
+      (is (= [:map [:y :int]] (get-in spec [:schema :output])))
+      (is (fn? (:handler spec))))))
+
+;; ===== 2. Handler executes correctly =====
+
+(deftest defcell-handler-executes-test
+  (testing "defcell handler is callable and produces correct output"
+    (cell/defcell :test/double
+      {:input  [:map [:x :int]]
+       :output [:map [:result :int]]}
+      (fn [_ data] {:result (* 2 (:x data))}))
+    (let [handler (:handler (cell/get-cell :test/double))]
+      (is (= {:result 10} (handler {} {:x 5}))))))
+
+;; ===== 3. defcell without schema =====
+
+(deftest defcell-no-schema-test
+  (testing "defcell works without schema (nil schema)"
+    (cell/defcell :test/no-schema
+      (fn [_ data] data))
+    (let [spec (cell/get-cell :test/no-schema)]
+      (is (some? spec))
+      (is (= :test/no-schema (:id spec)))
+      (is (nil? (:schema spec)))
+      (is (fn? (:handler spec))))))
+
+;; ===== 4. defcell with opts map (doc, requires, async?) =====
+
+(deftest defcell-with-opts-test
+  (testing "defcell accepts optional :doc, :requires, :async?"
+    (cell/defcell :test/with-opts
+      {:input  [:map [:x :int]]
+       :output [:map [:y :int]]
+       :doc "A test cell"
+       :requires [:db]
+       :async? true}
+      (fn [resources data callback _error-callback]
+        (callback {:y (inc (:x data))})))
+    (let [spec (cell/get-cell :test/with-opts)]
+      (is (= "A test cell" (:doc spec)))
+      (is (= [:db] (:requires spec)))
+      (is (true? (:async? spec))))))
+
+;; ===== 5. defcell with per-transition output schema =====
+
+(deftest defcell-per-transition-output-test
+  (testing "defcell supports per-transition output schemas"
+    (cell/defcell :test/branching
+      {:input  [:map [:x :int]]
+       :output {:high [:map [:result [:= :high]]]
+                :low  [:map [:result [:= :low]]]}}
+      (fn [_ data]
+        {:result (if (> (:x data) 10) :high :low)}))
+    (let [spec (cell/get-cell :test/branching)]
+      (is (map? (get-in spec [:schema :output])))
+      (is (= #{:high :low} (set (keys (get-in spec [:schema :output]))))))))
+
+;; ===== 6. defcell works in workflow =====
+
+(deftest defcell-in-workflow-test
+  (testing "Cell registered via defcell works in a compiled workflow"
+    (cell/defcell :test/add-ten
+      {:input  [:map [:x :int]]
+       :output [:map [:result :int]]}
+      (fn [_ data] {:result (+ (:x data) 10)}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/add-ten}
+                    :edges {:start :end}}
+                   {} {:x 5})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= 15 (:result result))))))
+
+;; ===== 7. defcell ID deduplication — no need to repeat ID =====
+
+(deftest defcell-id-not-duplicated-test
+  (testing "defcell sets :id automatically from the first argument"
+    (cell/defcell :test/auto-id
+      {:input [:map] :output [:map]}
+      (fn [_ data] data))
+    (is (= :test/auto-id (:id (cell/get-cell :test/auto-id))))))
+
+;; ===== 8. Multiple defcells coexist =====
+
+(deftest defcell-multiple-coexist-test
+  (testing "Multiple defcell registrations coexist"
+    (cell/defcell :test/cell-a
+      {:input [:map [:x :int]] :output [:map [:a :int]]}
+      (fn [_ data] {:a (:x data)}))
+    (cell/defcell :test/cell-b
+      {:input [:map [:a :int]] :output [:map [:b :int]]}
+      (fn [_ data] {:b (* 2 (:a data))}))
+    (is (some? (cell/get-cell :test/cell-a)))
+    (is (some? (cell/get-cell :test/cell-b)))
+    (is (= :test/cell-a (:id (cell/get-cell :test/cell-a))))
+    (is (= :test/cell-b (:id (cell/get-cell :test/cell-b))))))
+
+;; ===== 9. defcell overrides are cleared by clear-registry! =====
+
+(deftest defcell-cleared-by-registry-test
+  (testing "defcell registrations are cleared by clear-registry!"
+    (cell/defcell :test/clearable
+      (fn [_ data] data))
+    (is (some? (cell/get-cell :test/clearable)))
+    (cell/clear-registry!)
+    (is (nil? (cell/get-cell :test/clearable)))))

--- a/test/mycelium/generate_stubs_test.clj
+++ b/test/mycelium/generate_stubs_test.clj
@@ -1,0 +1,118 @@
+(ns mycelium.generate-stubs-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [mycelium.cell :as cell]
+            [mycelium.dev :as dev]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== 1. Basic stub generation from workflow definition =====
+
+(deftest generate-stubs-basic-test
+  (testing "generate-stubs produces defcell forms for each cell"
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :app/validate
+                           :process :app/transform}
+                   :edges {:start :process
+                           :process :end}})]
+      (is (string? stubs))
+      (is (str/includes? stubs "defcell"))
+      (is (str/includes? stubs ":app/validate"))
+      (is (str/includes? stubs ":app/transform")))))
+
+;; ===== 2. Stubs include schemas when cells have them =====
+
+(deftest generate-stubs-with-schemas-test
+  (testing "generate-stubs includes schema from cell definitions"
+    (cell/defcell :stub/with-schema
+      {:input  [:map [:x :int]]
+       :output [:map [:y :int]]}
+      (fn [_ data] data))
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :stub/with-schema}
+                   :edges {:start :end}})]
+      (is (str/includes? stubs ":input"))
+      (is (str/includes? stubs ":output"))
+      (is (str/includes? stubs "[:map [:x :int]]")))))
+
+;; ===== 3. Stubs for unregistered cells produce TODO handler =====
+
+(deftest generate-stubs-unregistered-test
+  (testing "generate-stubs produces TODO stubs for unregistered cells"
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :app/unknown-cell}
+                   :edges {:start :end}})]
+      (is (str/includes? stubs ":app/unknown-cell"))
+      (is (str/includes? stubs "TODO")))))
+
+;; ===== 4. Stubs from manifest with full cell definitions =====
+
+(deftest generate-stubs-from-manifest-test
+  (testing "generate-stubs works with manifest-style cell definitions"
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start {:id     :app/validate
+                                   :schema {:input  [:map [:name :string]]
+                                            :output [:map [:valid :boolean]]}}}
+                   :edges {:start :end}})]
+      (is (str/includes? stubs ":app/validate"))
+      (is (str/includes? stubs "[:map [:name :string]]"))
+      (is (str/includes? stubs "[:map [:valid :boolean]]")))))
+
+;; ===== 5. Stubs include per-transition output schemas =====
+
+(deftest generate-stubs-branching-output-test
+  (testing "generate-stubs handles per-transition output schemas"
+    (cell/defcell :stub/branching
+      {:input  [:map [:x :int]]
+       :output {:high [:map [:result [:= :high]]]
+                :low  [:map [:result [:= :low]]]}}
+      (fn [_ data] data))
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :stub/branching}
+                   :edges {:start {:high :end :low :end}}
+                   :dispatches {:start [[:high (fn [d] (= :high (:result d)))]
+                                        [:low (fn [d] (= :low (:result d)))]]}})]
+      (is (str/includes? stubs ":high"))
+      (is (str/includes? stubs ":low")))))
+
+;; ===== 6. Stubs include :requires =====
+
+(deftest generate-stubs-with-requires-test
+  (testing "generate-stubs includes :requires from cell spec"
+    (cell/defcell :stub/needs-db
+      {:input    [:map [:id :string]]
+       :output   [:map [:user :map]]
+       :requires [:db]}
+      (fn [{:keys [db]} data] data))
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :stub/needs-db}
+                   :edges {:start :end}})]
+      (is (str/includes? stubs ":requires"))
+      (is (str/includes? stubs ":db")))))
+
+;; ===== 7. Stubs include :doc =====
+
+(deftest generate-stubs-with-doc-test
+  (testing "generate-stubs includes :doc from cell spec"
+    (cell/defcell :stub/documented
+      {:input  [:map]
+       :output [:map]
+       :doc    "Validates user input"}
+      (fn [_ data] data))
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :stub/documented}
+                   :edges {:start :end}})]
+      (is (str/includes? stubs "Validates user input")))))
+
+;; ===== 8. Output is valid Clojure (parseable) =====
+
+(deftest generate-stubs-parseable-test
+  (testing "generate-stubs produces parseable Clojure code"
+    (let [stubs (dev/generate-stubs
+                  {:cells {:start :app/step-a
+                           :next  :app/step-b}
+                   :edges {:start :next
+                           :next  :end}})]
+      ;; Should parse without error
+      (is (every? some?
+                  (read-string (str "[" stubs "]")))))))


### PR DESCRIPTION
- cell/defcell: registers cells with no ID duplication. Accepts optional schema map with :doc, :requires, :async? lifted to spec.
- dev/generate-stubs: generates defcell stub code from a workflow definition. Cells with schemas get pre-filled schemas, unregistered cells get TODO handlers.
- docs/llm-guide.md: concise ~150-line reference for LLM context windows. Covers cell definition, workflow patterns, development workflow, and common mistakes identified in benchmark analysis.
- Updated quick-reference.md, cookbook.md, and site creating-cells.md to use defcell as the recommended registration pattern.