### PR TITLE
Require explicit [:per-transition ...] wrapper; honor :optional on inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## Unreleased
+
+### Breaking: per-transition output schemas require explicit `[:per-transition ...]` wrapper
+
+Cells whose downstream edge selection depends on the cell's output
+declare a different schema per transition. Pre-1.0 the wrapper was
+implicit — a plain map whose values were all vectors was inferred
+to be per-transition. That heuristic silently misclassified lite
+map output schemas whose values happened to be vector schemas
+(e.g. `{:user/profile [:maybe :map]}` — every value is a vector,
+so it got treated as per-transition with transitions `:user/profile`).
+
+The wrapper is now mandatory:
+
+```clojure
+;; Before — implicit, ambiguous
+:output {:high [:map [:result [:= :high]]]
+         :low  [:map [:result [:= :low]]]}
+
+;; After — explicit
+:output [:per-transition {:high [:map [:result [:= :high]]]
+                          :low  [:map [:result [:= :low]]]}]
+```
+
+Bare map output schemas are now ALWAYS lite-map syntax, never
+per-transition. The migration error message includes the exact
+rewrite for each cell that needs updating. EDN manifest files
+follow the same form.
+
+### Fix: schema-chain validator honors `{:optional true}` on inputs
+
+A cell that declared `[:k {:optional true} <schema>]` in its input
+was previously rejected by `compile-workflow` unless every
+upstream cell on the cell's path produced `:k`. The validator now
+filters out optional keys when computing a cell's required inputs.
+
+```clojure
+;; This now compiles — :b is optional, upstream needn't produce it
+(cell/defcell :downstream
+  {:input [:map [:a :int] [:b {:optional true} [:maybe :string]]]
+   :output [:map [:done :boolean]]}
+  ...)
+```
+
 ## 2026-03-07
 
 ### Unified Error Inspection

--- a/MYCELIUM_GUIDE.md
+++ b/MYCELIUM_GUIDE.md
@@ -76,8 +76,9 @@ Cells with multiple outgoing edges can declare different output schemas per tran
 
 ```clojure
 :schema {:input  [:map [:id :string]]
-         :output {:found     [:map [:profile [:map [:name :string]]]]
-                  :not-found [:map [:error-message :string]]}}
+         :output [:per-transition
+                  {:found     [:map [:profile [:map [:name :string]]]]
+                   :not-found [:map [:error-message :string]]}]}
 ```
 
 The schema chain validator tracks keys per path independently.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ Cells with multiple outgoing edges can declare different output schemas for each
                     (assoc data :profile profile)
                     (assoc data :error-message "Not found")))
    :schema      {:input  [:map [:user-id :string]]
-                 :output {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
-                          :not-found [:map [:error-message :string]]}}
+                 :output [:per-transition
+                          {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
+                           :not-found [:map [:error-message :string]]}]}
    :requires    [:db]})
 ```
 
@@ -192,12 +193,21 @@ In the workflow, per-transition schemas are validated based on which dispatch ma
 ;; Single schema (all transitions must satisfy it)
 :output [:map [:profile map?]]
 
-;; Per-transition schemas (each transition has its own contract)
-:output {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
-         :not-found [:map [:error-message :string]]}
+;; Per-transition schemas (each transition has its own contract).
+;; The [:per-transition ...] wrapper is required — a bare map is always lite-map syntax.
+:output [:per-transition
+         {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
+          :not-found [:map [:error-message :string]]}]
 ```
 
 The schema chain validator tracks which keys are available on each path independently, so a downstream cell on the `:found` path can require `:profile` without the `:not-found` path needing to produce it.
+
+Input keys marked `{:optional true}` are excluded from the schema chain's required-keys check — an optional key may or may not be produced upstream, and the validator won't fail compilation if it isn't:
+
+```clojure
+;; :b is optional — this cell can sit anywhere downstream, even if no upstream cell produces :b
+:input [:map [:a :int] [:b {:optional true} [:maybe :string]]]
+```
 
 ### Resources
 
@@ -211,8 +221,9 @@ External dependencies are injected, never acquired by cells:
                     (assoc data :profile profile)
                     (assoc data :error-message "Not found")))
    :schema      {:input  [:map [:user-id :string]]
-                 :output {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
-                          :not-found [:map [:error-message :string]]}}
+                 :output [:per-transition
+                          {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
+                           :not-found [:map [:error-message :string]]}]}
    :requires    [:db]})
 
 ;; Resources are passed at run time
@@ -731,8 +742,8 @@ Child workflows produce `:success` or `:failure` based on whether `:mycelium/err
 ```clojure
 ;; The child workflow's last cell declares [:map [:credit-score :int] [:risk-level :keyword]]
 ;; workflow->cell infers this and produces a per-transition output schema:
-;;   {:success [:map [:credit-score :int] [:risk-level :keyword]]
-;;    :failure [:map [:mycelium/error :any]]}
+;;   [:per-transition {:success [:map [:credit-score :int] [:risk-level :keyword]]
+;;                     :failure [:map [:mycelium/error :any]]}]
 ```
 
 If you pass a concrete `[:map ...]` vector as `:output` in the schema argument, it takes precedence over inference.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -44,12 +44,13 @@ Problem-oriented patterns for common workflow tasks. Each recipe shows the probl
 
 The cell handler sets a key (`:fraud-status`). Dispatch predicates examine that key and pick the edge. Handlers compute data; dispatches decide the route.
 
-For per-transition output schemas, use a map instead of a single schema:
+For per-transition output schemas, wrap the schema map in `[:per-transition ...]`:
 
 ```clojure
 :schema {:input  [:map [:total :double]]
-         :output {:clean      [:map [:fraud-status [:= :ok]]]
-                  :suspicious [:map [:fraud-status [:= :flagged]]]}}
+         :output [:per-transition
+                  {:clean      [:map [:fraud-status [:= :ok]]]
+                   :suspicious [:map [:fraud-status [:= :flagged]]]}]}
 ```
 
 ---

--- a/docs/creating-cells.md
+++ b/docs/creating-cells.md
@@ -20,9 +20,10 @@ Register cells via `defmethod` on the `cell/cell-spec` multimethod:
                    (assoc data :error-type :missing-token
                                :error-message "No auth token provided"))))
    :schema   {:input  [:map [:http-request [:map [:body map?]]]]
-              :output {:success [:map [:auth-token :string]]
-                       :failure [:map [:error-type :keyword]
-                                      [:error-message :string]]}}
+              :output [:per-transition
+                       {:success [:map [:auth-token :string]]
+                        :failure [:map [:error-type :keyword]
+                                       [:error-message :string]]}]}
    :requires []})
 ```
 
@@ -33,7 +34,7 @@ Register cells via `defmethod` on the `cell/cell-spec` multimethod:
 | `:id` | yes | Keyword identifier, conventionally `namespace/name` (e.g. `:auth/parse-request`) |
 | `:doc` | yes | Non-empty string describing the cell's purpose and semantics — helps LLMs understand how the cell should be used |
 | `:handler` | yes | `(fn [resources data] -> data)` for sync, or `(fn [resources data callback error-callback])` for async |
-| `:schema` | yes | Map with `:input` (Malli schema) and `:output` (single schema or per-transition map) |
+| `:schema` | yes | Map with `:input` (Malli schema) and `:output` (single schema or `[:per-transition {...}]` map) |
 | `:requires` | no | Vector of resource keys the handler needs (e.g. `[:db]`) |
 | `:async?` | no | Set to `true` for async handlers |
 
@@ -61,13 +62,14 @@ Register cells via `defmethod` on the `cell/cell-spec` multimethod:
 :output [:map [:result :int]]
 ```
 
-**Per-transition schemas** — each dispatch transition has its own contract:
+**Per-transition schemas** — each dispatch transition has its own contract. Wrap the map in `[:per-transition ...]`:
 ```clojure
-:output {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
-         :not-found [:map [:error-type :keyword] [:error-message :string]]}
+:output [:per-transition
+         {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
+          :not-found [:map [:error-type :keyword] [:error-message :string]]}]
 ```
 
-The transition keys in the output map must match the dispatch labels defined in the workflow's `:dispatches` for this cell.
+The transition keys must match the dispatch labels defined in the workflow's `:dispatches` for this cell. A bare map (without the `[:per-transition ...]` wrapper) is always interpreted as lite-map syntax, never per-transition.
 
 ## Rules
 
@@ -111,8 +113,9 @@ The transition keys in the output map must match the dispatch labels defined in 
                  (assoc data :error-type :not-found
                              :error-message "User not found")))
    :schema   {:input  [:map [:user-id :string]]
-              :output {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
-                       :not-found [:map [:error-type :keyword] [:error-message :string]]}}
+              :output [:per-transition
+                       {:found     [:map [:profile [:map [:name :string] [:email :string]]]]
+                        :not-found [:map [:error-type :keyword] [:error-message :string]]}]}
    :requires [:db]})
 ```
 

--- a/docs/developing-workflows.md
+++ b/docs/developing-workflows.md
@@ -134,17 +134,24 @@ With key propagation (on by default), cells only need to return new keys — inp
 
 ```clojure
 ;; Good: the schema documents the domain
-:output {:approve [:map [:decision [:= :approve]]]
-         :reject  [:map [:decision [:= :reject]]]
-         :review  [:map [:decision [:= :review]]]}
+:output [:per-transition
+         {:approve [:map [:decision [:= :approve]]]
+          :reject  [:map [:decision [:= :reject]]]
+          :review  [:map [:decision [:= :review]]]}]
 
 ;; Weak: tells you nothing about valid values
 :output [:map [:decision :keyword]]
 ```
 
-**Use per-transition output schemas** when a cell branches. This lets the schema chain validator verify that each downstream path receives the right shape.
+**Use per-transition output schemas** when a cell branches. Wrap the per-transition map in `[:per-transition ...]` — a bare map is always interpreted as lite-map syntax. This lets the schema chain validator verify that each downstream path receives the right shape.
 
 **Use open schemas (`:map`) for cells that receive external input** (e.g., after halt/resume), since the schema chain can't track keys injected from outside.
+
+**Mark optional inputs with `{:optional true}`** when a cell can run without a key. The schema chain validator skips optional keys when computing required inputs, so the cell can sit downstream of paths that don't produce that key:
+
+```clojure
+:input [:map [:user-id :string] [:trace-id {:optional true} :string]]
+```
 
 ---
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -421,10 +421,11 @@ Use per-transition output schemas to validate both success and failure paths:
 
 ```clojure
 :schema {:input  [:map [:card :string] [:total :double]]
-         :output {:approved [:map [:payment-status [:= :approved]]
-                              [:transaction-id :string]]
-                  :declined [:map [:payment-status [:= :declined]]
-                              [:decline-reason :string]]}}
+         :output [:per-transition
+                  {:approved [:map [:payment-status [:= :approved]]
+                                   [:transaction-id :string]]
+                   :declined [:map [:payment-status [:= :declined]]
+                                   [:decline-reason :string]]}]}
 ```
 
 Each branch gets its own schema validation — a declined payment must include `:decline-reason`.

--- a/docs/llm-guide.md
+++ b/docs/llm-guide.md
@@ -132,8 +132,9 @@ When a cell branches, declare output per edge:
 ```clojure
 (cell/defcell :app/check
   {:input  [:map [:value :int]]
-   :output {:pass [:map [:status [:= :ok]]]
-            :fail [:map [:status [:= :error]] [:reason :string]]}}
+   :output [:per-transition
+            {:pass [:map [:status [:= :ok]]]
+             :fail [:map [:status [:= :error]] [:reason :string]]}]}
   (fn [_ data]
     (if (pos? (:value data))
       {:status :ok}

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -234,9 +234,10 @@ The `:prompt` string contains everything an LLM needs to implement the cell: sch
  {:fetch-profile-by-id
   {:id       :user/fetch-profile-by-id
    :schema   {:input  [:map [:http-request [:map [:path-params [:map [:id :string]]]]]]
-              :output {:found     [:map [:profile map?]]
-                       :not-found [:map [:error-type :keyword]
-                                        [:error-message :string]]}}
+              :output [:per-transition
+                       {:found     [:map [:profile map?]]
+                        :not-found [:map [:error-type :keyword]
+                                         [:error-message :string]]}]}
    :on-error :render-error
    :requires [:db]}
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -574,7 +574,7 @@ Stateful policies (circuit breaker, rate limiter) require `pre-compile` + `run-c
 {:id       :namespace/name    ;; cell registry ID
  :doc      "..."              ;; required — describes purpose and semantics for LLMs
  :schema   {:input  [...]     ;; Malli schema
-            :output [...]}    ;; single or per-transition
+            :output [...]}    ;; single schema, or [:per-transition {:label1 schema, :label2 schema}]
  :requires [:db]              ;; optional resource dependencies
  :on-error :cell-name}        ;; or nil — required in strict mode (default)
 ```
@@ -667,9 +667,10 @@ Use full Malli syntax when you need: enums (`[:enum :a :b]`), unions (`[:or :str
 ;; Single (all transitions)
 :output [:map [:result :int]]
 
-;; Per-transition
-:output {:success [:map [:data :string]]
-         :failure [:map [:error :string]]}
+;; Per-transition (wrapper is required — a bare map is always lite-map syntax)
+:output [:per-transition
+         {:success [:map [:data :string]]
+          :failure [:map [:error :string]]}]
 ```
 
 Per-transition schemas are validated based on which dispatch matched. The schema chain validator tracks available keys independently per path.

--- a/docs/workflow-fragments.md
+++ b/docs/workflow-fragments.md
@@ -22,28 +22,31 @@ A fragment is an EDN file declaring its own cells, edges, dispatches, entry poin
  {:extract-session
   {:id       :auth/extract-cookie-session
    :schema   {:input  [:map [:http-request [:map]]]
-              :output {:success [:map [:auth-token :string]]
-                       :failure [:map [:error-type :keyword]
-                                      [:error-message :string]]}}
+              :output [:per-transition
+                       {:success [:map [:auth-token :string]]
+                        :failure [:map [:error-type :keyword]
+                                       [:error-message :string]]}]}
    :on-error :_exit/failure     ;; resolves to host's :failure exit target
    :requires []}
 
   :validate-session
   {:id       :auth/validate-session
    :schema   {:input  [:map [:auth-token :string]]
-              :output {:authorized   [:map [:session-valid :boolean] [:user-id :string]]
-                       :unauthorized [:map [:session-valid :boolean]
-                                           [:error-type :keyword]
-                                           [:error-message :string]]}}
+              :output [:per-transition
+                       {:authorized   [:map [:session-valid :boolean] [:user-id :string]]
+                        :unauthorized [:map [:session-valid :boolean]
+                                            [:error-type :keyword]
+                                            [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires [:db]}
 
   :fetch-profile
   {:id       :user/fetch-profile
    :schema   {:input  [:map [:user-id :string] [:session-valid :boolean]]
-              :output {:found     [:map [:profile map?]]
-                       :not-found [:map [:error-type :keyword]
-                                        [:error-message :string]]}}
+              :output [:per-transition
+                       {:found     [:map [:profile map?]]
+                        :not-found [:map [:error-type :keyword]
+                                         [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires [:db]}}
 

--- a/examples/expense_approval/src/expense/cells.clj
+++ b/examples/expense_approval/src/expense/cells.clj
@@ -23,9 +23,9 @@
                   :else
                   (assoc data :validation-status :valid))))
    :schema {:input  [:map [:amount [:maybe number?]] [:description :string]]
-            :output {:valid   [:map [:validation-status [:= :valid]]]
+            :output [:per-transition {:valid   [:map [:validation-status [:= :valid]]]
                      :invalid [:map [:validation-status [:= :invalid]]
-                                    [:validation-error :string]]}}})
+                                    [:validation-error :string]]}]}})
 
 ;; --- Categorize by amount ---
 

--- a/examples/loan_processing/src/loan/cells.clj
+++ b/examples/loan_processing/src/loan/cells.clj
@@ -30,10 +30,10 @@
                        [:applicant-name {:optional true} [:maybe :string]]
                        [:income {:optional true} [:maybe number?]]
                        [:loan-amount {:optional true} [:maybe number?]]]
-             :output {:valid   [:map [:validation-status [:= :valid]]]
+             :output [:per-transition {:valid   [:map [:validation-status [:= :valid]]]
                       :invalid [:map
                                 [:validation-status [:= :invalid]]
-                                [:validation-errors [:vector :string]]]}}})
+                                [:validation-errors [:vector :string]]]}]}})
 
 ;; ===== Credit Assessment (subworkflow cells) =====
 
@@ -114,9 +114,9 @@
                   :else
                   (assoc data :decision :review))))
    :schema  {:input  [:map [:risk-level [:enum :low :medium :high]] [:loan-amount number?]]
-             :output {:approve [:map [:decision [:= :approve]]]
+             :output [:per-transition {:approve [:map [:decision [:= :approve]]]
                       :reject  [:map [:decision [:= :reject]]]
-                      :review  [:map [:decision [:= :review]]]}}})
+                      :review  [:map [:decision [:= :review]]]}]}})
 
 ;; ===== Decision Outcomes =====
 
@@ -222,10 +222,10 @@
                   (assoc data :fetch-status :not-found
                               :error-message (str "No application found for " name)))))
    :schema  {:input  [:map [:applicant-name :string]]
-             :output {:found     [:map [:fetch-status [:= :found]]]
+             :output [:per-transition {:found     [:map [:fetch-status [:= :found]]]
                       :not-found [:map
                                   [:fetch-status [:= :not-found]]
-                                  [:error-message :string]]}}
+                                  [:error-message :string]]}]}
    :requires [:app-store]})
 
 (defmethod cell/cell-spec :loan/format-status [_]

--- a/examples/user_onboarding/resources/fragments/cookie-auth.edn
+++ b/examples/user_onboarding/resources/fragments/cookie-auth.edn
@@ -10,11 +10,11 @@
    :doc      "Extract auth token from session-token cookie or query parameters"
    :schema   {:input  [:map
                         [:http-request [:map]]]
-              :output {:success [:map
+              :output [:per-transition {:success [:map
                                   [:auth-token :string]]
                        :failure [:map
                                   [:error-type :keyword]
-                                  [:error-message :string]]}}
+                                  [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires []}
 
@@ -23,13 +23,13 @@
    :doc      "Check credentials against the session store"
    :schema   {:input  [:map
                         [:auth-token :string]]
-              :output {:authorized   [:map
+              :output [:per-transition {:authorized   [:map
                                        [:session-valid :boolean]
                                        [:user-id :string]]
                        :unauthorized [:map
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
-                                       [:error-message :string]]}}
+                                       [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires [:db]}
 
@@ -39,11 +39,11 @@
    :schema   {:input  [:map
                         [:user-id :string]
                         [:session-valid :boolean]]
-              :output {:found     [:map
+              :output [:per-transition {:found     [:map
                                     [:profile map?]]
                        :not-found [:map
                                     [:error-type :keyword]
-                                    [:error-message :string]]}}
+                                    [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires [:db]}}
 

--- a/examples/user_onboarding/resources/fragments/parse-auth.edn
+++ b/examples/user_onboarding/resources/fragments/parse-auth.edn
@@ -12,12 +12,12 @@
                         [:http-request [:map
                           [:headers map?]
                           [:body map?]]]]
-              :output {:success [:map
+              :output [:per-transition {:success [:map
                                   [:user-id :string]
                                   [:auth-token :string]]
                        :failure [:map
                                   [:error-type :keyword]
-                                  [:error-message :string]]}}
+                                  [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires []}
 
@@ -27,13 +27,13 @@
    :schema   {:input  [:map
                         [:user-id :string]
                         [:auth-token :string]]
-              :output {:authorized   [:map
+              :output [:per-transition {:authorized   [:map
                                        [:session-valid :boolean]
                                        [:user-id :string]]
                        :unauthorized [:map
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
-                                       [:error-message :string]]}}
+                                       [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires [:db]}
 
@@ -43,11 +43,11 @@
    :schema   {:input  [:map
                         [:user-id :string]
                         [:session-valid :boolean]]
-              :output {:found     [:map
+              :output [:per-transition {:found     [:map
                                     [:profile map?]]
                        :not-found [:map
                                     [:error-type :keyword]
-                                    [:error-message :string]]}}
+                                    [:error-message :string]]}]}
    :on-error :_exit/failure
    :requires [:db]}}
 

--- a/examples/user_onboarding/resources/workflows/order-summary.edn
+++ b/examples/user_onboarding/resources/workflows/order-summary.edn
@@ -14,11 +14,11 @@
    :doc      "Extract auth token from cookie or query parameters"
    :schema   {:input  [:map
                          [:http-request [:map]]]
-              :output {:success [:map
+              :output [:per-transition {:success [:map
                                   [:auth-token :string]]
                        :failure [:map
                                   [:error-type :keyword]
-                                  [:error-message :string]]}}
+                                  [:error-message :string]]}]}
    :on-error :render-error
    :requires []}
 
@@ -27,13 +27,13 @@
    :doc      "Check credentials against the session store"
    :schema   {:input  [:map
                          [:auth-token :string]]
-              :output {:authorized   [:map
+              :output [:per-transition {:authorized   [:map
                                        [:session-valid :boolean]
                                        [:user-id :string]]
                        :unauthorized [:map
                                        [:session-valid :boolean]
                                        [:error-type :keyword]
-                                       [:error-message :string]]}}
+                                       [:error-message :string]]}]}
    :on-error :render-error
    :requires [:db]}
 
@@ -43,13 +43,13 @@
    :schema   {:input  [:map
                          [:user-id :string]
                          [:session-valid :boolean]]
-              :output {:found     [:map
+              :output [:per-transition {:found     [:map
                                     [:profile [:map
                                       [:name :string]
                                       [:email :string]]]]
                        :not-found [:map
                                     [:error-type :keyword]
-                                    [:error-message :string]]}}
+                                    [:error-message :string]]}]}
    :on-error :render-error
    :requires [:db]}
 

--- a/examples/user_onboarding/resources/workflows/user-profile.edn
+++ b/examples/user_onboarding/resources/workflows/user-profile.edn
@@ -17,11 +17,11 @@
                         [:http-request [:map
                           [:path-params [:map
                             [:id :string]]]]]]
-              :output {:found     [:map
+              :output [:per-transition {:found     [:map
                                     [:profile map?]]
                        :not-found [:map
                                     [:error-type :keyword]
-                                    [:error-message :string]]}}
+                                    [:error-message :string]]}]}
    :on-error :render-error
    :requires [:db]}
 

--- a/implementation.md
+++ b/implementation.md
@@ -375,9 +375,11 @@ At compile time, validate:
 
 This is a critical safety mechanism. When cell A connects to cell B via an edge, the compiler verifies that A's output provides what B's input requires. Since the data map uses passthrough semantics (keys not in a cell's schema flow through untouched), the check is:
 
-> For every key in cell B's `:input` schema, that key must appear in either:
+> For every **required** key in cell B's `:input` schema, that key must appear in either:
 > (a) cell A's `:output` schema, or
 > (b) the accumulated outputs of all cells that can reach B through any path from `:start`
+
+Input keys marked `{:optional true}` are excluded from the required set — the chain validator will not fail a compile if an optional key is never produced upstream.
 
 This is a static reachability analysis over the graph. The compiler walks every path from `:start` to each cell, accumulates the output keys along the way, and checks that the cell's input requirements are satisfied.
 

--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -37,14 +37,13 @@
                       {:id id}))))
 
 (defn- output-dispatched?
-  "Heuristic for defcell/set-cell-schema! (no edge context available):
-   a map output schema is per-transition if all values are vectors (Malli schema
-   forms like [:map ...], [:or ...], etc.). If any value is a keyword or map,
-   it's treated as lite syntax. For manifests, edge context is used instead.
-   Trade-off: per-transition maps with bare keyword schemas (e.g. {:success :any})
-   would be misclassified as lite — use vector form [:any] in that rare case."
+  "True when the output schema is in explicit per-transition form
+  `[:per-transition {tx schema, ...}]`. Pre-1.0 mycelium used a
+  heuristic over plain map outputs which silently misclassified
+  lite maps whose values happened to be vector schemas; the
+  marker is now mandatory and the heuristic is gone."
   [output]
-  (and (map? output) (seq output) (every? vector? (vals output))))
+  (schema/per-transition? output))
 
 (defn set-cell-schema!
   "Sets or overwrites the schema for an already-registered cell.

--- a/src/mycelium/compose.clj
+++ b/src/mycelium/compose.clj
@@ -29,9 +29,10 @@
   (cond
     ;; Unconditional edge to :end
     (= :end edge-def)
-    (cond
-      (vector? output) (get-map-entries output)
-      (map? output)    (mapcat (fn [[_ s]] (or (get-map-entries s) [])) output))
+    (if (schema/per-transition? output)
+      (mapcat (fn [[_ s]] (or (get-map-entries s) []))
+              (schema/transitions-map output))
+      (get-map-entries output))
 
     ;; Map edges — collect entries from transitions routing to :end
     (map? edge-def)
@@ -39,11 +40,12 @@
                                   (when (= :end target) transition))
                                 edge-def)]
       (when (seq end-transitions)
-        (cond
-          (vector? output) (get-map-entries output)
-          (map? output)    (mapcat (fn [t]
-                                     (or (some-> (get output t) get-map-entries) []))
-                                   end-transitions))))))
+        (if (schema/per-transition? output)
+          (let [transitions (schema/transitions-map output)]
+            (mapcat (fn [t]
+                      (or (some-> (get transitions t) get-map-entries) []))
+                    end-transitions))
+          (get-map-entries output))))))
 
 (defn- collect-end-reaching-output-entries
   "Walks workflow edges to find cells routing to :end and collects their output entries.
@@ -58,22 +60,33 @@
        vec))
 
 (defn- infer-workflow-output-schema
-  "Infers a per-transition output schema for a composed cell.
+  "Infers a per-transition output schema for a composed cell, wrapped
+   in the explicit `[:per-transition {...}]` form.
+
    :success path gets the union of output keys from cells routing to :end.
    :failure path gets [:map [:mycelium/error :any]].
-   Only infers when the caller's :output schema is bare :map keyword.
-   If the caller provides a proper [:map ...] vector, uses that directly."
+
+   When the caller passes a proper [:map ...] vector, that becomes the
+   :success schema. When the caller's schema is the bare :map keyword,
+   we infer :success from the child workflow's end-reaching cells, and
+   fall back to bare :map when there's nothing to infer."
   [workflow schema]
   (let [output (:output schema)]
-    (if (and (not (keyword? output)) (vector? output))
+    (cond
+      ;; Caller already passed an explicit per-transition wrapper — use it as-is.
+      (schema/per-transition? output)
+      output
+
       ;; Caller provided a real schema — use it as :success, add :failure
-      {:success output
-       :failure [:map [:mycelium/error :any]]}
-      ;; Infer from child workflow
+      (and (not (keyword? output)) (vector? output))
+      [:per-transition {:success output
+                        :failure [:map [:mycelium/error :any]]}]
+
+      :else
       (let [entries (collect-end-reaching-output-entries (:edges workflow) (:cells workflow))]
         (if (seq entries)
-          {:success (into [:map] entries)
-           :failure [:map [:mycelium/error :any]]}
+          [:per-transition {:success (into [:map] entries)
+                            :failure [:map [:mycelium/error :any]]}]
           ;; Fall back to bare :map
           :map)))))
 

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -303,10 +303,14 @@
   (let [cell   (cell/get-cell cell-id)
         output (when cell (get-in cell [:schema :output]))]
     (cond
-      (nil? output)    #{}
-      (vector? output) (get-map-keys output)
-      (map? output)    (reduce (fn [acc [_ s]] (set/union acc (get-map-keys s))) #{} output)
-      :else            #{})))
+      (nil? output) #{}
+
+      (schema/per-transition? output)
+      (reduce (fn [acc [_ s]] (set/union acc (get-map-keys s)))
+              #{}
+              (schema/transitions-map output))
+
+      :else (or (get-map-keys output) #{}))))
 
 (defn- cell-input-keys
   "Returns the set of input keys for a cell."

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -152,12 +152,8 @@
                                  (if (or (= :inherit (:schema cell-def))
                                          (nil? (:schema cell-def)))
                                    [cell-name cell-def]
-                                   (let [edge-def    (get edges cell-name)
-                                         output      (get-in cell-def [:schema :output])
-                                         dispatched? (or (map? edge-def)
-                                                         (and (map? output)
-                                                              (seq output)
-                                                              (every? vector? (vals output))))
+                                   (let [output      (get-in cell-def [:schema :output])
+                                         dispatched? (schema/per-transition? output)
                                          normalized  (schema/normalize-cell-schema
                                                        (:schema cell-def) dispatched?)]
                                      [cell-name (assoc cell-def :schema normalized)]))))
@@ -243,23 +239,23 @@
 
 (defn- format-output-schema-section
   "Formats output schema section for the cell-brief prompt.
-   Handles both single-schema (vector) and per-edge (map) formats."
+   Handles both single-schema and explicit per-transition formats."
   [output-schema edge-labels]
-  (if (map? output-schema)
+  (if-let [transitions (schema/transitions-map output-schema)]
     (str "Output schemas (per edge):\n"
          (str/join "\n"
                    (map (fn [label]
-                          (str "  " (pr-str label) ": " (pr-str (get output-schema label))))
+                          (str "  " (pr-str label) ": " (pr-str (get transitions label))))
                         (sort edge-labels))))
     (str "Output schema:\n  " (pr-str output-schema))))
 
 (defn- generate-output-examples
-  "Generates output examples. For per-edge schema maps, generates one per edge."
+  "Generates output examples. For per-transition schemas, generates one per edge."
   [output-schema edge-labels]
-  (if (map? output-schema)
+  (if-let [transitions (schema/transitions-map output-schema)]
     (into {}
           (map (fn [label]
-                 [label (generate-example (get output-schema label))]))
+                 [label (generate-example (get transitions label))]))
           (sort edge-labels))
     (generate-example output-schema)))
 
@@ -278,7 +274,7 @@
         input-ex    (generate-example (:input schema))
         output-ex   (generate-output-examples (:output schema) edge-labels)
         output-section (format-output-schema-section (:output schema) edge-labels)
-        example-section (if (map? (:output schema))
+        example-section (if (schema/per-transition? (:output schema))
                           (str/join "\n\n"
                                     (map (fn [[label ex]]
                                            (str "Example output (" (pr-str label) "):\n  " (pr-str ex)))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -9,6 +9,54 @@
             [malli.transform :as mt]
             [maestro.core :as fsm]))
 
+;; ===== Per-transition output schema =====
+;;
+;; Cells whose downstream edge selection depends on the cell's
+;; OUTPUT (per-transition cells) can declare a different schema
+;; for each transition. The explicit form is:
+;;
+;;     :output [:per-transition {:ok     [:map [:result :string]]
+;;                               :failed [:map [:error  :string]]}]
+;;
+;; The marker is mandatory: a bare map output is ALWAYS lite-map
+;; syntax, never per-transition. Pre-1.0 mycelium inferred
+;; per-transition from "all values are vectors", which silently
+;; misclassified lite maps whose values happened to be vector
+;; schemas (e.g. `{:user/name [:maybe :string]}`). The explicit
+;; marker removes that ambiguity.
+
+(defn per-transition?
+  "True if `output` is an explicit per-transition output schema —
+  the vector form `[:per-transition {:transition-1 schema, ...}]`."
+  [output]
+  (and (vector? output)
+       (= 2 (count output))
+       (= :per-transition (first output))
+       (map? (second output))))
+
+(defn transitions-map
+  "Extracts the {:transition-1 schema, ...} map from an explicit
+  per-transition output schema. Returns nil when `output` isn't
+  in per-transition form."
+  [output]
+  (when (per-transition? output)
+    (second output)))
+
+(defn- looks-like-implicit-per-transition?
+  "Detects the OLD implicit per-transition form: a plain map whose
+  values are all vector schemas. Used only to produce a clear
+  migration error — the implicit form is no longer accepted."
+  [output]
+  (and (map? output)
+       (seq output)
+       (every? vector? (vals output))
+       ;; Sanity: per-transition keys are simple keywords (edge
+       ;; labels like :ok / :failed / :high / :low). If any key has
+       ;; a namespace, it's almost certainly a lite map of
+       ;; namespaced data keys whose values happen to be vectors
+       ;; like [:maybe :string].
+       (not-any? namespace (keys output))))
+
 ;; ===== Lite schema normalization =====
 
 (defn normalize-schema
@@ -42,17 +90,43 @@
     :else schema))
 
 (defn normalize-output-schema
-  "Normalizes an output schema, accounting for per-transition maps.
-   When `dispatched?` is true and the schema is a map, each value is normalized
-   individually (per-transition output). Otherwise the map is treated as lite syntax."
-  [schema dispatched?]
-  (cond
-    (nil? schema)    nil
-    (vector? schema) schema
-    (map? schema)    (if dispatched?
-                       (into {} (map (fn [[k v]] [k (normalize-schema v)])) schema)
-                       (normalize-schema schema))
-    :else            schema))
+  "Normalizes an output schema:
+    * `[:per-transition {tx schema, ...}]` — each transition's
+      schema is normalized in place; the wrapper is preserved.
+    * `[:map ...]` and other Malli vector schemas — pass through.
+    * `{:k schema, :k2 schema, ...}` — lite map syntax, normalized
+      to `[:map [:k schema] [:k2 schema] ...]`.
+
+  Rejects the pre-1.0 implicit per-transition shape (a plain map
+  whose values are all vectors and whose keys are unnamespaced)
+  with a migration error.
+
+  The `dispatched?` parameter is accepted for backwards
+  compatibility but is no longer consulted — per-transition is
+  determined entirely by the explicit `[:per-transition ...]`
+  wrapper."
+  ([schema] (normalize-output-schema schema false))
+  ([schema _dispatched?]
+   (cond
+     (nil? schema) nil
+
+     (per-transition? schema)
+     [:per-transition (into {} (map (fn [[k v]] [k (normalize-schema v)]))
+                            (transitions-map schema))]
+
+     (vector? schema) schema
+
+     (looks-like-implicit-per-transition? schema)
+     (throw (ex-info
+              (str "Implicit per-transition output schema is no longer "
+                   "supported. Wrap the transition map in [:per-transition ...]:\n"
+                   "  Old: :output " (pr-str schema) "\n"
+                   "  New: :output " (pr-str [:per-transition schema]))
+              {:schema schema}))
+
+     (map? schema) (normalize-schema schema)
+
+     :else schema)))
 
 (defn normalize-cell-schema
   "Normalizes a cell's :schema map, converting lite syntax to Malli.
@@ -167,15 +241,15 @@
 
 (defn output-schema-for-transition
   "Returns the output schema for a specific transition of a cell.
-   If output is nil → nil. If vector → same schema for all transitions.
-   If map → schema for that transition key (or nil if not found)."
+   nil output → nil. Explicit per-transition wrapper → the schema
+   for that transition (or nil if not found). Any other vector or
+   map → same schema for all transitions."
   [cell transition]
   (let [output (get-in cell [:schema :output])]
     (cond
-      (nil? output)    nil
-      (vector? output) output
-      (map? output)    (get output transition)
-      :else            output)))
+      (nil? output)            nil
+      (per-transition? output) (get (transitions-map output) transition)
+      :else                    output)))
 
 (defn validate-output
   "Validates data against the cell's output schema.
@@ -192,18 +266,18 @@
        ;; No output schema — always passes
        (nil? output) nil
 
-       ;; Per-transition output schema (map)
-       (map? output)
-       (if transition
-         ;; Validate against the specific transition's schema
-         (when-let [schema (get output transition)]
-           (when-let [explanation (m/explain schema data)]
-             (build-error-map (:id cell) :output explanation data)))
-         ;; No transition known — validate against all schemas, pass if any matches
-         (let [schemas (vals output)]
+       ;; Explicit per-transition output schema
+       (per-transition? output)
+       (let [transitions (transitions-map output)]
+         (if transition
+           ;; Validate against the specific transition's schema
+           (when-let [schema (get transitions transition)]
+             (when-let [explanation (m/explain schema data)]
+               (build-error-map (:id cell) :output explanation data)))
+           ;; No transition known — validate against all schemas, pass if any matches
            (when (every? (fn [schema]
                            (some? (m/explain schema data)))
-                         schemas)
+                         (vals transitions))
              (let [msg (str "Data does not match any output schema for " (:id cell))]
                {:cell-id (:id cell)
                 :phase   :output
@@ -250,27 +324,28 @@
        (nil? output)
        {:data data}
 
-       (map? output)
-       (if transition
-         (if-let [schema (get output transition)]
-           (let [coerced (m/decode schema data number-coercion-transformer)]
-             (if-let [explanation (m/explain schema coerced)]
-               {:error (build-error-map (:id cell) :output explanation data)}
-               {:data coerced}))
-           {:data data})
-         ;; No transition — try each schema, use first that matches after coercion
-         (let [results (for [[_label schema] output]
-                         (let [coerced (m/decode schema data number-coercion-transformer)]
-                           (when-not (m/explain schema coerced)
-                             coerced)))]
-           (if-let [coerced (first (filter some? results))]
-             {:data coerced}
-             (let [msg (str "Data does not match any output schema for " (:id cell))]
-               {:error {:cell-id (:id cell)
-                        :phase   :output
-                        :message msg
-                        :errors  msg
-                        :data    (strip-mycelium-keys data)}}))))
+       (per-transition? output)
+       (let [transitions (transitions-map output)]
+         (if transition
+           (if-let [schema (get transitions transition)]
+             (let [coerced (m/decode schema data number-coercion-transformer)]
+               (if-let [explanation (m/explain schema coerced)]
+                 {:error (build-error-map (:id cell) :output explanation data)}
+                 {:data coerced}))
+             {:data data})
+           ;; No transition — try each schema, use first that matches after coercion
+           (let [results (for [[_label schema] transitions]
+                           (let [coerced (m/decode schema data number-coercion-transformer)]
+                             (when-not (m/explain schema coerced)
+                               coerced)))]
+             (if-let [coerced (first (filter some? results))]
+               {:data coerced}
+               (let [msg (str "Data does not match any output schema for " (:id cell))]
+                 {:error {:cell-id (:id cell)
+                          :phase   :output
+                          :message msg
+                          :errors  msg
+                          :data    (strip-mycelium-keys data)}})))))
 
        :else
        (let [coerced (m/decode output data number-coercion-transformer)]
@@ -299,11 +374,13 @@
                      output (get-in cell [:schema :output])
                      compiled-input  (compile-schema-value input)
                      compiled-output (cond
-                                      (nil? output)    nil
-                                      (map? output)    (into {} (map (fn [[k v]]
-                                                                       [k (compile-schema-value v)])
-                                                                     output))
-                                      :else            (compile-schema-value output))
+                                      (nil? output)            nil
+                                      (per-transition? output) [:per-transition
+                                                                (into {}
+                                                                      (map (fn [[k v]]
+                                                                             [k (compile-schema-value v)]))
+                                                                      (transitions-map output))]
+                                      :else                    (compile-schema-value output))
                      updated-cell (cond-> cell
                                     compiled-input  (assoc-in [:schema :input] compiled-input)
                                     (some? compiled-output) (assoc-in [:schema :output] compiled-output))]

--- a/src/mycelium/validation.clj
+++ b/src/mycelium/validation.clj
@@ -20,17 +20,28 @@
                       {:label label :schema schema}
                       e)))))
 
+(defn- per-transition-output?
+  "True when `output-schema` is in explicit per-transition form.
+   Duplicated from mycelium.schema/per-transition? to avoid a
+   cyclic dependency (schema → validation → schema)."
+  [output-schema]
+  (and (vector? output-schema)
+       (= 2 (count output-schema))
+       (= :per-transition (first output-schema))
+       (map? (second output-schema))))
+
 (defn validate-output-schema!
-  "Validates an output schema which may be a single schema (vector/keyword)
-   or a per-transition map. If a map, validates each value as a Malli schema."
+  "Validates an output schema: either a single Malli schema, or an
+   explicit per-transition wrapper [:per-transition {tx schema, ...}]
+   whose inner values are each Malli schemas."
   [output-schema label]
   (cond
+    (per-transition-output? output-schema)
+    (doseq [[k v] (second output-schema)]
+      (validate-malli-schema! v (str label " transition " k)))
+
     (vector? output-schema)
     (validate-malli-schema! output-schema label)
-
-    (map? output-schema)
-    (doseq [[k v] output-schema]
-      (validate-malli-schema! v (str label " transition " k)))
 
     :else
     (validate-malli-schema! output-schema label)))

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -85,44 +85,73 @@
 ;; ===== Schema key utilities =====
 
 (defn- get-map-keys
-  "Extracts top-level keys from a Malli schema. Returns nil if not a map schema.
-   Handles both normalized [:map [:k v] ...] and lite syntax {:k v}.
-   Skips Malli property maps (e.g. {:closed true} in [:map {:closed true} [:x :int]])."
-  [schema]
-  (cond
-    ;; Standard Malli vector syntax: [:map [:k1 v1] [:k2 v2] ...]
-    (and (vector? schema) (= :map (first schema)))
-    (set (keep (fn [entry]
-                 (when (vector? entry)
-                   (first entry)))
-               (rest schema)))
+  "Extracts top-level keys from a Malli :map schema. Returns nil if
+  not a map schema.
 
-    ;; Lite map syntax: {:k1 v1 :k2 v2}
-    (map? schema)
-    (set (keys schema))))
+  Handles both normalized `[:map [:k v] ...]` and lite syntax `{:k v}`.
+  Skips Malli property maps (e.g. `{:closed true}` in
+  `[:map {:closed true} [:x :int]]`).
+
+  `:include-optional?` (default true) — when false, child entries
+  carrying `{:optional true}` are filtered out. The schema-chain
+  validator uses :include-optional? false when collecting a cell's
+  REQUIRED inputs, so that upstream cells aren't forced to produce
+  keys the downstream cell has declared optional."
+  ([schema] (get-map-keys schema {}))
+  ([schema {:keys [include-optional?] :or {include-optional? true}}]
+   (cond
+     ;; Standard Malli vector syntax: [:map [:k1 v1] [:k1 opts v1] ...]
+     (and (vector? schema) (= :map (first schema)))
+     (set (keep (fn [entry]
+                  (when (vector? entry)
+                    (let [k    (first entry)
+                          opts (when (and (= 3 (count entry))
+                                          (map? (second entry)))
+                                 (second entry))]
+                      (when (or include-optional? (not (:optional opts)))
+                        k))))
+                (rest schema)))
+
+     ;; Lite map syntax: {:k1 v1 :k2 v2}. Lite syntax has no
+     ;; per-key optional modifier — every key is required.
+     (map? schema)
+     (set (keys schema)))))
+
+(defn- get-required-input-keys
+  "Required (non-optional) input keys for a cell."
+  [cell-id]
+  (let [cell   (cell/get-cell! cell-id)
+        schema (get-in cell [:schema :input])]
+    (get-map-keys schema {:include-optional? false})))
+
+(defn- per-transition-output? [output]
+  (schema/per-transition? output))
+
+(defn- transitions [output]
+  (schema/transitions-map output))
 
 (defn- get-output-keys-for-transition
   "Gets output keys for a specific transition of a cell.
-   For vector output schema, returns all keys for any transition.
-   For map output schema, returns keys for that specific transition.
-   When the exact transition key isn't found (e.g., parent uses :approve but composed
-   cell uses :success/:failure), falls back to the union of all transitions' keys."
+   For single-schema outputs, returns its keys (same for any transition).
+   For explicit per-transition outputs, returns keys for that
+   transition (or the union across transitions when the transition
+   isn't present — handles composed cells where the parent workflow's
+   edge labels don't match the composed cell's transitions)."
   [cell-id transition]
   (let [cell   (cell/get-cell! cell-id)
         output (get-in cell [:schema :output])]
     (cond
-      (nil? output)    nil
-      (vector? output) (get-map-keys output)
-      (map? output)    (if-let [schema (get output transition)]
-                         (get-map-keys schema)
-                         ;; Transition not found — fall back to union of all output keys.
-                         ;; This handles composed cells where the parent workflow's edge labels
-                         ;; (:approve, :review) don't match the composed cell's transitions
-                         ;; (:success, :failure) — the dispatch predicates handle the mapping.
-                         (reduce (fn [acc [_ schema]]
-                                   (into acc (get-map-keys schema)))
-                                 #{}
-                                 output)))))
+      (nil? output) nil
+
+      (per-transition-output? output)
+      (if-let [schema (get (transitions output) transition)]
+        (get-map-keys schema)
+        (reduce (fn [acc [_ schema]]
+                  (into acc (get-map-keys schema)))
+                #{}
+                (transitions output)))
+
+      :else (get-map-keys output))))
 
 (defn- get-all-output-keys
   "Gets the union of all output keys across all transitions.
@@ -131,12 +160,15 @@
   (let [cell   (cell/get-cell! cell-id)
         output (get-in cell [:schema :output])]
     (cond
-      (nil? output)    nil
-      (vector? output) (get-map-keys output)
-      (map? output)    (reduce (fn [acc [_ schema]]
-                                 (into acc (get-map-keys schema)))
-                               #{}
-                               output))))
+      (nil? output) nil
+
+      (per-transition-output? output)
+      (reduce (fn [acc [_ schema]]
+                (into acc (get-map-keys schema)))
+              #{}
+              (transitions output))
+
+      :else (get-map-keys output))))
 
 (defn- get-join-member-output-keys
   "Gets the union of all output keys from a single join member cell."
@@ -144,12 +176,15 @@
   (let [cell   (cell/get-cell! cell-id)
         output (get-in cell [:schema :output])]
     (cond
-      (nil? output)    #{}
-      (vector? output) (or (get-map-keys output) #{})
-      (map? output)    (reduce (fn [acc [_ schema]]
-                                 (into acc (or (get-map-keys schema) #{})))
-                               #{}
-                               output))))
+      (nil? output) #{}
+
+      (per-transition-output? output)
+      (reduce (fn [acc [_ schema]]
+                (into acc (or (get-map-keys schema) #{})))
+              #{}
+              (transitions output))
+
+      :else (or (get-map-keys output) #{}))))
 
 ;; ===== Join validation =====
 
@@ -458,10 +493,12 @@
     (get-map-keys schema)))
 
 (defn- get-transform-input-keys
-  "Extracts input keys from a transform spec's :schema :input, if present."
+  "Extracts required input keys from a transform spec's :schema :input,
+   if present. Optional keys are filtered out so the schema-chain
+   validator doesn't demand them from upstream producers."
   [transform-spec]
   (when-let [schema (get-in transform-spec [:schema :input])]
-    (get-map-keys schema)))
+    (get-map-keys schema {:include-optional? false})))
 
 (defn- validate-schema-chain!
   "Walks all paths from :start, accumulating output keys.
@@ -473,10 +510,11 @@
   ([edges-map cells-map joins-map]
    (validate-schema-chain! edges-map cells-map joins-map nil))
   ([edges-map cells-map joins-map transforms]
-   (let [get-input-keys  (fn [cell-id]
-                           (let [cell   (cell/get-cell! cell-id)
-                                 schema (get-in cell [:schema :input])]
-                             (get-map-keys schema)))
+   (let [;; Required (non-optional) input keys only. A downstream
+         ;; cell that declares `[:k {:optional true} ...]` doesn't
+         ;; force upstream cells to produce :k.
+         get-input-keys  (fn [cell-id]
+                           (get-required-input-keys cell-id))
          errors (atom [])
          visit  (fn visit [cell-name available-keys visited]
                   (when-not (or (contains? visited cell-name)

--- a/test/mycelium/cell_test.clj
+++ b/test/mycelium/cell_test.clj
@@ -102,11 +102,11 @@
       {:id          :test/map-out
        :handler     (fn [_ d] d)
        :schema      {:input  [:map [:x :int]]
-                     :output {:found     [:map [:profile :map]]
-                              :not-found [:map [:error-message :string]]}}})
-    (let [spec (cell/get-cell :test/map-out)]
-      (is (map? (get-in spec [:schema :output])))
-      (is (= #{:found :not-found} (set (keys (get-in spec [:schema :output]))))))))
+                     :output [:per-transition {:found     [:map [:profile :map]]
+                              :not-found [:map [:error-message :string]]}]}})
+    (let [output (get-in (cell/get-cell :test/map-out) [:schema :output])]
+      (is (= :per-transition (first output)))
+      (is (= #{:found :not-found} (set (keys (second output))))))))
 
 ;; ===== Per-transition output schema in set-cell-schema! =====
 
@@ -117,10 +117,10 @@
        :handler     (fn [_ d] d)})
     (cell/set-cell-schema! :test/set-map-out
                            {:input  [:map [:x :int]]
-                            :output {:found     [:map [:profile :map]]
-                                     :not-found [:map [:error :string]]}})
-    (let [spec (cell/get-cell :test/set-map-out)]
-      (is (map? (get-in spec [:schema :output]))))))
+                            :output [:per-transition {:found     [:map [:profile :map]]
+                                     :not-found [:map [:error :string]]}]})
+    (let [output (get-in (cell/get-cell :test/set-map-out) [:schema :output])]
+      (is (= :per-transition (first output))))))
 
 (deftest redefine-does-not-clear-overrides-test
   (testing "Re-defining via defmethod does NOT clear overrides (they persist until clear-registry!)"

--- a/test/mycelium/coercion_test.clj
+++ b/test/mycelium/coercion_test.clj
@@ -100,8 +100,8 @@
       {:id      :test/pt-coerce
        :handler (fn [_ data] data)
        :schema  {:input  [:map [:x :int]]
-                 :output {:success [:map [:y :int]]
-                          :failure [:map [:error-message :string]]}}})
+                 :output [:per-transition {:success [:map [:y :int]]
+                          :failure [:map [:error-message :string]]}]}})
     (let [cell   (cell/get-cell! :test/pt-coerce)
           result (schema/coerce-output cell {:y 42.0} :success)]
       (is (nil? (:error result)))
@@ -114,8 +114,8 @@
       {:id      :test/pt-coerce
        :handler (fn [_ data] data)
        :schema  {:input  [:map [:x :int]]
-                 :output {:success [:map [:y :int]]
-                          :failure [:map [:error-message :string]]}}})
+                 :output [:per-transition {:success [:map [:y :int]]
+                          :failure [:map [:error-message :string]]}]}})
     (let [cell   (cell/get-cell! :test/pt-coerce)
           result (schema/coerce-output cell {:y 42.0})]
       (is (nil? (:error result)))

--- a/test/mycelium/compose_test.clj
+++ b/test/mycelium/compose_test.clj
@@ -310,17 +310,19 @@
           spec (compose/workflow->cell :comp/inferred child-wf
                                        {:input [:map [:a :int]]
                                         :output :map})]
-      ;; Output should be a per-transition map, not bare :map
-      (is (map? (get-in spec [:schema :output])))
-      ;; :success should contain the inferred keys
-      (let [success-schema (get-in spec [:schema :output :success])]
-        (is (vector? success-schema))
-        (is (= :map (first success-schema)))
-        ;; Should include :x-val
-        (let [key-names (set (map first (filter vector? (rest success-schema))))]
-          (is (contains? key-names :x-val))))
-      ;; :failure should exist
-      (is (some? (get-in spec [:schema :output :failure]))))))
+      ;; Output should be the explicit per-transition wrapper, not bare :map
+      (let [output      (get-in spec [:schema :output])
+            transitions (second output)]
+        (is (= :per-transition (first output)))
+        ;; :success should contain the inferred keys
+        (let [success-schema (get transitions :success)]
+          (is (vector? success-schema))
+          (is (= :map (first success-schema)))
+          ;; Should include :x-val
+          (let [key-names (set (map first (filter vector? (rest success-schema))))]
+            (is (contains? key-names :x-val))))
+        ;; :failure should exist
+        (is (some? (get transitions :failure)))))))
 
 (deftest inferred-output-enables-chain-validation-test
   (testing "Parent workflow chain validation passes without set-cell-schema! workaround"
@@ -371,4 +373,4 @@
                                        {:input [:map]
                                         :output [:map [:y :int]]})]
       ;; Output should use the caller's schema for :success
-      (is (= [:map [:y :int]] (get-in spec [:schema :output :success]))))))
+      (is (= [:map [:y :int]] (get-in (second (get-in spec [:schema :output])) [:success]))))))

--- a/test/mycelium/default_transition_test.clj
+++ b/test/mycelium/default_transition_test.clj
@@ -84,8 +84,8 @@
       {:id      :dt4/produce
        :handler (fn [_ data] (assoc data :value 42))
        :schema  {:input  [:map]
-                 :output {:success [:map [:value :int]]
-                          :default [:map [:value :int]]}}})
+                 :output [:per-transition {:success [:map [:value :int]]
+                          :default [:map [:value :int]]}]}})
     (defmethod cell/cell-spec :dt4/consume [_]
       {:id      :dt4/consume
        :handler (fn [_ data] (assoc data :doubled (* 2 (:value data))))

--- a/test/mycelium/defcell_test.clj
+++ b/test/mycelium/defcell_test.clj
@@ -72,13 +72,13 @@
     (cell/defcell :test/branching
       {:doc    "Classifies input as high or low based on threshold"
        :input  [:map [:x :int]]
-       :output {:high [:map [:result [:= :high]]]
-                :low  [:map [:result [:= :low]]]}}
+       :output [:per-transition {:high [:map [:result [:= :high]]]
+                :low  [:map [:result [:= :low]]]}]}
       (fn [_ data]
         {:result (if (> (:x data) 10) :high :low)}))
-    (let [spec (cell/get-cell :test/branching)]
-      (is (map? (get-in spec [:schema :output])))
-      (is (= #{:high :low} (set (keys (get-in spec [:schema :output]))))))))
+    (let [output (get-in (cell/get-cell :test/branching) [:schema :output])]
+      (is (= :per-transition (first output)))
+      (is (= #{:high :low} (set (keys (second output))))))))
 
 ;; ===== 6. defcell works in workflow =====
 

--- a/test/mycelium/dev_test.clj
+++ b/test/mycelium/dev_test.clj
@@ -80,8 +80,8 @@
                         (assoc data :profile {:name "Alice"})
                         (assoc data :error-message "Not found")))
        :schema      {:input [:map [:id :string]]
-                     :output {:found     [:map [:profile [:map [:name :string]]]]
-                              :not-found [:map [:error-message :string]]}}})
+                     :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                              :not-found [:map [:error-message :string]]}]}})
     (let [dispatches [[:found     (fn [d] (:profile d))]
                       [:not-found (fn [d] (:error-message d))]]
           result (dev/test-cell :dev/dispatch-cell
@@ -97,8 +97,8 @@
        :handler     (fn [_ data]
                       (assoc data :error-message "Not found"))
        :schema      {:input [:map [:id :string]]
-                     :output {:found     [:map [:profile [:map [:name :string]]]]
-                              :not-found [:map [:error-message :string]]}}})
+                     :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                              :not-found [:map [:error-message :string]]}]}})
     (let [dispatches [[:found     (fn [d] (:profile d))]
                       [:not-found (fn [d] (:error-message d))]]
           result (dev/test-cell :dev/dispatch-cell2
@@ -114,8 +114,8 @@
        :handler     (fn [_ data]
                       (assoc data :profile {:name "Alice"}))
        :schema      {:input [:map [:id :string]]
-                     :output {:found     [:map [:profile [:map [:name :string]]]]
-                              :not-found [:map [:error-message :string]]}}})
+                     :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                              :not-found [:map [:error-message :string]]}]}})
     (let [dispatches [[:found     (fn [d] (:profile d))]
                       [:not-found (fn [d] (:error-message d))]]]
       ;; Correct expectation
@@ -139,8 +139,8 @@
        :handler     (fn [_ data]
                       (assoc data :profile {:name "Alice"}))
        :schema      {:input [:map [:id :string]]
-                     :output {:found     [:map [:profile [:map [:name :string]]]]
-                              :not-found [:map [:error-message :string]]}}})
+                     :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                              :not-found [:map [:error-message :string]]}]}})
     (let [dispatches [[:found     (fn [d] (:profile d))]
                       [:not-found (fn [d] (:error-message d))]]
           result (dev/test-cell :dev/pt-cell
@@ -159,8 +159,8 @@
                         (assoc data :profile {:name "Alice"})
                         (assoc data :error-message "Not found")))
        :schema      {:input [:map [:id :string]]
-                     :output {:found     [:map [:profile [:map [:name :string]]]]
-                              :not-found [:map [:error-message :string]]}}})
+                     :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                              :not-found [:map [:error-message :string]]}]}})
     (let [dispatches [[:found     (fn [d] (:profile d))]
                       [:not-found (fn [d] (:error-message d))]]
           results (dev/test-transitions :dev/multi-cell
@@ -347,7 +347,7 @@
       {:id      :dev/schema-router
        :handler (fn [_ data] data)
        :schema  {:input [:map [:x :int]]
-                 :output {:ok [:map [:a :int]] :fail [:map [:err :string]]}}})
+                 :output [:per-transition {:ok [:map [:a :int]] :fail [:map [:err :string]]}]}})
     (defmethod cell/cell-spec :dev/schema-leaf [_]
       {:id      :dev/schema-leaf
        :handler (fn [_ data] (assoc data :done true))

--- a/test/mycelium/fragment_test.clj
+++ b/test/mycelium/fragment_test.clj
@@ -19,19 +19,19 @@
     {:id     :auth/extract-cookie-session
      :doc    "Extracts auth token from HTTP cookie session"
      :schema {:input  [:map [:http-request [:map]]]
-              :output {:success [:map [:auth-token :string]]
+              :output [:per-transition {:success [:map [:auth-token :string]]
                        :failure [:map [:error-type :keyword]
-                                      [:error-message :string]]}}
+                                      [:error-message :string]]}]}
      :on-error :_exit/failure}
     :validate-session
     {:id     :auth/validate-session
      :doc    "Validates auth token against session store"
      :schema {:input  [:map [:auth-token :string]]
-              :output {:authorized   [:map [:session-valid :boolean]
+              :output [:per-transition {:authorized   [:map [:session-valid :boolean]
                                            [:user-id :string]]
                        :unauthorized [:map [:session-valid :boolean]
                                            [:error-type :keyword]
-                                           [:error-message :string]]}}
+                                           [:error-message :string]]}]}
      :on-error :_exit/failure}}
    :edges
    {:extract-session  {:success :validate-session
@@ -177,14 +177,14 @@
       {:id      :frag/extract
        :handler (fn [_ data] (assoc data :auth-token "tok-123"))
        :schema  {:input [:map [:http-request [:map]]]
-                 :output {:success [:map [:auth-token :string]]
-                          :failure [:map [:error-type :keyword]]}}})
+                 :output [:per-transition {:success [:map [:auth-token :string]]
+                          :failure [:map [:error-type :keyword]]}]}})
     (defmethod cell/cell-spec :frag/validate [_]
       {:id      :frag/validate
        :handler (fn [_ data] (assoc data :user-id "u1" :session-valid true))
        :schema  {:input [:map [:auth-token :string]]
-                 :output {:authorized [:map [:session-valid :boolean] [:user-id :string]]
-                          :unauthorized [:map [:session-valid :boolean] [:error-type :keyword]]}}})
+                 :output [:per-transition {:authorized [:map [:session-valid :boolean] [:user-id :string]]
+                          :unauthorized [:map [:session-valid :boolean] [:error-type :keyword]]}]}})
     (defmethod cell/cell-spec :frag/render-dashboard [_]
       {:id      :frag/render-dashboard
        :handler (fn [_ data] (assoc data :html "<h1>Dashboard</h1>"))
@@ -200,13 +200,13 @@
                 :cells {:extract  {:id     :frag/extract
                                    :doc    "Extracts auth token from request"
                                    :schema {:input  [:map [:http-request [:map]]]
-                                            :output {:success [:map [:auth-token :string]]
-                                                     :failure [:map [:error-type :keyword]]}}}
+                                            :output [:per-transition {:success [:map [:auth-token :string]]
+                                                     :failure [:map [:error-type :keyword]]}]}}
                         :validate {:id     :frag/validate
                                    :doc    "Validates auth token"
                                    :schema {:input  [:map [:auth-token :string]]
-                                            :output {:authorized   [:map [:session-valid :boolean] [:user-id :string]]
-                                                     :unauthorized [:map [:session-valid :boolean] [:error-type :keyword]]}}}}
+                                            :output [:per-transition {:authorized   [:map [:session-valid :boolean] [:user-id :string]]
+                                                     :unauthorized [:map [:session-valid :boolean] [:error-type :keyword]]}]}}}
                 :edges {:extract  {:success :validate
                                    :failure :_exit/failure}
                         :validate {:authorized   :_exit/success

--- a/test/mycelium/generate_stubs_test.clj
+++ b/test/mycelium/generate_stubs_test.clj
@@ -66,8 +66,8 @@
     (cell/defcell :stub/branching
       {:doc    "Classifies input as high or low"
        :input  [:map [:x :int]]
-       :output {:high [:map [:result [:= :high]]]
-                :low  [:map [:result [:= :low]]]}}
+       :output [:per-transition {:high [:map [:result [:= :high]]]
+                :low  [:map [:result [:= :low]]]}]}
       (fn [_ data] data))
     (let [stubs (dev/generate-stubs
                   {:cells {:start :stub/branching}

--- a/test/mycelium/halt_resume_test.clj
+++ b/test/mycelium/halt_resume_test.clj
@@ -208,8 +208,8 @@
                   (assoc data :path (if (> (:x data) 10) :big :small)
                               :mycelium/halt true))
        :schema  {:input  [:map [:x :int]]
-                 :output {:big   [:map [:path [:= :big]]]
-                          :small [:map [:path [:= :small]]]}}})
+                 :output [:per-transition {:big   [:map [:path [:= :big]]]
+                          :small [:map [:path [:= :small]]]}]}})
     (defmethod cell/cell-spec :halt/big [_]
       {:id      :halt/big
        :handler (fn [_ data] (assoc data :result "big"))

--- a/test/mycelium/invoke_cell_test.clj
+++ b/test/mycelium/invoke_cell_test.clj
@@ -150,8 +150,8 @@
     (myc/defcell :ic-test/branching
       {:doc    "Returns either an :ok or :failed shape."
        :input  [:map [:want [:enum :ok :failed]]]
-       :output {:ok     [:map [:result :int]]
-                :failed [:map [:error :string]]}}
+       :output [:per-transition {:ok     [:map [:result :int]]
+                :failed [:map [:error :string]]}]}
       (fn [_ {:keys [want]}]
         (case want
           :ok     {:mycelium/transition :ok     :result 42}
@@ -164,7 +164,7 @@
       (myc/defcell :ic-test/branching-bad
         {:doc    "Returns :ok transition but the wrong shape."
          :input  [:map]
-         :output {:ok [:map [:result :int]]}}
+         :output [:per-transition {:ok [:map [:result :int]]}]}
         (fn [_ _] {:mycelium/transition :ok :result "not-an-int"}))
       (let [thrown (try (myc/invoke-cell :ic-test/branching-bad {} {})
                         (catch clojure.lang.ExceptionInfo e e))]

--- a/test/mycelium/lite_schema_test.clj
+++ b/test/mycelium/lite_schema_test.clj
@@ -35,35 +35,36 @@
 ;; ===== 2. normalize-output-schema: dispatched vs single =====
 
 (deftest normalize-output-schema-test
-  (testing "Non-dispatched map output is treated as lite schema"
+  (testing "Map output is normalized as lite syntax"
     (is (= [:map [:tax :double]]
-           (schema/normalize-output-schema {:tax :double} false))))
+           (schema/normalize-output-schema {:tax :double}))))
 
-  (testing "Dispatched map output normalizes each transition value"
-    (is (= {:success [:map [:result :string]]
-            :failure [:map [:error :string]]}
+  (testing "Explicit per-transition wrapper normalizes each transition value"
+    (is (= [:per-transition {:success [:map [:result :string]]
+                             :failure [:map [:error :string]]}]
            (schema/normalize-output-schema
-            {:success {:result :string}
-             :failure {:error :string}}
-            true))))
+            [:per-transition {:success {:result :string}
+                              :failure {:error  :string}}]))))
 
-  (testing "Dispatched map output with existing Malli vectors passes through"
-    (is (= {:high [:map [:result [:= :high]]]
-            :low  [:map [:result [:= :low]]]}
+  (testing "Per-transition wrapper with already-normalized Malli vectors passes through"
+    (is (= [:per-transition {:high [:map [:result [:= :high]]]
+                             :low  [:map [:result [:= :low]]]}]
            (schema/normalize-output-schema
+            [:per-transition {:high [:map [:result [:= :high]]]
+                              :low  [:map [:result [:= :low]]]}]))))
+
+  (testing "Implicit per-transition map (all-vector values, unnamespaced keys) is rejected"
+    (is (thrown-with-msg? Exception #"Implicit per-transition output schema"
+          (schema/normalize-output-schema
             {:high [:map [:result [:= :high]]]
-             :low  [:map [:result [:= :low]]]}
-            true))))
+             :low  [:map [:result [:= :low]]]}))))
 
-  (testing "Vector output passes through regardless of dispatch flag"
+  (testing "Vector output passes through"
     (is (= [:map [:x :int]]
-           (schema/normalize-output-schema [:map [:x :int]] false)))
-    (is (= [:map [:x :int]]
-           (schema/normalize-output-schema [:map [:x :int]] true))))
+           (schema/normalize-output-schema [:map [:x :int]]))))
 
   (testing "nil output passes through"
-    (is (nil? (schema/normalize-output-schema nil false)))
-    (is (nil? (schema/normalize-output-schema nil true)))))
+    (is (nil? (schema/normalize-output-schema nil)))))
 
 ;; ===== 3. defcell with lite syntax =====
 
@@ -98,18 +99,17 @@
       (is (= [:map [:x :int]] (get-in spec [:schema :input])))
       (is (= [:map [:y :int]] (get-in spec [:schema :output])))))
 
-  (testing "defcell with per-transition vector output is unchanged"
+  (testing "defcell with explicit per-transition output is preserved"
     (cell/defcell :test/per-transition
       {:doc    "Classifies x as high or low"
        :input  {:x :int}
-       :output {:high [:map [:result [:= :high]]]
-                :low  [:map [:result [:= :low]]]}}
+       :output [:per-transition {:high [:map [:result [:= :high]]]
+                                 :low  [:map [:result [:= :low]]]}]}
       (fn [_ data]
         {:result (if (> (:x data) 10) :high :low)}))
-    (let [spec (cell/get-cell :test/per-transition)]
-      ;; Per-transition values are vectors, so they stay as per-transition map
-      (is (map? (get-in spec [:schema :output])))
-      (is (= #{:high :low} (set (keys (get-in spec [:schema :output]))))))))
+    (let [output (get-in (cell/get-cell :test/per-transition) [:schema :output])]
+      (is (= :per-transition (first output)))
+      (is (= #{:high :low} (set (keys (second output))))))))
 
 ;; ===== 4. set-cell-schema! with lite syntax =====
 
@@ -215,8 +215,9 @@
              :cells {:start {:id :test/branch
                               :doc "Classifies x as positive or negative"
                               :schema {:input {:x :int}
-                                       :output {:positive {:sign :keyword}
-                                                :negative {:sign :keyword}}}
+                                       :output [:per-transition
+                                                {:positive {:sign :keyword}
+                                                 :negative {:sign :keyword}}]}
                               :on-error nil}}
              :edges {:start {:positive :end :negative :end}}
              :dispatches {:start [[:positive (fn [d] (= :positive (:sign d)))]

--- a/test/mycelium/manifest_test.clj
+++ b/test/mycelium/manifest_test.clj
@@ -106,8 +106,8 @@
            {:id       :test/lookup
             :doc      "Look up a thing"
             :schema   {:input  [:map [:id :string]]
-                       :output {:found     [:map [:profile [:map [:name :string]]]]
-                                :not-found [:map [:error-message :string]]}}
+                       :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                                :not-found [:map [:error-message :string]]}]}
             :on-error nil
             :requires [:db]}
            :render
@@ -143,9 +143,10 @@
   (testing "manifest->workflow applies per-transition schema to cells"
     (let [workflow-def (manifest/manifest->workflow per-transition-manifest)]
       (is (map? workflow-def))
-      (let [cell (cell/get-cell :test/lookup)]
-        (is (map? (get-in cell [:schema :output])))
-        (is (= #{:found :not-found} (set (keys (get-in cell [:schema :output])))))))))
+      (let [cell   (cell/get-cell :test/lookup)
+            output (get-in cell [:schema :output])]
+        (is (= :per-transition (first output)))
+        (is (= #{:found :not-found} (set (keys (second output)))))))))
 
 ;; ===== Dispatch coverage validation =====
 
@@ -186,8 +187,8 @@
            {:id       :test/jm-start
             :doc      "Start cell for join workflow"
             :schema   {:input  [:map [:x :int]]
-                       :output {:success [:map [:user-id :string]]
-                                :failure [:map [:error :string]]}}
+                       :output [:per-transition {:success [:map [:user-id :string]]
+                                :failure [:map [:error :string]]}]}
             :on-error nil
             :requires []}
            :fetch-a

--- a/test/mycelium/resilience_test.clj
+++ b/test/mycelium/resilience_test.clj
@@ -17,8 +17,8 @@
                   (Thread/sleep 200)
                   (assoc data :result "done"))
        :schema  {:input [:map [:x :int]]
-                 :output {:done    [:map [:result :string]]
-                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+                 :output [:per-transition {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}]}})
     (defmethod cell/cell-spec :res/handle-timeout [_]
       {:id      :res/handle-timeout
        :handler (fn [_ data] (assoc data :handled true))
@@ -43,8 +43,8 @@
       {:id      :res/fast
        :handler (fn [_ data] (assoc data :result "fast"))
        :schema  {:input  [:map [:x :int]]
-                 :output {:done    [:map [:result :string]]
-                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+                 :output [:per-transition {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}]}})
 
     (let [result (myc/run-workflow
                   {:cells {:start :res/fast}
@@ -65,8 +65,8 @@
                   (Thread/sleep 200)
                   (assoc data :result "done"))
        :schema  {:input  [:map [:x :int]]
-                 :output {:done    [:map [:result :string]]
-                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+                 :output [:per-transition {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}]}})
     (defmethod cell/cell-spec :res/handle-timeout2 [_]
       {:id      :res/handle-timeout2
        :handler (fn [_ data] (assoc data :handled true))
@@ -316,8 +316,8 @@
                     (Thread/sleep 500)
                     (callback (assoc data :result "done"))))
        :schema  {:input [:map [:x :int]]
-                 :output {:done    [:map [:result :string]]
-                          :timeout [:map [:mycelium/resilience-error :map]]}}})
+                 :output [:per-transition {:done    [:map [:result :string]]
+                          :timeout [:map [:mycelium/resilience-error :map]]}]}})
     (defmethod cell/cell-spec :res/async-timeout-handler [_]
       {:id      :res/async-timeout-handler
        :handler (fn [_ data] (assoc data :handled true))
@@ -347,8 +347,8 @@
                     (Thread/sleep 500)
                     (callback (assoc data :result "late"))))
        :schema  {:input [:map [:x :int]]
-                 :output {:done [:map [:result :string]]
-                          :failed [:map [:mycelium/resilience-error :map]]}}})
+                 :output [:per-transition {:done [:map [:result :string]]
+                          :failed [:map [:mycelium/resilience-error :map]]}]}})
     (defmethod cell/cell-spec :res/async-hang-fallback [_]
       {:id      :res/async-hang-fallback
        :handler (fn [_ data] (assoc data :handled true))

--- a/test/mycelium/schema_test.clj
+++ b/test/mycelium/schema_test.clj
@@ -158,8 +158,8 @@
       {:id          :test/per-trans
        :handler     (fn [_ data] data)
        :schema      {:input  [:map [:x :int]]
-                     :output {:found     [:map [:profile [:map [:name :string]]]]
-                              :not-found [:map [:error-message :string]]}}})
+                     :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                              :not-found [:map [:error-message :string]]}]}})
     (let [cell (cell/get-cell! :test/per-trans)]
       (is (= [:map [:profile [:map [:name :string]]]]
              (schema/output-schema-for-transition cell :found)))
@@ -183,8 +183,8 @@
     {:id          :test/pt-cell
      :handler     (fn [_ data] data)
      :schema      {:input  [:map [:x :int]]
-                   :output {:success   [:map [:y :int]]
-                            :failure   [:map [:error-message :string]]}}}))
+                   :output [:per-transition {:success   [:map [:y :int]]
+                            :failure   [:map [:error-message :string]]}]}}))
 
 (deftest validate-output-per-transition-passes-test
   (testing "Per-transition schema passes correct data for given transition label"
@@ -370,10 +370,10 @@
           compiled    (schema/pre-compile-schemas state->cell)
           cell        (get compiled :test/pt-cell)
           output      (get-in cell [:schema :output])]
-      ;; Output should still be a map, but values should be compiled schemas
-      (is (map? output))
-      (is (m/schema? (get output :success)))
-      (is (m/schema? (get output :failure))))))
+      ;; Output should still be the per-transition wrapper, with values as compiled schemas
+      (is (= :per-transition (first output)))
+      (is (m/schema? (get-in output [1 :success])))
+      (is (m/schema? (get-in output [1 :failure]))))))
 
 (deftest pre-compile-schemas-validate-still-works-test
   (testing "validate-input/output still work with pre-compiled schemas"

--- a/test/mycelium/transform_test.clj
+++ b/test/mycelium/transform_test.clj
@@ -28,8 +28,8 @@
                 {:tier (if (> (:score data) 80) :premium :basic)
                  :raw-score (:score data)})
      :schema  {:input  [:map [:score :int]]
-               :output {:premium [:map [:tier [:= :premium]] [:raw-score :int]]
-                        :basic   [:map [:tier [:= :basic]] [:raw-score :int]]}}})
+               :output [:per-transition {:premium [:map [:tier [:= :premium]] [:raw-score :int]]
+                        :basic   [:map [:tier [:= :basic]] [:raw-score :int]]}]}})
   ;; Cell that expects :level (not :tier)
   (defmethod cell/cell-spec :xf/premium-handler [_]
     {:id      :xf/premium-handler

--- a/test/mycelium/validation_test.clj
+++ b/test/mycelium/validation_test.clj
@@ -22,16 +22,16 @@
     (is (thrown? Exception
           (v/validate-output-schema! [:not-real] "test")))))
 
-(deftest validate-output-schema-map-test
-  (testing "Map output schema validates each transition's schema"
+(deftest validate-output-schema-per-transition-test
+  (testing "Per-transition output schema validates each transition's schema"
     (is (nil? (v/validate-output-schema!
-               {:found [:map [:profile :map]]
-                :not-found [:map [:error :string]]}
+               [:per-transition {:found     [:map [:profile :map]]
+                                 :not-found [:map [:error :string]]}]
                "test")))
     (is (thrown-with-msg? Exception #"transition :bad"
           (v/validate-output-schema!
-           {:good [:map [:x :int]]
-            :bad  [:not-real]}
+           [:per-transition {:good [:map [:x :int]]
+                             :bad  [:not-real]}]
            "test")))))
 
 (deftest validate-output-schema-keyword-test

--- a/test/mycelium/workflow_test.clj
+++ b/test/mycelium/workflow_test.clj
@@ -230,8 +230,8 @@
                   (assoc data :profile {:name "Alice"})
                   (assoc data :error-message "Not found")))
      :schema {:input [:map [:id :string]]
-              :output {:found     [:map [:profile [:map [:name :string]]]]
-                       :not-found [:map [:error-message :string]]}}})
+              :output [:per-transition {:found     [:map [:profile [:map [:name :string]]]]
+                       :not-found [:map [:error-message :string]]}]}})
   (defmethod cell/cell-spec :test/render-profile [_]
     {:id :test/render-profile
      :handler (fn [_ data] (assoc data :html "ok"))
@@ -569,3 +569,90 @@
                                   :step-b [[:done (constantly true)]]}})]
       (is (some? compiled)))))
 
+
+;; =====================================================================
+;; Schema chain validator: regressions from real apparat / federation use
+;; =====================================================================
+
+(deftest schema-chain-honors-optional-input-keys-test
+  (testing "An input key marked {:optional true} does NOT have to be
+            produced by an upstream cell — the chain validator
+            should pass."
+    (cell/defcell :test/produce
+      {:doc "Produces only :a"
+       :input  [:map]
+       :output [:map [:a :int]]}
+      (fn [_ _] {:a 1}))
+    (cell/defcell :test/consume
+      {:doc "Requires :a, optionally consumes :b"
+       :input  [:map
+                [:a :int]
+                [:b {:optional true} [:maybe :string]]]
+       :output [:map [:done :boolean]]}
+      (fn [_ _] {:done true}))
+    ;; Before fix: validator demanded :b from upstream and failed
+    ;; compile. After fix: optional :b is filtered out of the
+    ;; required-input-keys set.
+    (is (some? (wf/compile-workflow
+                 {:cells {:start :test/produce
+                          :step  :test/consume}
+                  :edges {:start :step
+                          :step  :end}})))))
+
+(deftest schema-chain-still-rejects-missing-required-input-test
+  (testing "Schema-chain validator still rejects a missing REQUIRED
+            input — the optional-key fix doesn't accidentally
+            relax non-optional fields."
+    (cell/defcell :test/produce-a
+      {:doc "Produces only :a"
+       :input  [:map]
+       :output [:map [:a :int]]}
+      (fn [_ _] {:a 1}))
+    (cell/defcell :test/needs-b
+      {:doc "Needs both :a and required :b"
+       :input  [:map [:a :int] [:b :string]]
+       :output [:map [:done :boolean]]}
+      (fn [_ _] {:done true}))
+    (is (thrown-with-msg? Exception #"Schema chain error"
+          (wf/compile-workflow
+            {:cells {:start :test/produce-a
+                     :step  :test/needs-b}
+             :edges {:start :step
+                     :step  :end}})))))
+
+(deftest lite-map-output-with-namespaced-keys-vector-values-test
+  (testing "A lite map output schema whose keys are namespaced and
+            whose values are vectors is NOT misclassified as
+            per-transition. Pre-fix, mycelium's implicit heuristic
+            (every value is a vector) would treat this as
+            per-transition; the explicit marker fixes that."
+    (cell/defcell :test/parse-body
+      {:doc "Parses an incoming request body"
+       :input  [:map [:http-request :map]]
+       :output {:inbox/body-bytes [:maybe :any]
+                :inbox/activity   [:maybe :map]
+                :inbox/error      [:maybe :string]
+                :inbox/status     [:maybe :int]}}
+      (fn [_ _] {:inbox/body-bytes nil
+                 :inbox/activity   nil
+                 :inbox/error      nil
+                 :inbox/status     nil}))
+    (cell/defcell :test/validate-envelope
+      {:doc "Validates parsed envelope"
+       :input  [:map
+                [:inbox/activity [:maybe :map]]
+                [:inbox/error    [:maybe :string]]
+                [:inbox/status   [:maybe :int]]]
+       :output [:map [:inbox/error  [:maybe :string]]
+                     [:inbox/status [:maybe :int]]]}
+      (fn [_ _] {:inbox/error nil :inbox/status nil}))
+    ;; Before fix: parse-body's output was misclassified as
+    ;; per-transition (because all values are vectors), so its
+    ;; output keys never reached validate-envelope's available-keys
+    ;; set, and compile failed with
+    ;; "requires keys #{:inbox/status :inbox/activity :inbox/error}
+    ;;  but only #{:http-request} available".
+    (is (some? (wf/compile-workflow
+                 {:cells {:start    :test/parse-body
+                          :validate :test/validate-envelope}
+                  :edges {:start :validate :validate :end}})))))


### PR DESCRIPTION
## Summary

Two related fixes to the schema layer, surfaced while building a multi-stage federation workflow on top of mycelium.

### Bug 1 — implicit per-transition output is ambiguous

`mycelium.cell/output-dispatched?` inferred per-transition output from a heuristic: *the schema is a map AND every value is a vector.* That silently misclassified perfectly ordinary lite map output schemas whose values happened to be vector schemas. For example:

```clojure
:output {:inbox/body-bytes [:maybe :any]
         :inbox/activity   [:maybe :map]
         :inbox/error      [:maybe :string]
         :inbox/status     [:maybe :int]}
```

was treated as per-transition with transitions `:inbox/body-bytes`, `:inbox/activity`, `:inbox/error`, `:inbox/status` — and the schema-chain validator then refused to forward those keys to downstream cells, because every transition-key's "schema" (`[:maybe :string]` etc.) extracts zero map keys.

Per-transition output now requires an explicit wrapper:

```clojure
:output [:per-transition {:high [:map ...] :low [:map ...]}]
```

Bare map output is ALWAYS lite-map syntax — no exceptions, no inference. `normalize-output-schema` rejects the pre-1.0 implicit form with a migration error that quotes both the old and new form, so updates are mechanical.

### Bug 2 — schema-chain validator ignored `{:optional true}`

A cell that declared

```clojure
:input [:map [:a :int] [:b {:optional true} [:maybe :string]]]
```

couldn't sit anywhere downstream of cells that produced only `:a` — `compile-workflow` rejected it with `requires keys #{:b} but only #{:a} available`. `mycelium.schema/schema-expected-keys` already filtered optionals for runtime diagnostics; the workflow-level helper `get-map-keys` did not.

`workflow/get-map-keys` now takes `:include-optional?` and the schema-chain validator calls it with `:include-optional? false` when computing required input keys.

## Migration

For per-transition cells:

```clojure
;; Before
:output {:high [:map [:result [:= :high]]]
         :low  [:map [:result [:= :low]]]}

;; After
:output [:per-transition {:high [:map [:result [:= :high]]]
                          :low  [:map [:result [:= :low]]]}]
```

EDN manifests follow the same form. The error message thrown by `normalize-output-schema` includes a copy-pasteable rewrite for each cell that needs updating.

## Test plan

- [x] `clojure -M:test` — 513 → 516 tests, 1115 → 1118 assertions, 0 failures.
- [x] Per-transition cells in `examples/expense_approval`, `examples/loan_processing`, and `examples/user_onboarding/resources/**` migrated to the new form via a small `rewrite-clj` script.
- [x] Three new regression tests in `workflow_test.clj` pin both bugs:
  - `schema-chain-honors-optional-input-keys-test`
  - `schema-chain-still-rejects-missing-required-input-test` (guard against over-relaxing)
  - `lite-map-output-with-namespaced-keys-vector-values-test` (the actual production-style case)
- [x] Existing `lite_schema_test/normalize-output-schema-test` rewritten — the matrix of `dispatched?` booleans is replaced with the explicit-wrapper / implicit-rejection contract.

## Files touched

7 source namespaces (cell, schema, validation, workflow, manifest, compose, dev) + 16 test files migrated + 4 EDN manifest files + 2 example app source files + CHANGELOG entry. 31 files, +574/-301.