### PR TITLE
Add :mycelium/trace to preserved mycelium keys

### DIFF
--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -1072,7 +1072,7 @@
 
 (def ^:private preserved-mycelium-keys
   "Mycelium keys that survive key propagation (stripped from input, re-attached after merge)."
-  #{:mycelium/warnings})
+  #{:mycelium/warnings :mycelium/trace})
 
 (defn- strip-mycelium-keys
   "Removes :mycelium/* keys from a data map for key propagation.


### PR DESCRIPTION
Otherwise trace does not get accumulated. Without this change I could only get the latest trace entry in the mycelium/trace keys of the result data.