### PR TITLE
Add schema inference from test runs

### DIFF
--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -232,6 +232,16 @@
    See mycelium.dev/generate-stubs."
   dev/generate-stubs)
 
+(def infer-schemas
+  "Infers input/output schemas by running workflow with test inputs.
+   See mycelium.dev/infer-schemas."
+  dev/infer-schemas)
+
+(def apply-inferred-schemas!
+  "Applies inferred schemas to cells in the registry.
+   See mycelium.dev/apply-inferred-schemas!."
+  dev/apply-inferred-schemas!)
+
 ;; --- Error inspection ---
 
 (defn workflow-error

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [malli.core :as m]
             [malli.generator :as mg]
+            [malli.provider :as mp]
             [mycelium.cell :as cell]
             [mycelium.schema :as schema]
             [mycelium.workflow :as wf]
@@ -475,3 +476,68 @@
   (let [counter (atom -1)]
     (fn [entry]
       (println (format-trace-entry (swap! counter inc) entry)))))
+
+;; ===== Schema inference from test runs =====
+
+(defn- strip-mycelium-keys
+  "Removes :mycelium/* keys from a data map for schema inference."
+  [data]
+  (into {} (remove (fn [[k _]] (and (keyword? k) (= "mycelium" (namespace k))))) data))
+
+(defn infer-schemas
+  "Infers input/output schemas for each cell by running a workflow with test inputs.
+   Runs the workflow in :validate :off mode, captures cell inputs and outputs
+   via :on-trace, then uses malli.provider/provide to generate schemas.
+
+   Returns a map of {cell-name {:input schema :output schema}}.
+
+   Arguments:
+     workflow-def — workflow definition map
+     resources    — resources map
+     test-inputs  — vector of input data maps to run"
+  [workflow-def resources test-inputs]
+  (let [cell-data (atom {})] ;; {cell-name {:inputs [...] :outputs [...]}}
+    ;; Run workflow for each test input sequentially
+    (doseq [input test-inputs]
+      (let [;; Per-run capture of cell input data (keyed by state-id)
+            input-capture (atom {})
+            pre-hook (fn [fsm-state _resources]
+                       (let [state-id (:current-state-id fsm-state)]
+                         (when-not (contains? #{::fsm/end ::fsm/error ::fsm/halt} state-id)
+                           (swap! input-capture assoc state-id
+                                  (strip-mycelium-keys (:data fsm-state))))
+                         fsm-state))
+            on-trace (fn [{:keys [cell] :as _entry}]
+                       (let [input-data  (get @input-capture
+                                             (wf/resolve-state-id cell))
+                             output-data (strip-mycelium-keys (:data _entry))]
+                         (swap! cell-data update cell
+                                (fn [m]
+                                  (-> (or m {:inputs [] :outputs []})
+                                      (update :inputs conj (or input-data output-data))
+                                      (update :outputs conj output-data))))))
+            compiled (wf/compile-workflow workflow-def
+                                         {:validate :off
+                                          :pre pre-hook
+                                          :on-trace on-trace})]
+        (try
+          @(fsm/run-async compiled resources {:data input})
+          (catch Exception _))))
+    ;; Infer schemas from collected data
+    (into {}
+          (map (fn [[cell-name {:keys [inputs outputs]}]]
+                 [cell-name {:input  (mp/provide inputs)
+                             :output (mp/provide outputs)}]))
+          @cell-data)))
+
+(defn apply-inferred-schemas!
+  "Applies inferred schemas to cells in the registry.
+   `inferred` is the output of `infer-schemas`.
+   `workflow-def` is the workflow definition (needed to map cell-names to cell-ids)."
+  [inferred workflow-def]
+  (let [cells (:cells workflow-def)]
+    (doseq [[cell-name schema-map] inferred]
+      (let [cell-ref (get cells cell-name)
+            cell-id  (if (map? cell-ref) (:id cell-ref) cell-ref)]
+        (when cell-id
+          (cell/set-cell-schema! cell-id schema-map))))))

--- a/test/mycelium/infer_schema_test.clj
+++ b/test/mycelium/infer_schema_test.clj
@@ -1,0 +1,119 @@
+(ns mycelium.infer-schema-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [mycelium.dev :as dev]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+;; ===== 1. infer-schemas with single test input =====
+
+(deftest infer-schemas-single-input-test
+  (testing "Infers input/output schemas for each cell from a single test run"
+    (cell/defcell :test/double
+      (fn [_ data] {:result (* 2 (:x data))}))
+    (cell/defcell :test/format
+      (fn [_ data] {:message (str "Result: " (:result data))}))
+    (let [wf-def  {:cells {:start :test/double
+                           :fmt   :test/format}
+                   :edges {:start :fmt
+                           :fmt   :end}}
+          inferred (dev/infer-schemas wf-def {} [{:x 5}])]
+      ;; Should have schemas for both cells
+      (is (contains? inferred :start))
+      (is (contains? inferred :fmt))
+      ;; Output of :start should include :result
+      (let [start-output (get-in inferred [:start :output])]
+        (is (some? start-output))
+        (is (m/validate start-output {:result 10 :x 5}))))))
+
+;; ===== 2. Multiple test inputs — schema covers variants =====
+
+(deftest infer-schemas-multiple-inputs-test
+  (testing "Multiple inputs produce schema covering all variants"
+    (cell/defcell :test/classify
+      (fn [_ data]
+        (cond-> {:category (if (pos? (:x data)) :positive :negative)}
+          (:label data) (assoc :label (:label data)))))
+    (let [wf-def  {:cells {:start :test/classify}
+                   :edges {:start :end}}
+          inferred (dev/infer-schemas wf-def {}
+                     [{:x 5}
+                      {:x -3 :label "test"}
+                      {:x 0}])]
+      ;; Schema should mark :label as optional (not present in all inputs)
+      (let [output-schema (get-in inferred [:start :output])]
+        (is (some? output-schema))
+        ;; Should validate all test outputs
+        (is (m/validate output-schema {:category :positive :x 5}))
+        (is (m/validate output-schema {:category :negative :x -3 :label "test"}))))))
+
+;; ===== 3. Inferred schemas validate original test data =====
+
+(deftest inferred-schemas-validate-test
+  (testing "Inferred schemas validate against the original test data"
+    (cell/defcell :test/enrich
+      (fn [_ data] {:enriched true :original (:name data)}))
+    (let [wf-def  {:cells {:start :test/enrich}
+                   :edges {:start :end}}
+          inputs  [{:name "Alice"} {:name "Bob"}]
+          inferred (dev/infer-schemas wf-def {} inputs)
+          output-schema (get-in inferred [:start :output])]
+      ;; Run each input and verify output matches inferred schema
+      (doseq [input inputs]
+        (let [result (myc/run-workflow wf-def {} input)]
+          (is (m/validate output-schema result)))))))
+
+;; ===== 4. apply-inferred-schemas! updates cell registry =====
+
+(deftest apply-inferred-schemas-test
+  (testing "apply-inferred-schemas! updates cell schemas in registry"
+    (cell/defcell :test/compute
+      (fn [_ data] {:result (* 3 (:x data))}))
+    (let [wf-def  {:cells {:start :test/compute}
+                   :edges {:start :end}}
+          inferred (dev/infer-schemas wf-def {} [{:x 1} {:x 2}])]
+      (is (nil? (:schema (cell/get-cell :test/compute))))
+      (dev/apply-inferred-schemas! inferred wf-def)
+      (let [spec (cell/get-cell :test/compute)]
+        (is (some? (get-in spec [:schema :input])))
+        (is (some? (get-in spec [:schema :output])))))))
+
+;; ===== 5. Round-trip: infer → apply → strict run passes =====
+
+(deftest infer-apply-strict-roundtrip-test
+  (testing "Infer → apply → strict run passes for matching data"
+    (cell/defcell :test/roundtrip
+      (fn [_ data] {:doubled (* 2 (:n data))}))
+    (let [wf-def   {:cells {:start :test/roundtrip}
+                    :edges {:start :end}}
+          inferred (dev/infer-schemas wf-def {} [{:n 1} {:n 2} {:n 3}])]
+      (dev/apply-inferred-schemas! inferred wf-def)
+      ;; Run with strict validation — should pass
+      (let [result (myc/run-workflow wf-def {} {:n 10})]
+        (is (nil? (myc/workflow-error result)))
+        (is (= 20 (:doubled result)))))))
+
+;; ===== 6. Multi-cell workflow inference =====
+
+(deftest infer-schemas-multi-cell-test
+  (testing "Infers schemas across a multi-cell workflow"
+    (cell/defcell :test/step-a
+      (fn [_ data] {:a-out (inc (:x data))}))
+    (cell/defcell :test/step-b
+      (fn [_ data] {:b-out (* 2 (:a-out data))}))
+    (cell/defcell :test/step-c
+      (fn [_ data] {:final (str "done:" (:b-out data))}))
+    (let [wf-def  {:cells {:start :test/step-a
+                           :b     :test/step-b
+                           :c     :test/step-c}
+                   :edges {:start :b
+                           :b     :c
+                           :c     :end}}
+          inferred (dev/infer-schemas wf-def {} [{:x 1} {:x 2}])]
+      (is (= #{:start :b :c} (set (keys inferred))))
+      ;; Each cell should have input and output
+      (doseq [cell-name [:start :b :c]]
+        (is (some? (get-in inferred [cell-name :input])) (str cell-name " missing input"))
+        (is (some? (get-in inferred [cell-name :output])) (str cell-name " missing output"))))))


### PR DESCRIPTION
## Summary
- Adds `infer-schemas` to dev namespace: runs a workflow with test inputs in `:validate :off` mode, captures cell inputs/outputs via `:on-trace`, and uses `malli.provider/provide` to generate schemas
- Adds `apply-inferred-schemas!`: updates cell registry with inferred schemas
- Both functions re-exported via `myc/` for convenience
- Supports write-handlers-first development: implement cells without schemas, infer schemas from test data, then lock them down

## Test plan
- [x] 6 tests in `infer_schema_test.clj` covering:
  - Single test input inference
  - Multiple inputs (schema covers variants)
  - Inferred schemas validate original test data
  - `apply-inferred-schemas!` updates registry
  - Round-trip: infer → apply → strict run passes
  - Multi-cell workflow inference
- [x] All 489 tests pass (full suite)

> **Note:** This PR targets `feature/validate-modes` (stacked PR). Merge the prior PRs first.