### PR TITLE
Surface :start convention with an actionable error when :pipeline misuses it

### DIFF
--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -61,6 +61,16 @@
       (when (empty? pipeline)
         (throw (ex-info ":pipeline must have at least 1 element"
                         {:id (:id manifest)})))
+      (when (not= :start (first pipeline))
+        (throw (ex-info (str "Pipeline must begin with a cell named :start, got "
+                             (first pipeline) ". Reachability is BFS-rooted at "
+                             ":start; any other entry name is reported as "
+                             "unreachable. Rename the first cell in :cells from "
+                             (first pipeline) " to :start, or use :edges + "
+                             ":dispatches directly if you need a custom entry.")
+                        {:id         (:id manifest)
+                         :pipeline   pipeline
+                         :first-cell (first pipeline)})))
       (let [cell-names (set (keys cells))]
         (doseq [cell-name pipeline]
           (when-not (contains? cell-names cell-name)

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -355,7 +355,13 @@
 
 (defn- expand-pipeline
   "Expands a :pipeline vector into :edges and :dispatches for programmatic workflows.
-   Pipeline is mutually exclusive with :edges, :dispatches, and :joins."
+   Pipeline is mutually exclusive with :edges, :dispatches, and :joins.
+
+   The first element of :pipeline must be the cell named :start. The
+   reachability validator BFS-roots at :start, so any other entry name
+   leaves every cell in the workflow reported as unreachable. We catch
+   that misuse here with an actionable error rather than letting it
+   surface as `Unreachable cells: #{...}` later."
   [{:keys [pipeline cells edges dispatches joins] :as workflow}]
   (if-not pipeline
     workflow
@@ -368,6 +374,15 @@
         (throw (ex-info ":pipeline is mutually exclusive with :joins" {})))
       (when (empty? pipeline)
         (throw (ex-info ":pipeline must have at least 1 element" {})))
+      (when (not= :start (first pipeline))
+        (throw (ex-info (str "Pipeline must begin with a cell named :start, got "
+                             (first pipeline) ". Reachability is BFS-rooted at "
+                             ":start; any other entry name is reported as "
+                             "unreachable. Rename the first cell in :cells from "
+                             (first pipeline) " to :start, or use :edges + "
+                             ":dispatches directly if you need a custom entry.")
+                        {:pipeline   pipeline
+                         :first-cell (first pipeline)})))
       (let [cell-names (set (keys cells))]
         (doseq [name pipeline]
           (when-not (contains? cell-names name)

--- a/test/mycelium/manifest_test.clj
+++ b/test/mycelium/manifest_test.clj
@@ -404,6 +404,23 @@
       (is (thrown-with-msg? Exception #"at least 1"
             (manifest/validate-manifest m))))))
 
+(deftest pipeline-non-start-first-element-throws-test
+  (testing "Pipeline whose first element is not :start throws an actionable error"
+    (let [m {:id :test/pipeline-bad-entry
+             :pipeline [:probe :render]
+             :cells {:probe  {:id :test/pn-probe
+                              :doc "Probe cell"
+                              :schema {:input [:map] :output [:map [:x :int]]}
+                              :on-error nil}
+                     :render {:id :test/pn-render
+                              :doc "Render cell"
+                              :schema {:input [:map [:x :int]] :output [:map [:html :string]]}
+                              :on-error nil}}}]
+      (is (thrown-with-msg? Exception #"begin with a cell named :start"
+            (manifest/validate-manifest m)))
+      (is (thrown-with-msg? Exception #"\:probe"
+            (manifest/validate-manifest m))))))
+
 ;; ===== Parameterized cells in manifest =====
 
 (deftest manifest-parameterized-cell-validates-test

--- a/test/mycelium/workflow_test.clj
+++ b/test/mycelium/workflow_test.clj
@@ -517,6 +517,20 @@
            {:cells {:start :test/cell-a}
             :pipeline [:start :nonexistent]})))))
 
+(deftest pipeline-non-start-first-element-throws-test
+  (testing "Pipeline whose first element is not :start throws an actionable error"
+    (register-cells!)
+    (is (thrown-with-msg? Exception #"begin with a cell named :start"
+          (wf/compile-workflow
+           {:cells {:probe  :test/cell-a
+                    :render :test/cell-b}
+            :pipeline [:probe :render]})))
+    (is (thrown-with-msg? Exception #":probe"
+          (wf/compile-workflow
+           {:cells {:probe  :test/cell-a
+                    :render :test/cell-b}
+            :pipeline [:probe :render]})))))
+
 ;; ===== Parameterized cells =====
 
 (deftest parameterized-cell-compiles-test


### PR DESCRIPTION
## Summary

A `:pipeline` whose first element isn't `:start` (e.g. `[:probe :render]`)
currently fails with an opaque error from the reachability validator:

```
Unreachable cells: #{:render :probe}
```

Reachability is BFS-rooted at the literal cell name `:start`, so any other
entry name leaves every cell unreachable. There's no hint in the error
that the convention is at fault — users (and LLMs) end up inspecting
`:cells` and `:edges` for a connectivity bug that doesn't exist.

## Change

Move the validation up into `expand-pipeline` (both copies — `workflow.clj`
and `manifest.clj`) so the error fires before reachability runs and
explains the contract:

```
Pipeline must begin with a cell named :start, got :probe.
Reachability is BFS-rooted at :start; any other entry name is reported
as unreachable. Rename the first cell in :cells from :probe to :start,
or use :edges + :dispatches directly if you need a custom entry.
```

## Reproducer

```clojure
(require '[mycelium.core :as myc])
(myc/defcell :test/probe  {:input {} :output {:result :string} :doc "probe"}
  (fn [_ _] {:result "ok"}))
(myc/defcell :test/render {:input {:result :string} :output {:html :string} :doc "render"}
  (fn [_ d] {:html (:result d)}))
(myc/pre-compile {:cells    {:probe :test/probe :render :test/render}
                  :pipeline [:probe :render]})
;; => Before: Unreachable cells: #{:render :probe}
;; => After : Pipeline must begin with a cell named :start, got :probe. ...
```

## Tests

Added in both `manifest_test.clj` and `workflow_test.clj` covering both
code paths. Full suite: 492 tests / 1068 assertions / 0 failures.

## Notes

There are still two `expand-pipeline` implementations (`workflow.clj`
and `manifest.clj`) — patched both. Consolidating them is out of scope
for this PR but worth tracking; a future change should let `manifest.clj`
delegate to `workflow.clj` so this kind of fix only needs to land once.

## Test plan
- [x] `clj -M:test` green (492/1068)
- [x] Reproducer above produces the new error