### PR TITLE
Add lite schema syntax for cell definitions

### DIFF
--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -1,6 +1,7 @@
 (ns mycelium.cell
   "Cell registry for Mycelium. Cells are registered via `defmethod cell-spec`."
-  (:require [mycelium.validation :as v]))
+  (:require [mycelium.schema :as schema]
+            [mycelium.validation :as v]))
 
 (defmulti cell-spec
   "Multimethod-backed cell registry. Dispatches on cell-id keyword,
@@ -35,26 +36,38 @@
       (throw (ex-info (str "Cell " id " not found in registry")
                       {:id id}))))
 
+(defn- output-dispatched?
+  "Heuristic for defcell/set-cell-schema! (no edge context available):
+   a map output schema is per-transition if all values are vectors (Malli schema
+   forms like [:map ...], [:or ...], etc.). If any value is a keyword or map,
+   it's treated as lite syntax. For manifests, edge context is used instead.
+   Trade-off: per-transition maps with bare keyword schemas (e.g. {:success :any})
+   would be misclassified as lite — use vector form [:any] in that rare case."
+  [output]
+  (and (map? output) (seq output) (every? vector? (vals output))))
+
 (defn set-cell-schema!
   "Sets or overwrites the schema for an already-registered cell.
-   Validates that the schema is well-formed Malli before updating.
+   Normalizes lite syntax, validates Malli, then updates.
    Throws if the cell is not found or the schema is invalid."
   [cell-id schema]
   (when-not (cell-spec cell-id)
     (throw (ex-info (str "Cell " cell-id " not found in registry")
                     {:id cell-id})))
-  (when (:input schema)
-    (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
-  (when (:output schema)
-    (v/validate-output-schema! (:output schema) (str cell-id " :output")))
-  (swap! cell-overrides update cell-id merge {:schema schema})
-  schema)
+  (let [dispatched? (output-dispatched? (:output schema))
+        schema (schema/normalize-cell-schema schema dispatched?)]
+    (when (:input schema)
+      (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
+    (when (:output schema)
+      (v/validate-output-schema! (:output schema) (str cell-id " :output")))
+    (swap! cell-overrides update cell-id merge {:schema schema})
+    schema))
 
 (defn set-cell-meta!
   "Sets metadata overrides (schema, requires) on a registered cell.
    The manifest calls this to inject metadata into cells that were registered
-   without schemas/requires. Validates schema is well-formed.
-   Throws if the cell is not found."
+   without schemas/requires. Expects schemas to be pre-normalized.
+   Validates schema is well-formed. Throws if the cell is not found."
   [cell-id {:keys [schema requires] :as meta-map}]
   (when-not (cell-spec cell-id)
     (throw (ex-info (str "Cell " cell-id " not found in registry")
@@ -110,9 +123,12 @@
   ([cell-id opts handler-fn]
    (let [schema-keys #{:input :output}
          opt-keys    #{:doc :requires :async?}
-         schema      (when opts
+         raw-schema  (when opts
                        (let [s (select-keys opts schema-keys)]
                          (when (seq s) s)))
+         dispatched? (and raw-schema (output-dispatched? (:output raw-schema)))
+         schema      (when raw-schema
+                       (schema/normalize-cell-schema raw-schema dispatched?))
          extra       (when opts (select-keys opts opt-keys))
          spec        (cond-> {:id cell-id :handler handler-fn}
                        schema (assoc :schema schema)

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -135,12 +135,19 @@
      ;; Resolve :schema :inherit, then normalize lite syntax before validation
      (let [cells    (resolve-inherit-schemas cells)
            ;; Normalize cell schemas using edge context for output disambiguation
+           ;; Join members have no edge entries, so fall back to heuristic:
+           ;; a map output where all values are vectors is per-transition.
            cells    (into {}
                           (map (fn [[cell-name cell-def]]
                                  (if (or (= :inherit (:schema cell-def))
                                          (nil? (:schema cell-def)))
                                    [cell-name cell-def]
-                                   (let [dispatched? (map? (get edges cell-name))
+                                   (let [edge-def    (get edges cell-name)
+                                         output      (get-in cell-def [:schema :output])
+                                         dispatched? (or (map? edge-def)
+                                                         (and (map? output)
+                                                              (seq output)
+                                                              (every? vector? (vals output))))
                                          normalized  (schema/normalize-cell-schema
                                                        (:schema cell-def) dispatched?)]
                                      [cell-name (assoc cell-def :schema normalized)]))))

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -7,6 +7,7 @@
             [malli.generator :as mg]
             [mycelium.cell :as cell]
             [mycelium.fragment :as fragment]
+            [mycelium.schema :as schema]
             [mycelium.validation :as v]))
 
 ;; ===== Cell definition validation =====
@@ -131,8 +132,19 @@
        (throw (ex-info "Manifest missing :cells" {:id id})))
      (when-not edges
        (throw (ex-info "Manifest missing :edges" {:id id})))
-     ;; Resolve :schema :inherit before validation
+     ;; Resolve :schema :inherit, then normalize lite syntax before validation
      (let [cells    (resolve-inherit-schemas cells)
+           ;; Normalize cell schemas using edge context for output disambiguation
+           cells    (into {}
+                          (map (fn [[cell-name cell-def]]
+                                 (if (or (= :inherit (:schema cell-def))
+                                         (nil? (:schema cell-def)))
+                                   [cell-name cell-def]
+                                   (let [dispatched? (map? (get edges cell-name))
+                                         normalized  (schema/normalize-cell-schema
+                                                       (:schema cell-def) dispatched?)]
+                                     [cell-name (assoc cell-def :schema normalized)]))))
+                          cells)
            manifest (assoc manifest :cells cells)]
        ;; Validate each cell definition
        (doseq [[cell-name cell-def] cells]
@@ -174,9 +186,9 @@
                effective-dispatches (merge join-dispatches (or dispatches {}))]
            (v/validate-dispatch-coverage! edges effective-dispatches))
          (v/validate-reachability! edges valid-names))
-       ;; Validate :input-schema if present
+       ;; Validate :input-schema if present (normalize lite syntax first)
        (when-let [input-schema (:input-schema manifest)]
-         (v/validate-malli-schema! input-schema "input-schema"))
+         (v/validate-malli-schema! (schema/normalize-schema input-schema) "input-schema"))
        ;; Validate :regions if present
        (when-let [regions (:regions manifest)]
          (validate-regions! regions cells))
@@ -320,7 +332,7 @@
              :edges edges}
       dispatches (assoc :dispatches dispatches)
       (:joins manifest) (assoc :joins (:joins manifest))
-      (:input-schema manifest) (assoc :input-schema (:input-schema manifest))
+      (:input-schema manifest) (assoc :input-schema (schema/normalize-schema (:input-schema manifest)))
       (:interceptors manifest) (assoc :interceptors (:interceptors manifest))
       (:resilience manifest) (assoc :resilience (:resilience manifest))
       (:transforms manifest) (assoc :transforms (:transforms manifest)))))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -7,6 +7,48 @@
             [malli.transform :as mt]
             [maestro.core :as fsm]))
 
+;; ===== Lite schema normalization =====
+
+(defn normalize-schema
+  "Normalizes a schema that may be in lite syntax to standard Malli.
+   - Plain maps become [:map [:k1 v1] [:k2 v2] ...] with values recursively normalized
+   - Vectors, keywords, and nil pass through unchanged
+   Examples:
+     {:subtotal :double}             → [:map [:subtotal :double]]
+     {:address {:street :string}}    → [:map [:address [:map [:street :string]]]]
+     [:map [:x :int]]                → [:map [:x :int]]
+     :int                            → :int"
+  [schema]
+  (cond
+    (nil? schema) nil
+    (map? schema) (into [:map] (map (fn [[k v]] [k (normalize-schema v)])) schema)
+    :else schema))
+
+(defn normalize-output-schema
+  "Normalizes an output schema, accounting for per-transition maps.
+   When `dispatched?` is true and the schema is a map, each value is normalized
+   individually (per-transition output). Otherwise the map is treated as lite syntax."
+  [schema dispatched?]
+  (cond
+    (nil? schema)    nil
+    (vector? schema) schema
+    (map? schema)    (if dispatched?
+                       (into {} (map (fn [[k v]] [k (normalize-schema v)])) schema)
+                       (normalize-schema schema))
+    :else            schema))
+
+(defn normalize-cell-schema
+  "Normalizes a cell's :schema map, converting lite syntax to Malli.
+   `dispatched?` — true if the cell has branching edges (per-transition output)."
+  ([schema] (normalize-cell-schema schema false))
+  ([schema dispatched?]
+   (when schema
+     (let [input  (:input schema)
+           output (:output schema)]
+       (cond-> schema
+         input  (assoc :input (normalize-schema input))
+         output (assoc :output (normalize-output-schema output dispatched?)))))))
+
 (def ^:private terminal-states
   #{::fsm/end ::fsm/error ::fsm/halt})
 

--- a/src/mycelium/validation.clj
+++ b/src/mycelium/validation.clj
@@ -40,6 +40,7 @@
 (defn validate-cell-def!
   "Validates a single cell definition (manifest or fragment).
    Checks :id and :schema presence, validates Malli schemas.
+   Expects schemas to be pre-normalized (lite syntax already converted).
    Skips schema validation for :schema :inherit (resolved separately).
    `context` is a string prefix for error messages (e.g. \"Cell\" or \"Fragment cell\")."
   [cell-name cell-def context]

--- a/test/mycelium/lite_schema_test.clj
+++ b/test/mycelium/lite_schema_test.clj
@@ -1,0 +1,216 @@
+(ns mycelium.lite-schema-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.manifest :as manifest]
+            [mycelium.schema :as schema]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== 1. normalize-schema: basic lite map conversion =====
+
+(deftest normalize-schema-basic-test
+  (testing "Converts {key type} map to [:map [key type] ...]"
+    (is (= [:map [:subtotal :double] [:state :string]]
+           (schema/normalize-schema {:subtotal :double :state :string}))))
+
+  (testing "Nested maps are recursively converted"
+    (is (= [:map [:address [:map [:street :string] [:city :string]]]]
+           (schema/normalize-schema {:address {:street :string :city :string}}))))
+
+  (testing "Vector schemas pass through unchanged"
+    (is (= [:map [:x :int]]
+           (schema/normalize-schema [:map [:x :int]]))))
+
+  (testing "Keyword schemas pass through unchanged"
+    (is (= :int (schema/normalize-schema :int))))
+
+  (testing "nil passes through"
+    (is (nil? (schema/normalize-schema nil))))
+
+  (testing "Compound type values (vectors) pass through as values"
+    (is (= [:map [:items [:vector :string]] [:count :int]]
+           (schema/normalize-schema {:items [:vector :string] :count :int})))))
+
+;; ===== 2. normalize-output-schema: dispatched vs single =====
+
+(deftest normalize-output-schema-test
+  (testing "Non-dispatched map output is treated as lite schema"
+    (is (= [:map [:tax :double]]
+           (schema/normalize-output-schema {:tax :double} false))))
+
+  (testing "Dispatched map output normalizes each transition value"
+    (is (= {:success [:map [:result :string]]
+            :failure [:map [:error :string]]}
+           (schema/normalize-output-schema
+            {:success {:result :string}
+             :failure {:error :string}}
+            true))))
+
+  (testing "Dispatched map output with existing Malli vectors passes through"
+    (is (= {:high [:map [:result [:= :high]]]
+            :low  [:map [:result [:= :low]]]}
+           (schema/normalize-output-schema
+            {:high [:map [:result [:= :high]]]
+             :low  [:map [:result [:= :low]]]}
+            true))))
+
+  (testing "Vector output passes through regardless of dispatch flag"
+    (is (= [:map [:x :int]]
+           (schema/normalize-output-schema [:map [:x :int]] false)))
+    (is (= [:map [:x :int]]
+           (schema/normalize-output-schema [:map [:x :int]] true))))
+
+  (testing "nil output passes through"
+    (is (nil? (schema/normalize-output-schema nil false)))
+    (is (nil? (schema/normalize-output-schema nil true)))))
+
+;; ===== 3. defcell with lite syntax =====
+
+(deftest defcell-lite-schema-test
+  (testing "defcell normalizes lite input schema"
+    (cell/defcell :test/lite-input
+      {:input {:x :int :y :int}
+       :output [:map [:sum :int]]}
+      (fn [_ data] {:sum (+ (:x data) (:y data))}))
+    (let [spec (cell/get-cell :test/lite-input)]
+      (is (= [:map [:x :int] [:y :int]]
+             (get-in spec [:schema :input])))))
+
+  (testing "defcell normalizes lite output schema"
+    (cell/defcell :test/lite-output
+      {:input [:map [:x :int]]
+       :output {:doubled :int}}
+      (fn [_ data] {:doubled (* 2 (:x data))}))
+    (let [spec (cell/get-cell :test/lite-output)]
+      (is (= [:map [:doubled :int]]
+             (get-in spec [:schema :output])))))
+
+  (testing "defcell normalizes both input and output lite schemas"
+    (cell/defcell :test/lite-both
+      {:input  {:x :int}
+       :output {:y :int}}
+      (fn [_ data] {:y (inc (:x data))}))
+    (let [spec (cell/get-cell :test/lite-both)]
+      (is (= [:map [:x :int]] (get-in spec [:schema :input])))
+      (is (= [:map [:y :int]] (get-in spec [:schema :output])))))
+
+  (testing "defcell with per-transition vector output is unchanged"
+    (cell/defcell :test/per-transition
+      {:input  {:x :int}
+       :output {:high [:map [:result [:= :high]]]
+                :low  [:map [:result [:= :low]]]}}
+      (fn [_ data]
+        {:result (if (> (:x data) 10) :high :low)}))
+    (let [spec (cell/get-cell :test/per-transition)]
+      ;; Per-transition values are vectors, so they stay as per-transition map
+      (is (map? (get-in spec [:schema :output])))
+      (is (= #{:high :low} (set (keys (get-in spec [:schema :output]))))))))
+
+;; ===== 4. set-cell-schema! with lite syntax =====
+
+(deftest set-cell-schema-lite-test
+  (testing "set-cell-schema! normalizes lite schemas"
+    (cell/defcell :test/schema-override
+      (fn [_ data] {:y (inc (:x data))}))
+    (cell/set-cell-schema! :test/schema-override
+                           {:input {:x :int} :output {:y :int}})
+    (let [spec (cell/get-cell :test/schema-override)]
+      (is (= [:map [:x :int]] (get-in spec [:schema :input])))
+      (is (= [:map [:y :int]] (get-in spec [:schema :output]))))))
+
+;; ===== 5. set-cell-meta! receives pre-normalized schemas from manifest =====
+
+(deftest set-cell-meta-normalized-test
+  (testing "set-cell-meta! works with pre-normalized lite schemas"
+    (cell/defcell :test/meta-override
+      (fn [_ data] data))
+    ;; Simulate what manifest->workflow does: normalize first, then set-cell-meta!
+    (let [normalized (schema/normalize-cell-schema
+                       {:input {:name :string} :output {:greeting :string}})]
+      (cell/set-cell-meta! :test/meta-override {:schema normalized})
+      (let [spec (cell/get-cell :test/meta-override)]
+        (is (= [:map [:name :string]] (get-in spec [:schema :input])))
+        (is (= [:map [:greeting :string]] (get-in spec [:schema :output])))))))
+
+;; ===== 6. End-to-end: workflow with lite schemas runs correctly =====
+
+(deftest lite-schema-workflow-e2e-test
+  (testing "Workflow runs with lite schemas in defcell"
+    (cell/defcell :test/greet
+      {:input  {:name :string}
+       :output {:greeting :string}}
+      (fn [_ data] {:greeting (str "Hello, " (:name data) "!")}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/greet}
+                    :edges {:start :end}}
+                   {} {:name "Alice"})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= "Hello, Alice!" (:greeting result)))))
+
+  (testing "Workflow with nested lite schemas validates correctly"
+    (cell/defcell :test/extract-city
+      {:input  {:address {:street :string :city :string}}
+       :output {:city :string}}
+      (fn [_ data] {:city (get-in data [:address :city])}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/extract-city}
+                    :edges {:start :end}}
+                   {} {:address {:street "123 Main" :city "Portland"}})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= "Portland" (:city result)))))
+
+  (testing "Workflow rejects invalid input against lite schema"
+    (cell/defcell :test/typed-add
+      {:input  {:x :int :y :int}
+       :output {:sum :int}}
+      (fn [_ data] {:sum (+ (:x data) (:y data))}))
+    (let [on-error (fn [_resources fsm-state] (:data fsm-state))
+          result   (myc/run-workflow
+                     {:cells {:start :test/typed-add}
+                      :edges {:start :end}}
+                     {} {:x "not-an-int" :y 5} {:on-error on-error})]
+      (is (some? (myc/workflow-error result))))))
+
+;; ===== 7. Manifest loading with lite schemas =====
+
+(deftest manifest-lite-schema-test
+  (testing "Manifest with lite schemas validates via manifest->workflow"
+    (cell/defcell :test/compute
+      (fn [_ data] {:result (* 2 (:x data))}))
+    (let [m {:id :test-workflow
+             :cells {:start {:id :test/compute
+                              :schema {:input {:x :int}
+                                       :output {:result :int}}
+                              :on-error nil}}
+             :edges {:start :end}
+             :input-schema {:x :int}}
+          ;; validate-manifest normalizes lite schemas
+          validated (manifest/validate-manifest m {:strict? true})
+          ;; manifest->workflow injects schemas into cells
+          wf-def   (manifest/manifest->workflow validated)
+          result   (myc/run-workflow wf-def {} {:x 5})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= 10 (:result result)))))
+
+  (testing "Manifest with per-transition lite schemas normalizes correctly"
+    (cell/defcell :test/branch
+      (fn [_ data]
+        (if (pos? (:x data))
+          {:sign :positive}
+          {:sign :negative})))
+    (let [m {:id :test-branch-wf
+             :cells {:start {:id :test/branch
+                              :schema {:input {:x :int}
+                                       :output {:positive {:sign :keyword}
+                                                :negative {:sign :keyword}}}
+                              :on-error nil}}
+             :edges {:start {:positive :end :negative :end}}
+             :dispatches {:start [[:positive (fn [d] (= :positive (:sign d)))]
+                                  [:negative (fn [d] (= :negative (:sign d)))]]}}
+          validated (manifest/validate-manifest m {:strict? true})
+          wf-def   (manifest/manifest->workflow validated)]
+      ;; Per-transition output with lite values should work
+      (let [result (myc/run-workflow wf-def {} {:x 5})]
+        (is (nil? (myc/workflow-error result)))
+        (is (= :positive (:sign result)))))))


### PR DESCRIPTION
## Summary
- Adds `normalize-schema` and `normalize-cell-schema` to convert lite map syntax (`{:key :type}`) to standard Malli (`[:map [:key :type]]`) at registration time
- Supports nested maps, mixed syntax (lite + vector), and per-transition output schemas
- Normalization at three entry points: `defcell`, `set-cell-schema!`, and manifest `validate-manifest`
- Uses heuristic (all-values-are-vectors = per-transition) for `defcell`/`set-cell-schema!`, and edge context for manifests

## Test plan
- [x] 7 tests in `lite_schema_test.clj` covering:
  - Basic lite map conversion and nested maps
  - Per-transition output disambiguation
  - `defcell` and `set-cell-schema!` normalization
  - End-to-end workflow runs with lite schemas
  - Manifest loading with lite schemas
- [x] All 469 existing tests pass