### PR TITLE
Remove implicit per-transition migration helper and dead args

### DIFF
--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -36,15 +36,6 @@
       (throw (ex-info (str "Cell " id " not found in registry")
                       {:id id}))))
 
-(defn- output-dispatched?
-  "True when the output schema is in explicit per-transition form
-  `[:per-transition {tx schema, ...}]`. Pre-1.0 mycelium used a
-  heuristic over plain map outputs which silently misclassified
-  lite maps whose values happened to be vector schemas; the
-  marker is now mandatory and the heuristic is gone."
-  [output]
-  (schema/per-transition? output))
-
 (defn set-cell-schema!
   "Sets or overwrites the schema for an already-registered cell.
    Normalizes lite syntax, validates Malli, then updates.
@@ -53,8 +44,7 @@
   (when-not (cell-spec cell-id)
     (throw (ex-info (str "Cell " cell-id " not found in registry")
                     {:id cell-id})))
-  (let [dispatched? (output-dispatched? (:output schema))
-        schema (schema/normalize-cell-schema schema dispatched?)]
+  (let [schema (schema/normalize-cell-schema schema)]
     (when (:input schema)
       (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
     (when (:output schema)
@@ -128,9 +118,8 @@
         opt-keys    #{:doc :requires :async?}
         raw-schema  (let [s (select-keys opts schema-keys)]
                       (when (seq s) s))
-        dispatched? (and raw-schema (output-dispatched? (:output raw-schema)))
         schema      (when raw-schema
-                      (schema/normalize-cell-schema raw-schema dispatched?))
+                      (schema/normalize-cell-schema raw-schema))
         extra       (select-keys opts opt-keys)
         spec        (cond-> {:id cell-id :handler handler-fn :doc (:doc extra)}
                       schema (assoc :schema schema)

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -144,19 +144,14 @@
        (throw (ex-info "Manifest missing :edges" {:id id})))
      ;; Resolve :schema :inherit, then normalize lite syntax before validation
      (let [cells    (resolve-inherit-schemas cells)
-           ;; Normalize cell schemas using edge context for output disambiguation
-           ;; Join members have no edge entries, so fall back to heuristic:
-           ;; a map output where all values are vectors is per-transition.
            cells    (into {}
                           (map (fn [[cell-name cell-def]]
                                  (if (or (= :inherit (:schema cell-def))
                                          (nil? (:schema cell-def)))
                                    [cell-name cell-def]
-                                   (let [output      (get-in cell-def [:schema :output])
-                                         dispatched? (schema/per-transition? output)
-                                         normalized  (schema/normalize-cell-schema
-                                                       (:schema cell-def) dispatched?)]
-                                     [cell-name (assoc cell-def :schema normalized)]))))
+                                   [cell-name (assoc cell-def :schema
+                                                     (schema/normalize-cell-schema
+                                                       (:schema cell-def)))])))
                           cells)
            manifest (assoc manifest :cells cells)]
        ;; Validate each cell definition

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -42,21 +42,6 @@
   (when (per-transition? output)
     (second output)))
 
-(defn- looks-like-implicit-per-transition?
-  "Detects the OLD implicit per-transition form: a plain map whose
-  values are all vector schemas. Used only to produce a clear
-  migration error — the implicit form is no longer accepted."
-  [output]
-  (and (map? output)
-       (seq output)
-       (every? vector? (vals output))
-       ;; Sanity: per-transition keys are simple keywords (edge
-       ;; labels like :ok / :failed / :high / :low). If any key has
-       ;; a namespace, it's almost certainly a lite map of
-       ;; namespaced data keys whose values happen to be vectors
-       ;; like [:maybe :string].
-       (not-any? namespace (keys output))))
-
 ;; ===== Lite schema normalization =====
 
 (defn normalize-schema
@@ -97,48 +82,38 @@
     * `{:k schema, :k2 schema, ...}` — lite map syntax, normalized
       to `[:map [:k schema] [:k2 schema] ...]`.
 
-  Rejects the pre-1.0 implicit per-transition shape (a plain map
-  whose values are all vectors and whose keys are unnamespaced)
-  with a migration error.
+  Throws on a malformed `[:per-transition ...]` wrapper (anything
+  other than `[:per-transition {...}]`)."
+  [schema]
+  (cond
+    (nil? schema) nil
 
-  The `dispatched?` parameter is accepted for backwards
-  compatibility but is no longer consulted — per-transition is
-  determined entirely by the explicit `[:per-transition ...]`
-  wrapper."
-  ([schema] (normalize-output-schema schema false))
-  ([schema _dispatched?]
-   (cond
-     (nil? schema) nil
+    (per-transition? schema)
+    [:per-transition (into {} (map (fn [[k v]] [k (normalize-schema v)]))
+                           (transitions-map schema))]
 
-     (per-transition? schema)
-     [:per-transition (into {} (map (fn [[k v]] [k (normalize-schema v)]))
-                            (transitions-map schema))]
+    (and (vector? schema) (= :per-transition (first schema)))
+    (throw (ex-info
+             (str "Malformed [:per-transition ...] output schema. "
+                  "Expected [:per-transition {transition-label schema, ...}], got: "
+                  (pr-str schema))
+             {:schema schema}))
 
-     (vector? schema) schema
+    (vector? schema) schema
 
-     (looks-like-implicit-per-transition? schema)
-     (throw (ex-info
-              (str "Implicit per-transition output schema is no longer "
-                   "supported. Wrap the transition map in [:per-transition ...]:\n"
-                   "  Old: :output " (pr-str schema) "\n"
-                   "  New: :output " (pr-str [:per-transition schema]))
-              {:schema schema}))
+    (map? schema) (normalize-schema schema)
 
-     (map? schema) (normalize-schema schema)
-
-     :else schema)))
+    :else schema))
 
 (defn normalize-cell-schema
-  "Normalizes a cell's :schema map, converting lite syntax to Malli.
-   `dispatched?` — true if the cell has branching edges (per-transition output)."
-  ([schema] (normalize-cell-schema schema false))
-  ([schema dispatched?]
-   (when schema
-     (let [input  (:input schema)
-           output (:output schema)]
-       (cond-> schema
-         input  (assoc :input (normalize-schema input))
-         output (assoc :output (normalize-output-schema output dispatched?)))))))
+  "Normalizes a cell's :schema map, converting lite syntax to Malli."
+  [schema]
+  (when schema
+    (let [input  (:input schema)
+          output (:output schema)]
+      (cond-> schema
+        input  (assoc :input (normalize-schema input))
+        output (assoc :output (normalize-output-schema output))))))
 
 (def ^:private terminal-states
   #{::fsm/end ::fsm/error ::fsm/halt})

--- a/src/mycelium/validation.clj
+++ b/src/mycelium/validation.clj
@@ -35,15 +35,9 @@
    explicit per-transition wrapper [:per-transition {tx schema, ...}]
    whose inner values are each Malli schemas."
   [output-schema label]
-  (cond
-    (per-transition-output? output-schema)
+  (if (per-transition-output? output-schema)
     (doseq [[k v] (second output-schema)]
       (validate-malli-schema! v (str label " transition " k)))
-
-    (vector? output-schema)
-    (validate-malli-schema! output-schema label)
-
-    :else
     (validate-malli-schema! output-schema label)))
 
 ;; ===== Cell definition validation =====

--- a/test/mycelium/lite_schema_test.clj
+++ b/test/mycelium/lite_schema_test.clj
@@ -53,11 +53,17 @@
             [:per-transition {:high [:map [:result [:= :high]]]
                               :low  [:map [:result [:= :low]]]}]))))
 
-  (testing "Implicit per-transition map (all-vector values, unnamespaced keys) is rejected"
-    (is (thrown-with-msg? Exception #"Implicit per-transition output schema"
-          (schema/normalize-output-schema
+  (testing "Plain map output is always lite syntax, even when values are vectors"
+    (is (= [:map
+            [:high [:map [:result [:= :high]]]]
+            [:low  [:map [:result [:= :low]]]]]
+           (schema/normalize-output-schema
             {:high [:map [:result [:= :high]]]
              :low  [:map [:result [:= :low]]]}))))
+
+  (testing "Malformed [:per-transition ...] wrapper is rejected"
+    (is (thrown-with-msg? Exception #"Malformed \[:per-transition"
+          (schema/normalize-output-schema [:per-transition]))))
 
   (testing "Vector output passes through"
     (is (= [:map [:x :int]]


### PR DESCRIPTION
## Summary

Follow-up cleanup on top of #41. The implicit per-transition migration
helper was kept as a transitional aid; this PR removes it and tidies
up the surrounding dead code surfaced during review.

- **Breaking:** plain map output schemas always normalize as lite map
  syntax now. Pre-1.0 implicit per-transition forms (`{:label [:map ...]}`)
  silently become `[:map [:label [:map ...]] ...]` instead of throwing a
  migration error. Anything that still relies on the implicit shape must
  switch to the explicit `[:per-transition ...]` wrapper.
- Drop the dead `dispatched?` parameter from `normalize-output-schema` /
  `normalize-cell-schema`, the `output-dispatched?` helper in `cell.clj`,
  and the dead `dispatched?` computation in `manifest.clj`.
- Throw a clear error on malformed `[:per-transition ...]` wrappers
  (e.g. `[:per-transition]`, `[:per-transition X Y]`, or `[:per-transition non-map]`)
  instead of letting them fall through to a confusing Malli error later.
- Collapse the dead `vector?` branch in `validate-output-schema!`.

## Test plan

- [x] `clojure -M:test` — 516 tests, 1119 assertions, 0 failures.
- [x] Replaced the `"Implicit per-transition map ... is rejected"` test
  with a `"Plain map output is always lite syntax"` assertion plus a
  malformed-wrapper rejection test.