### PR TITLE
Update documentation for LLM ergonomics features

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -298,8 +298,8 @@ Graph-level timeouts **route** to a fallback cell. Resilience timeouts **error**
 (require '[mycelium.cell :as cell])
 
 (cell/defcell :order/compute-tax
-  {:input  [:map [:subtotal :double] [:tax-rate :double]]
-   :output [:map [:tax :double]]}
+  {:input  {:subtotal :double, :tax-rate :double}
+   :output {:tax :double}}
   (fn [resources data]
     ;; With key propagation (default): return only new keys
     {:tax (* (:subtotal data) (:tax-rate data))}))

--- a/docs/developing-workflows.md
+++ b/docs/developing-workflows.md
@@ -360,6 +360,44 @@ Verify that errors are caught and routed correctly:
 
 ## 7. Iterate and Refine
 
+### Validate Modes
+
+During development, use `:validate :warn` to see all schema problems without halting execution:
+
+```clojure
+(let [result (myc/run-workflow wf resources test-data {:validate :warn})]
+  ;; Workflow runs to completion even if schemas don't match
+  (println (:mycelium/warnings result)))
+;; => [{:cell-id :app/tax, :phase :output,
+;;      :message "Schema output validation failed at :app/tax
+;;        Missing key(s): #{:tax}
+;;        Extra key(s): #{:tax-amount}",
+;;      :key-diff {:missing #{:tax}, :extra #{:tax-amount}}}]
+```
+
+Or skip validation entirely during early prototyping:
+
+```clojure
+(myc/run-workflow wf resources test-data {:validate :off})
+```
+
+Switch to `:validate :strict` (the default) once logic is correct to enforce contracts.
+
+### Infer Schemas from Test Runs
+
+Write handlers first, let Mycelium figure out the schemas:
+
+```clojure
+(require '[mycelium.dev :as dev])
+
+(def inferred (dev/infer-schemas workflow-def {} [test-input-1 test-input-2]))
+;; => {:start {:input [:map [:x :int]], :output [:map [:x :int] [:result :int]]}
+;;     :step2 {:input [:map [:x :int] [:result :int]], :output [:map ...]}}
+
+;; Apply inferred schemas to cell registry
+(dev/apply-inferred-schemas! inferred workflow-def)
+```
+
 ### Use Dev Tools
 
 ```clojure

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -61,17 +61,33 @@ Schema errors are the most detailed. When a cell's input or output fails Malli v
 {:cell-id     :app/process-payment
  :cell-name   :payment
  :phase       :input           ;; or :output
- :message     "Schema input validation failed at payment (:app/process-payment) — failing keys: (:amount :currency)"
+ :message     "Schema input validation failed at payment (:app/process-payment)
+   Missing key(s): #{:currency}
+   Extra key(s): #{:curr}"
  :failed-keys {:amount   {:value "not-a-number"
                            :type  "java.lang.String"
                            :message "should be a double"}
                 :currency {:value nil
                            :type  nil
                            :message "missing required key"}}
+ :key-diff    {:missing #{:currency}   ;; expected by schema but not in data
+               :extra   #{:curr}}      ;; in data but not in schema (possible typo)
  :cell-path   [:validate :lookup]   ;; cells that ran before this one
  :errors      {:amount ["should be a double"]
                :currency ["missing required key"]}
  :data        {:user-id "alice"}}   ;; clean data (no :mycelium/* keys)
+```
+
+### Key-Diff Suggestions
+
+The `:key-diff` field helps identify typos and misnamed keys. When a schema expects `:currency` but the data contains `:curr`, the diff makes the fix obvious:
+
+```clojure
+(when-let [{:keys [key-diff]} (myc/workflow-error result)]
+  (when (seq (:missing key-diff))
+    (println "Missing keys:" (:missing key-diff)))
+  (when (seq (:extra key-diff))
+    (println "Extra keys (possible typos):" (:extra key-diff))))
 ```
 
 ### Diagnosing Schema Failures
@@ -111,6 +127,30 @@ Validate initial workflow data before any cells run:
 ```
 
 No cells execute when input validation fails.
+
+## Validation Modes
+
+Control how schema errors are handled with the `:validate` option:
+
+```clojure
+;; :strict (default) — halt on first schema error
+(myc/run-workflow wf resources data)
+(myc/run-workflow wf resources data {:validate :strict})
+
+;; :warn — log warnings, continue execution
+(let [result (myc/run-workflow wf resources data {:validate :warn})]
+  (println (:mycelium/warnings result)))
+;; => [{:cell-id :app/tax, :phase :output,
+;;      :message "Schema output validation failed at :app/tax
+;;        Missing key(s): #{:tax}
+;;        Extra key(s): #{:tax-amount}",
+;;      :key-diff {:missing #{:tax}, :extra #{:tax-amount}}}]
+
+;; :off — skip all schema validation
+(myc/run-workflow wf resources data {:validate :off})
+```
+
+Use `:warn` during iterative development to see all problems at once. Use `:off` for early prototyping when schemas aren't ready. Switch to `:strict` for production.
 
 ## Error Groups
 

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -12,16 +12,16 @@ A Mycelium workflow is a directed graph of **cells** (pure data transformations)
 (require '[mycelium.cell :as cell]
          '[mycelium.core :as myc])
 
-;; 1. Define cells
+;; 1. Define cells (lite schema syntax — {key type})
 (cell/defcell :app/validate
-  {:input  [:map [:name :string]]
-   :output [:map [:valid :boolean]]}
+  {:input  {:name :string}
+   :output {:valid :boolean}}
   (fn [_resources data]
     {:valid (not (empty? (:name data)))}))
 
 (cell/defcell :app/greet
-  {:input  [:map [:name :string]]
-   :output [:map [:greeting :string]]}
+  {:input  {:name :string}
+   :output {:greeting :string}}
   (fn [_resources data]
     {:greeting (str "Hello, " (:name data) "!")}))
 
@@ -49,17 +49,17 @@ Use `cell/defcell` to register cells. The ID is specified once (no duplication).
   (fn [resources data]
     {:result-key "value"}))
 
-;; With schema (recommended)
+;; With schema (recommended — lite syntax)
 (cell/defcell :ns/cell-id
-  {:input  [:map [:x :int]]
-   :output [:map [:y :int]]}
+  {:input  {:x :int}
+   :output {:y :int}}
   (fn [resources data]
     {:y (* 2 (:x data))}))
 
 ;; With schema + options
 (cell/defcell :ns/cell-id
-  {:input    [:map [:x :int]]
-   :output   [:map [:y :int]]
+  {:input    {:x :int}
+   :output   {:y :int}
    :doc      "Doubles the input"
    :requires [:db]}
   (fn [{:keys [db]} data]
@@ -72,7 +72,32 @@ Use `cell/defcell` to register cells. The ID is specified once (no duplication).
 2. **Return only new keys.** Key propagation is on by default — input keys are merged automatically. Don't `(assoc data ...)`, just return `{:new-key value}`.
 3. **Resources for infrastructure.** Database connections, HTTP clients, config go in `resources`. Data map is for workflow state only.
 4. **Errors are data.** Set a key (`:status :failed`) and let dispatch predicates route it. Don't throw for expected failures.
-5. **Schemas use [Malli](https://github.com/metosin/malli) syntax.** `[:map [:key :type]]` for maps. Types: `:string`, `:int`, `:double`, `:boolean`, `:keyword`, `:uuid`, `[:enum :a :b]`, `[:vector :type]`, etc.
+5. **Schemas use [Malli](https://github.com/metosin/malli) syntax** or **lite syntax** (see below).
+
+### Schema Syntax
+
+Two equivalent ways to write schemas:
+
+```clojure
+;; Malli vector syntax (full power)
+{:input  [:map [:subtotal :double] [:state :string]]
+ :output [:map [:tax :double]]}
+
+;; Lite syntax (simpler, recommended for most cases)
+{:input  {:subtotal :double, :state :string}
+ :output {:tax :double}}
+```
+
+Lite syntax auto-converts `{:key :type}` to `[:map [:key :type]]`. It works in `defcell`, `set-cell-schema!`, and manifest schemas. Nested maps are supported:
+
+```clojure
+{:input {:address {:street :string, :city :string}}}
+;; becomes [:map [:address [:map [:street :string] [:city :string]]]]
+```
+
+Use full Malli syntax when you need: enums (`[:enum :a :b]`), unions (`[:or :string :int]`), optional fields, or other advanced features. Both syntaxes can be mixed freely.
+
+Available types: `:string`, `:int`, `:double`, `:boolean`, `:keyword`, `:uuid`, `[:enum :a :b]`, `[:vector :type]`, `[:map-of :key-type :val-type]`, etc.
 
 ---
 
@@ -140,48 +165,81 @@ Join members have **no entries in `:edges`**. Each gets the same input snapshot.
 
 ---
 
-## Development Workflow
+## Development Workflow (3 Phases)
 
-### 1. Write the Manifest First
+Mycelium supports an iterative development workflow. You don't need to get everything right on the first try.
 
-Define cells, edges, schemas. Compilation validates everything:
+### Phase 1: Structure (compile-time feedback)
+
+Write the manifest with cells, edges, and schemas. Pre-compilation catches structural errors immediately:
 
 ```clojure
-(myc/pre-compile workflow-def) ;; Throws on invalid structure
+(myc/pre-compile workflow-def) ;; Throws on: missing edges, unreachable cells, bad schemas
 ```
 
-### 2. Generate Stubs
+Generate cell stubs from the workflow structure:
 
 ```clojure
 (println (myc/generate-stubs workflow-def))
 ;; Prints defcell forms with schemas and TODO handlers
 ```
 
-Copy the output, fill in handler logic. Schemas and wiring are pre-validated.
+### Phase 2: Logic (run with warnings, iterate)
 
-### 3. Test Cells in Isolation
+Write handler implementations. Run with `:validate :warn` to see all problems at once without halting:
+
+```clojure
+(let [result (myc/run-workflow workflow {} test-data {:validate :warn})]
+  ;; Workflow runs to completion even if schemas don't match
+  (println (:mycelium/warnings result)))
+;; => [{:cell-id :app/tax, :phase :output,
+;;      :message "Schema output validation failed at :app/tax
+;;        Missing key(s): #{:tax}
+;;        Extra key(s): #{:tax-amount}",
+;;      :key-diff {:missing #{:tax}, :extra #{:tax-amount}}}]
+```
+
+Schema errors now include **key-diff suggestions** — if you misname a key, the error tells you exactly what to rename.
+
+You can also skip validation entirely during early development:
+
+```clojure
+(myc/run-workflow workflow {} test-data {:validate :off})
+```
+
+**Or infer schemas from test runs** — write handlers first, let Mycelium figure out the schemas:
 
 ```clojure
 (require '[mycelium.dev :as dev])
 
+;; Run with test data, observe actual shapes
+(def inferred (dev/infer-schemas workflow-def {} test-inputs))
+;; => {:start {:input [:map [:x :int]], :output [:map [:x :int] [:result :int]]}
+;;     :fmt   {:input [:map [:x :int] [:result :int]], :output [:map ...]}}
+
+;; Apply inferred schemas to cell registry
+(dev/apply-inferred-schemas! inferred workflow-def)
+```
+
+### Phase 3: Contract (strict mode)
+
+Once logic is correct, lock down schemas. Run with `:validate :strict` (the default):
+
+```clojure
+(let [result (myc/run-workflow workflow {} data)]
+  ;; Schema violations halt execution with precise error
+  (when-let [err (myc/workflow-error result)]
+    (println (:message err))     ;; human-readable with key-diff suggestions
+    (println (:key-diff err))    ;; {:missing #{...} :extra #{...}}
+    (println (:failed-keys err)) ;; per-key details with types
+    ))
+```
+
+### Testing Cells in Isolation
+
+```clojure
 (dev/test-cell :app/validate {:input {:name "Alice"}})
 ;; => {:pass? true, :output {:valid true}, :errors [], :duration-ms 0.1}
-```
-
-### 4. Test the Workflow
-
-```clojure
-(let [result (myc/run-workflow workflow {} {:name "Alice"})]
-  (is (nil? (myc/workflow-error result)))
-  (is (= "Hello, Alice!" (:greeting result))))
-```
-
-### 5. Check Errors
-
-```clojure
-(when-let [err (myc/workflow-error result)]
-  ;; err has :error-type, :cell-name, :cell-id, :message, :failed-keys
-  (println (:message err)))
 ```
 
 ---
@@ -214,14 +272,19 @@ Cell handlers must return a map! Returning `nil` causes downstream failures. If 
 
 | Concept | Syntax |
 |---------|--------|
-| Register cell | `(cell/defcell :ns/id schema-map handler-fn)` |
+| Register cell | `(cell/defcell :ns/id {:input {:x :int} :output {:y :int}} handler-fn)` |
+| Lite schema | `{:input {:x :int}}` → `{:input [:map [:x :int]]}` |
 | Linear pipeline | `{:pipeline [:a :b :c]}` |
 | Branching edges | `{:edges {:start {:label :target}}}` |
 | Dispatch | `{:dispatches {:start [[:label (fn [d] pred)]]}}` |
 | Parallel join | `{:joins {:name {:cells [:a :b] :strategy :parallel}}}` |
 | Run workflow | `(myc/run-workflow wf resources data)` |
+| Run with warnings | `(myc/run-workflow wf res data {:validate :warn})` |
+| Run without validation | `(myc/run-workflow wf res data {:validate :off})` |
 | Pre-compile | `(def c (myc/pre-compile wf))` then `(myc/run-compiled c res data)` |
-| Check error | `(myc/workflow-error result)` |
+| Check error | `(myc/workflow-error result)` — includes `:key-diff` suggestions |
+| Infer schemas | `(dev/infer-schemas wf res [test-data ...])` |
+| Apply inferred | `(dev/apply-inferred-schemas! inferred wf)` |
 | Test cell | `(dev/test-cell :ns/id {:input {...}})` |
 | Generate stubs | `(println (myc/generate-stubs wf))` |
 | Coerce types | `(myc/pre-compile wf {:coerce? true})` |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -153,6 +153,7 @@ mentally reconstruct the architecture from.
  :on-end   (fn [resources fsm-state] data)        ;; runs when FSM enters end state
  :coerce?  true                                    ;; auto-coerce numeric types (int↔double)
  :propagate-keys? false                             ;; disable auto key propagation (on by default)
+ :validate :warn                                    ;; :strict (default), :warn, or :off
  :on-trace (fn [entry] ...)}                        ;; callback after each cell completes
 ```
 
@@ -185,7 +186,13 @@ Key propagation is on by default — cells can return only new/changed keys and 
 (cell/defcell :namespace/cell-id
   (fn [resources data] {:result "value"}))
 
-;; With schema
+;; With schema (lite syntax — recommended)
+(cell/defcell :namespace/cell-id
+  {:input  {:key :type}
+   :output {:result :string}}
+  (fn [resources data] {:result "value"}))
+
+;; With schema (full Malli vector syntax)
 (cell/defcell :namespace/cell-id
   {:input  [:map [:key :type]]
    :output [:map [:result :string]]}
@@ -193,8 +200,8 @@ Key propagation is on by default — cells can return only new/changed keys and 
 
 ;; With schema + options
 (cell/defcell :namespace/cell-id
-  {:input    [:map [:key :type]]
-   :output   [:map [:result :string]]
+  {:input    {:key :type}
+   :output   {:result :string}
    :doc      "..."
    :requires [:db]
    :async?   true}
@@ -628,6 +635,29 @@ Default dispatches `:success` / `:failure` are provided automatically based on `
 
 Output schema is inferred automatically by walking child workflow edges to `:end` and collecting output keys. Pass an explicit `:output` schema to override.
 
+## Schema Syntax
+
+Two equivalent ways to write schemas:
+
+```clojure
+;; Lite syntax (simpler, recommended for most cases)
+{:input  {:subtotal :double, :state :string}
+ :output {:tax :double}}
+
+;; Malli vector syntax (full power)
+{:input  [:map [:subtotal :double] [:state :string]]
+ :output [:map [:tax :double]]}
+```
+
+Lite syntax auto-converts `{:key :type}` to `[:map [:key :type]]`. It works in `defcell`, `set-cell-schema!`, and manifest schemas. Nested maps are supported:
+
+```clojure
+{:input {:address {:street :string, :city :string}}}
+;; becomes [:map [:address [:map [:street :string] [:city :string]]]]
+```
+
+Use full Malli syntax when you need: enums (`[:enum :a :b]`), unions (`[:or :string :int]`), optional fields, or other advanced features. Both syntaxes can be mixed freely.
+
 ## Output Schema Formats
 
 ```clojure
@@ -765,7 +795,17 @@ Declare compile-time path invariants that are checked against all enumerated pat
 ;; Useful for scaffolding — fill in handler logic after generating
 ```
 
-`analyze-workflow`, `infer-workflow-schema`, and `generate-stubs` are also available via `myc/`.
+```clojure
+;; Infer schemas from test data (run workflow, observe actual shapes)
+(dev/infer-schemas workflow-def {} [test-input-1 test-input-2])
+;; => {:start {:input [:map [:x :int]], :output [:map [:x :int] [:result :int]]}
+;;     :step2 {:input [:map [:x :int] [:result :int]], :output [:map ...]}}
+
+;; Apply inferred schemas to cell registry
+(dev/apply-inferred-schemas! inferred workflow-def)
+```
+
+`analyze-workflow`, `infer-workflow-schema`, `generate-stubs`, `infer-schemas`, and `apply-inferred-schemas!` are also available via `myc/`.
 
 ## Agent Orchestration
 
@@ -952,7 +992,10 @@ Instead of checking individual keys, use `workflow-error` and `error?`:
 (myc/error? result)           ;; => true/false
 (myc/workflow-error result)   ;; => {:error-type :schema/output, :cell-id :app/step,
                               ;;     :cell-name :step, :failed-keys {:x {...}},
-                              ;;     :message "Schema output validation failed at step (:app/step) — failing keys: (:x)",
+                              ;;     :key-diff {:missing #{:expected-key}, :extra #{:typo-key}},
+                              ;;     :message "Schema output validation failed at step (:app/step)
+                              ;;       Missing key(s): #{:expected-key}
+                              ;;       Extra key(s): #{:typo-key}",
                               ;;     :details {...}} or nil
 ```
 


### PR DESCRIPTION
## Summary
- **llm-guide.md**: comprehensive update with lite syntax, 3-phase development workflow, validate modes, schema inference, key-diff diagnostics
- **quick-reference.md**: add lite syntax examples in defcell, Schema Syntax section, `:validate` option in compilation opts, `infer-schemas` in dev tools, key-diff in error inspection
- **cookbook.md**: use lite syntax in Write a Cell recipe
- **developing-workflows.md**: add validate modes and schema inference sections to "Iterate and Refine"
- **error-handling.md**: add Validation Modes section, key-diff suggestions, updated schema error structure with `:key-diff`

## Test plan
- [x] Documentation-only changes, no code changes
- [x] All examples match the implemented API

> **Note:** This PR targets `feature/schema-inference` (stacked PR). Merge the prior PRs first.