### PR TITLE
Add :validate option for schema validation modes

### DIFF
--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -321,15 +321,18 @@
      `:coerce?`          — when true, coerces data before validation.
      `:state->names`     — map of state-id → cell-name keyword for error messages.
      `:input-transforms` — map of state-id → (fn [data] -> data), applied before validation.
+     `:validate`         — :strict (default), :warn, or :off.
    Skips terminal states."
   ([state->cell] (make-pre-interceptor state->cell {}))
   ([state->cell opts]
    (let [coerce?          (:coerce? opts)
          state->names     (:state->names opts)
-         input-transforms (:input-transforms opts)]
+         input-transforms (:input-transforms opts)
+         validate-mode    (or (:validate opts) :strict)]
      (fn [fsm-state _resources]
        (let [state-id (:current-state-id fsm-state)]
-         (if (contains? terminal-states state-id)
+         (if (or (contains? terminal-states state-id)
+                 (= :off validate-mode))
            fsm-state
            (if-let [cell (get state->cell state-id)]
              (let [;; Apply input transform before validation
@@ -339,20 +342,30 @@
                (if coerce?
                  (let [result (coerce-input cell (:data fsm-state))]
                    (if (:error result)
+                     (if (= :warn validate-mode)
+                       (let [warning (-> (:error result)
+                                         (attach-cell-path (:data fsm-state))
+                                         (attach-cell-name state-id state->names))]
+                         (update-in fsm-state [:data :mycelium/warnings] (fnil conj []) warning))
+                       (-> fsm-state
+                           (assoc :current-state-id ::fsm/error)
+                           (assoc-in [:data :mycelium/schema-error]
+                                     (-> (:error result)
+                                         (attach-cell-path (:data fsm-state))
+                                         (attach-cell-name state-id state->names)))))
+                     (assoc fsm-state :data (:data result))))
+                 (if-let [error (validate-input cell (:data fsm-state))]
+                   (if (= :warn validate-mode)
+                     (let [warning (-> error
+                                       (attach-cell-path (:data fsm-state))
+                                       (attach-cell-name state-id state->names))]
+                       (update-in fsm-state [:data :mycelium/warnings] (fnil conj []) warning))
                      (-> fsm-state
                          (assoc :current-state-id ::fsm/error)
                          (assoc-in [:data :mycelium/schema-error]
-                                   (-> (:error result)
+                                   (-> error
                                        (attach-cell-path (:data fsm-state))
-                                       (attach-cell-name state-id state->names))))
-                     (assoc fsm-state :data (:data result))))
-                 (if-let [error (validate-input cell (:data fsm-state))]
-                   (-> fsm-state
-                       (assoc :current-state-id ::fsm/error)
-                       (assoc-in [:data :mycelium/schema-error]
-                                 (-> error
-                                     (attach-cell-path (:data fsm-state))
-                                     (attach-cell-name state-id state->names))))
+                                       (attach-cell-name state-id state->names)))))
                    fsm-state)))
              fsm-state)))))))
 
@@ -367,13 +380,15 @@
    `opts` — optional map:
      `:coerce?`  — when true, coerces output data before validation.
      `:on-trace` — callback `(fn [trace-entry])` called after each cell completes.
+     `:validate` — :strict (default), :warn, or :off.
    Skips terminal states."
   ([state->cell state->edge-targets state->names]
    (make-post-interceptor state->cell state->edge-targets state->names {}))
   ([state->cell state->edge-targets state->names opts]
    (let [coerce?           (:coerce? opts)
          on-trace          (:on-trace opts)
-         output-transforms (:output-transforms opts)]
+         output-transforms (:output-transforms opts)
+         validate-mode     (or (:validate opts) :strict)]
      (fn [fsm-state _resources]
        (let [state-id (:last-state-id fsm-state)]
          (if (or (nil? state-id)
@@ -384,7 +399,8 @@
                                 (get-in state->edge-targets
                                         [state-id (:current-state-id fsm-state)]))
                    data       (:data fsm-state)
-                   skip-validation? (or (:mycelium/resilience-error data)
+                   skip-validation? (or (= :off validate-mode)
+                                        (:mycelium/resilience-error data)
                                         (:mycelium/timeout data)
                                         (:mycelium/error data))
                    ;; When coercing, get both error and coerced data
@@ -425,6 +441,16 @@
                                  error         (assoc :error error))]
                (when on-trace (on-trace trace-entry))
                (cond
+                 (and error (= :warn validate-mode))
+                 (let [warning (-> error
+                                   (attach-cell-path (:data fsm-state))
+                                   (attach-cell-name state-id state->names))]
+                   (-> fsm-state
+                       (assoc :data data)
+                       (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)
+                       (update :data dissoc :mycelium/join-traces :mycelium/params)
+                       (update-in [:data :mycelium/warnings] (fnil conj []) warning)))
+
                  error
                  (-> fsm-state
                      (update-in [:data :mycelium/trace] (fnil conj []) trace-entry)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -1053,10 +1053,17 @@
 
     :else false))
 
+(def ^:private preserved-mycelium-keys
+  "Mycelium keys that survive key propagation (stripped from input, re-attached after merge)."
+  #{:mycelium/warnings})
+
 (defn- strip-mycelium-keys
-  "Removes :mycelium/* keys from a data map for key propagation."
+  "Removes :mycelium/* keys from a data map for key propagation.
+   Preserves keys listed in `preserved-mycelium-keys`."
   [data]
-  (into {} (remove (fn [[k _]] (and (keyword? k) (= "mycelium" (namespace k))))) data))
+  (into {} (remove (fn [[k _]] (and (keyword? k)
+                                     (= "mycelium" (namespace k))
+                                     (not (contains? preserved-mycelium-keys k))))) data))
 
 (defn- wrap-handler-with-propagation
   "Wraps a cell handler so that input keys automatically propagate to output.
@@ -1282,7 +1289,7 @@
          transform-maps (when-let [transforms (:transforms workflow)]
                           (build-transform-maps transforms edges))
          ;; Build interceptors — compose custom pre/post with schema interceptors
-         schema-opts (-> (select-keys opts [:coerce? :on-trace])
+         schema-opts (-> (select-keys opts [:coerce? :on-trace :validate])
                         (assoc :state->names state->names)
                         (cond->
                           transform-maps (assoc :input-transforms  (:input transform-maps)

--- a/test/mycelium/validate_warn_test.clj
+++ b/test/mycelium/validate_warn_test.clj
@@ -1,0 +1,152 @@
+(ns mycelium.validate-warn-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+(def ^:private on-error (fn [_resources fsm-state] (:data fsm-state)))
+
+;; ===== 1. :validate :strict — current behavior unchanged =====
+
+(deftest validate-strict-test
+  (testing ":validate :strict halts on schema mismatch (default behavior)"
+    (cell/defcell :test/bad-output
+      {:input  {:x :int}
+       :output {:y :int}}
+      ;; Returns wrong key
+      (fn [_ data] {:z 42}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/bad-output}
+                    :edges {:start :end}}
+                   {} {:x 1} {:on-error on-error :validate :strict})]
+      (is (some? (myc/workflow-error result)))
+      (is (= :schema/output (:error-type (myc/workflow-error result)))))))
+
+;; ===== 2. :validate :warn — schema mismatch doesn't halt =====
+
+(deftest validate-warn-continues-test
+  (testing ":validate :warn continues execution on schema mismatch"
+    (cell/defcell :test/warn-output
+      {:input  {:x :int}
+       :output {:y :int}}
+      ;; Returns wrong key name
+      (fn [_ data] {:z (* 2 (:x data))}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/warn-output}
+                    :edges {:start :end}}
+                   {} {:x 5} {:validate :warn})]
+      ;; Should complete without error
+      (is (nil? (myc/workflow-error result)))
+      ;; Result should contain the handler output
+      (is (= 10 (:z result)))
+      ;; Warnings should be collected
+      (is (seq (:mycelium/warnings result))))))
+
+;; ===== 3. :validate :warn — warnings accumulate across cells =====
+
+(deftest validate-warn-accumulates-test
+  (testing "Warnings accumulate across multiple cells"
+    (cell/defcell :test/step-a
+      {:input  {:x :int}
+       :output {:a-result :int}}
+      ;; Wrong key
+      (fn [_ data] {:a-wrong 1}))
+    (cell/defcell :test/step-b
+      {:input  {:x :int}
+       :output {:b-result :int}}
+      ;; Also wrong key
+      (fn [_ data] {:b-wrong 2}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/step-a
+                            :step-b :test/step-b}
+                    :edges {:start :step-b
+                            :step-b :end}}
+                   {} {:x 1} {:validate :warn})]
+      (is (nil? (myc/workflow-error result)))
+      ;; Should have warnings from both cells
+      (is (>= (count (:mycelium/warnings result)) 2)))))
+
+;; ===== 4. Warning contains diagnostic info =====
+
+(deftest validate-warn-diagnostic-info-test
+  (testing "Warning contains cell-id, phase, and key-diff info"
+    (cell/defcell :test/diag
+      {:input  {:x :int}
+       :output {:result :int}}
+      (fn [_ data] {:rezult (* 2 (:x data))}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/diag}
+                    :edges {:start :end}}
+                   {} {:x 5} {:validate :warn})
+          warning (first (:mycelium/warnings result))]
+      (is (some? warning))
+      (is (= :test/diag (:cell-id warning)))
+      (is (= :output (:phase warning)))
+      (is (some? (:message warning)))
+      (is (some? (:key-diff warning))))))
+
+;; ===== 5. :validate :off — no schema validation at all =====
+
+(deftest validate-off-test
+  (testing ":validate :off skips all schema validation"
+    (cell/defcell :test/off
+      {:input  {:x :int}
+       :output {:y :int}}
+      ;; Completely wrong types and keys
+      (fn [_ data] {:z "not-an-int"}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/off}
+                    :edges {:start :end}}
+                   {} {:x 1} {:validate :off})]
+      (is (nil? (myc/workflow-error result)))
+      (is (= "not-an-int" (:z result)))
+      ;; No warnings either
+      (is (nil? (:mycelium/warnings result))))))
+
+;; ===== 6. run-compiled accepts :validate option =====
+
+(deftest run-compiled-validate-option-test
+  (testing "run-compiled passes :validate to compilation"
+    (cell/defcell :test/compiled-warn
+      {:input  {:x :int}
+       :output {:y :int}}
+      (fn [_ data] {:z 42}))
+    (let [compiled (myc/pre-compile
+                     {:cells {:start :test/compiled-warn}
+                      :edges {:start :end}}
+                     {:validate :warn})
+          result   (myc/run-compiled compiled {} {:x 1})]
+      (is (nil? (myc/workflow-error result)))
+      (is (seq (:mycelium/warnings result))))))
+
+;; ===== 7. Input validation respects :validate mode =====
+
+(deftest validate-warn-input-test
+  (testing ":validate :warn collects input schema warnings too"
+    (cell/defcell :test/input-warn
+      {:input  {:x :int}
+       :output {:y :int}}
+      (fn [_ data] {:y 42}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/input-warn}
+                    :edges {:start :end}}
+                   {} {:x "not-an-int"} {:validate :warn})]
+      ;; Should complete (handler still works with coercion-less wrong type)
+      ;; At minimum, should not halt on schema error
+      (is (nil? (:mycelium/schema-error result)))
+      (is (seq (:mycelium/warnings result))))))
+
+;; ===== 8. Default validate behavior is :strict =====
+
+(deftest validate-default-strict-test
+  (testing "Default behavior (no :validate opt) is strict"
+    (cell/defcell :test/default-strict
+      {:input  {:x :int}
+       :output {:y :int}}
+      (fn [_ data] {:z 42}))
+    (let [result (myc/run-workflow
+                   {:cells {:start :test/default-strict}
+                    :edges {:start :end}}
+                   {} {:x 1} {:on-error on-error})]
+      (is (some? (myc/workflow-error result))))))


### PR DESCRIPTION
## Summary
- Adds `:validate` option (`:strict`, `:warn`, `:off`) to `pre-compile` and `run-workflow`
- `:strict` (default): halts on first schema error (existing behavior)
- `:warn`: collects schema errors as `:mycelium/warnings`, continues execution
- `:off`: skips all schema validation entirely
- Warnings accumulate across cells and include key-diff diagnostics
- `:mycelium/warnings` key is preserved through key propagation via `preserved-mycelium-keys` allowlist

## Test plan
- [x] 8 tests in `validate_warn_test.clj` covering:
  - `:strict` mode unchanged behavior
  - `:warn` mode continues on mismatch
  - Warnings accumulate across multiple cells
  - Warning contains diagnostic info (cell-id, phase, key-diff)
  - `:off` mode skips all validation
  - `run-compiled` accepts `:validate` option
  - Input validation respects `:validate` mode
  - Default behavior is `:strict`
- [x] All existing tests pass

> **Note:** This PR targets `feature/key-diff` (stacked PR). Merge the prior PRs first.