### PR TITLE
Add ring-response output adapter for non-HTML workflows

### DIFF
--- a/src/mycelium/middleware.clj
+++ b/src/mycelium/middleware.clj
@@ -15,6 +15,35 @@
      :headers {"Content-Type" "text/plain"}
      :body    "Workflow produced no :html key"}))
 
+(defn ring-response
+  "Output adapter for workflows that produce arbitrary HTTP responses
+  (JSON, redirects, file streams, etc.) rather than only HTML.
+
+  The terminal render cell returns :status / :headers / :body keys
+  on the accumulated workflow data; this helper assembles those into
+  a Ring response, defaulting :status to 200 and :headers to {}.
+
+  Falls back to :html extraction (matching `html-response`) so a single
+  workflow can mix HTML pages and JSON endpoints without per-route
+  output-fn juggling."
+  [result]
+  (cond
+    (contains? result :body)
+    {:status  (:status  result 200)
+     :headers (:headers result {})
+     :body    (:body    result)}
+
+    (contains? result :html)
+    {:status  (:status  result 200)
+     :headers (merge {"Content-Type" "text/html; charset=utf-8"}
+                     (:headers result {}))
+     :body    (:html result)}
+
+    :else
+    {:status  500
+     :headers {"Content-Type" "text/plain"}
+     :body    "Workflow produced no :body or :html"}))
+
 (defn- run-compiled
   "Runs a pre-compiled workflow. Inlined to avoid cyclic dependency on mycelium.core."
   [{:keys [compiled-fsm input-schema-raw input-schema-compiled]} resources initial-data]

--- a/test/mycelium/middleware_test.clj
+++ b/test/mycelium/middleware_test.clj
@@ -33,6 +33,67 @@
     (let [resp (mw/html-response {:other "data"})]
       (is (= 500 (:status resp))))))
 
+;; ===== 1b. ring-response =====
+
+(deftest ring-response-body-test
+  (testing "ring-response uses :body / :status / :headers from the workflow"
+    (let [resp (mw/ring-response {:status 201
+                                  :headers {"Content-Type" "application/json"
+                                            "X-Trace-Id"   "abc"}
+                                  :body    "{\"ok\":true}"})]
+      (is (= 201 (:status resp)))
+      (is (= "{\"ok\":true}" (:body resp)))
+      (is (= "application/json" (get-in resp [:headers "Content-Type"])))
+      (is (= "abc" (get-in resp [:headers "X-Trace-Id"]))))))
+
+(deftest ring-response-defaults-test
+  (testing "ring-response defaults :status to 200 and :headers to {}"
+    (let [resp (mw/ring-response {:body "ok"})]
+      (is (= 200 (:status resp)))
+      (is (= "ok" (:body resp)))
+      (is (= {} (:headers resp))))))
+
+(deftest ring-response-html-fallback-test
+  (testing "ring-response falls back to :html with text/html when no :body"
+    (let [resp (mw/ring-response {:html "<h1>Hi</h1>"})]
+      (is (= 200 (:status resp)))
+      (is (= "<h1>Hi</h1>" (:body resp)))
+      (is (= "text/html; charset=utf-8" (get-in resp [:headers "Content-Type"])))))
+
+  (testing "ring-response :html honours per-request :status and merges :headers"
+    (let [resp (mw/ring-response {:html    "<h1>Gone</h1>"
+                                  :status  410
+                                  :headers {"X-Reason" "tombstone"}})]
+      (is (= 410 (:status resp)))
+      (is (= "tombstone" (get-in resp [:headers "X-Reason"])))
+      (is (= "text/html; charset=utf-8" (get-in resp [:headers "Content-Type"]))))))
+
+(deftest ring-response-missing-test
+  (testing "ring-response returns 500 when neither :body nor :html is present"
+    (let [resp (mw/ring-response {:other "data"})]
+      (is (= 500 (:status resp))))))
+
+(deftest workflow-handler-with-ring-response-test
+  (testing "workflow-handler + ring-response wires JSON through end-to-end"
+    (defmethod cell/cell-spec :mw-test/json [_]
+      {:id      :mw-test/json
+       :handler (fn [_ _]
+                  {:status  200
+                   :headers {"Content-Type" "application/json"}
+                   :body    "{\"ok\":true}"})
+       :schema  {:input  [:map]
+                 :output [:map [:body :string] [:status :int] [:headers :map]]}})
+    (let [compiled (myc/pre-compile
+                    {:cells {:start :mw-test/json}
+                     :edges {:start :end}})
+          handler  (mw/workflow-handler compiled
+                     {:resources {}
+                      :output-fn mw/ring-response})
+          resp     (handler {:uri "/api/thing"})]
+      (is (= 200 (:status resp)))
+      (is (= "application/json" (get-in resp [:headers "Content-Type"])))
+      (is (= "{\"ok\":true}" (:body resp))))))
+
 ;; ===== 2. workflow-handler basic =====
 
 (deftest workflow-handler-basic-test


### PR DESCRIPTION
## Summary

The default `html-response` adapter extracts only the `:html` key from
workflow output, which forces every JSON / redirect / file-stream
endpoint to write its own `:output-fn`. `ring-response` makes that case
ergonomic:

```clojure
(mw/workflow-handler compiled
  {:resources opts
   :output-fn mw/ring-response})
```

The terminal cell sets `:status` / `:headers` / `:body` on the
accumulated workflow data and `ring-response` assembles them into a Ring
response, defaulting `:status` to `200` and `:headers` to `{}`.

It also falls back to `:html` extraction (matching `html-response`) so a
single workflow can mix HTML pages and JSON endpoints without per-route
output-fn juggling, and HTML responses can override `:status` /
`:headers` (useful for `410 Gone` tombstones, custom cache-control,
etc.).

## Real-world usage

Came out of building a federated server on Mycelium — the very first
non-HTML route (`/healthz` returning JSON) needed a custom adapter,
which felt like the wrong default friction for a framework targeting
both HTML and JSON workflows. Lifting this small helper into the
framework removes that boilerplate from every consumer.

## Tests

Four new tests:
- explicit `:body` / `:status` / `:headers`
- `:body` with default 200 + `{}` headers
- `:html` fallback (a) with content-type only and (b) with header merge + status override
- end-to-end JSON through `workflow-handler` + `ring-response`

Plus existing 491 tests untouched. Full suite: 495 tests / 1081
assertions / 0 failures.

## Test plan
- [x] `clj -M:test` green (495/1081)
- [x] Verified the fallback path (`:html` only) preserves backward compat