### PR TITLE
Support custom Malli registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,34 @@
 
 ## Unreleased
 
-### Custom Malli registries
+### Breaking: per-transition output schemas require explicit `[:per-transition ...]` wrapper
+
+Cells whose downstream edge selection depends on the cell's output
+declare a different schema per transition. Pre-1.0 the wrapper was
+implicit — a plain map whose values were all vectors was inferred
+to be per-transition. That heuristic silently misclassified lite
+map output schemas whose values happened to be vector schemas
+(e.g. `{:user/profile [:maybe :map]}` — every value is a vector,
+so it got treated as per-transition with transitions `:user/profile`).
+
+The wrapper is now mandatory:
+
+```clojure
+;; Before — implicit, ambiguous
+:output {:high [:map [:result [:= :high]]]
+         :low  [:map [:result [:= :low]]]}
+
+;; After — explicit
+:output [:per-transition {:high [:map [:result [:= :high]]]
+                          :low  [:map [:result [:= :low]]]}]
+```
+
+Bare map output schemas are now ALWAYS lite-map syntax, never
+per-transition. The migration error message includes the exact
+rewrite for each cell that needs updating. EDN manifest files
+follow the same form.
+
+### Feature: custom Malli registries
 
 Compilation takes a `:malli/registry` option. Named schemas resolve against
 your registry instead of Malli's global one, so you can use namespaced schema
@@ -33,33 +60,6 @@ Two helpers behind this are now public: `mycelium.schema/compile-schema` and
 `mycelium.schema/compile-cell-schemas`. Both compile raw schema forms against
 a registry and pass already-compiled schemas through untouched.
 
-### Breaking: per-transition output schemas require explicit `[:per-transition ...]` wrapper
-
-Cells whose downstream edge selection depends on the cell's output
-declare a different schema per transition. Pre-1.0 the wrapper was
-implicit — a plain map whose values were all vectors was inferred
-to be per-transition. That heuristic silently misclassified lite
-map output schemas whose values happened to be vector schemas
-(e.g. `{:user/profile [:maybe :map]}` — every value is a vector,
-so it got treated as per-transition with transitions `:user/profile`).
-
-The wrapper is now mandatory:
-
-```clojure
-;; Before — implicit, ambiguous
-:output {:high [:map [:result [:= :high]]]
-         :low  [:map [:result [:= :low]]]}
-
-;; After — explicit
-:output [:per-transition {:high [:map [:result [:= :high]]]
-                          :low  [:map [:result [:= :low]]]}]
-```
-
-Bare map output schemas are now ALWAYS lite-map syntax, never
-per-transition. The migration error message includes the exact
-rewrite for each cell that needs updating. EDN manifest files
-follow the same form.
-
 ### Fix: schema-chain validator honors `{:optional true}` on inputs
 
 A cell that declared `[:k {:optional true} <schema>]` in its input
@@ -74,6 +74,15 @@ filters out optional keys when computing a cell's required inputs.
    :output [:map [:done :boolean]]}
   ...)
 ```
+### Fix: schemas are stored verbatim; lite maps compile through Malli itself
+
+Registration used to rewrite schemas, treating any map inside a schema vector
+as lite syntax. That corrupted ordinary Malli property maps: `[:string {:min 5}]`
+became `[:string [:map [:min 5]]]`, which doesn't compile, and the error only
+surfaced later at workflow compile time.
+
+The two dialects cannot be mixed: a lite map inside a Malli vector form is
+invalid Malli and is rejected at compile time.
 
 ## 2026-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+### Custom Malli registries
+
+Compilation takes a `:malli/registry` option. Named schemas resolve against
+your registry instead of Malli's global one, so you can use namespaced schema
+references without touching global state or wrapping every schema in
+`m/schema` by hand:
+
+```clojure
+(def registry
+  (mr/composite-registry
+   (m/default-schemas)
+   {:app/id      :uuid
+    :app/request [:map [:id :app/id]]}))
+
+(myc/pre-compile workflow {:malli/registry registry})
+```
+
+One registry at pre-compile covers the whole workflow: cell schemas,
+transform schemas, joins, and the workflow input schema. Manifests,
+generators, composed workflows, and `invoke-cell` take the same option.
+Nothing writes to the global registry, so two workflows in one process can
+use different registries and tests stay isolated.
+
+The registry is baked into each schema at compile time. If you use an
+`mr/mutable-registry`, changes made after compilation don't reach a compiled
+workflow; recompile to pick them up.
+
+Two helpers behind this are now public: `mycelium.schema/compile-schema` and
+`mycelium.schema/compile-cell-schemas`. Both compile raw schema forms against
+a registry and pass already-compiled schemas through untouched.
+
 ### Breaking: per-transition output schemas require explicit `[:per-transition ...]` wrapper
 
 Cells whose downstream edge selection depends on the cell's output

--- a/README.md
+++ b/README.md
@@ -209,6 +209,36 @@ Input keys marked `{:optional true}` are excluded from the schema chain's requir
 :input [:map [:a :int] [:b {:optional true} [:maybe :string]]]
 ```
 
+### Local Malli Registries
+
+If your application keeps its schemas in a local registry rather than Malli's
+global one, hand it to Mycelium at compile time:
+
+```clojure
+(require '[malli.core :as m]
+         '[malli.registry :as mr]
+         '[mycelium.core :as myc])
+
+(def app-registry
+  (mr/composite-registry
+   (m/default-schemas)
+   {:app/id      :uuid
+    :app/request [:map [:id :app/id]]}))
+
+(def compiled
+  (myc/pre-compile workflow {:malli/registry app-registry}))
+```
+
+That one option covers the whole workflow: cell schemas, transform schemas,
+joins, and the workflow input schema. Manifests, generators, composed
+workflows, and `invoke-cell` accept it too. Nothing writes to the global
+registry, so two workflows in the same process can use different registries
+without stepping on each other.
+
+The registry is baked into each schema at compile time. If you use an
+`mr/mutable-registry`, changes made after compilation don't reach an
+already-compiled workflow; recompile to pick them up.
+
 ### Resources
 
 External dependencies are injected, never acquired by cells:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -154,8 +154,24 @@ mentally reconstruct the architecture from.
  :coerce?  true                                    ;; auto-coerce numeric types (int↔double)
  :propagate-keys? false                             ;; disable auto key propagation (on by default)
  :validate :warn                                    ;; :strict (default), :warn, or :off
- :on-trace (fn [entry] ...)}                        ;; callback after each cell completes
+ :on-trace (fn [entry] ...)                         ;; callback after each cell completes
+ :malli/registry app-registry}                      ;; resolve named schemas
 ```
+
+A local registry applies to workflow input schemas, cell schemas, transforms,
+joins, composition, manifests, generators, and `invoke-cell`:
+
+```clojure
+(def compiled
+  (myc/pre-compile workflow-def {:malli/registry app-registry}))
+
+(myc/invoke-cell :app/load resources data
+                 {:malli/registry app-registry})
+```
+
+Compilation captures the registry in each Malli schema object and never changes
+the global registry. Mutating an `mr/mutable-registry` later does not update an
+already-compiled workflow. Recompile to capture registry changes.
 
 ## Accumulating Data Model
 

--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -39,38 +39,54 @@
 (defn set-cell-schema!
   "Sets or overwrites the schema for an already-registered cell.
    Normalizes lite syntax, validates Malli, then updates.
-   Throws if the cell is not found or the schema is invalid."
-  [cell-id schema]
-  (when-not (cell-spec cell-id)
-    (throw (ex-info (str "Cell " cell-id " not found in registry")
-                    {:id cell-id})))
-  (let [schema (schema/normalize-cell-schema schema)]
-    (when (:input schema)
-      (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
-    (when (:output schema)
-      (v/validate-output-schema! (:output schema) (str cell-id " :output")))
-    (swap! cell-overrides update cell-id merge {:schema schema})
-    schema))
+   Throws if the cell is not found or the schema is invalid.
+   opts:
+     :malli/registry — local Malli registry used to validate named schemas."
+  ([cell-id schema-map]
+   (set-cell-schema! cell-id schema-map {}))
+  ([cell-id schema-map opts]
+   (when-not (cell-spec cell-id)
+     (throw (ex-info (str "Cell " cell-id " not found in registry")
+                     {:id cell-id})))
+   (let [schema-map (schema/normalize-cell-schema schema-map)]
+     (when (:input schema-map)
+       (v/validate-malli-schema! (:input schema-map)
+                                 (str cell-id " :input")
+                                 opts))
+     (when (:output schema-map)
+       (v/validate-output-schema! (:output schema-map)
+                                  (str cell-id " :output")
+                                  opts))
+     (swap! cell-overrides update cell-id merge {:schema schema-map})
+     schema-map)))
 
 (defn set-cell-meta!
   "Sets metadata overrides (schema, requires) on a registered cell.
    The manifest calls this to inject metadata into cells that were registered
    without schemas/requires. Expects schemas to be pre-normalized.
-   Validates schema is well-formed. Throws if the cell is not found."
-  [cell-id {:keys [schema requires] :as meta-map}]
-  (when-not (cell-spec cell-id)
-    (throw (ex-info (str "Cell " cell-id " not found in registry")
-                    {:id cell-id})))
-  (when schema
-    (when (:input schema)
-      (v/validate-malli-schema! (:input schema) (str cell-id " :input")))
-    (when (:output schema)
-      (v/validate-output-schema! (:output schema) (str cell-id " :output"))))
-  (let [overrides (cond-> {}
-                    schema   (assoc :schema schema)
-                    requires (assoc :requires requires))]
-    (swap! cell-overrides update cell-id merge overrides))
-  meta-map)
+   Validates schema is well-formed. Throws if the cell is not found.
+   opts:
+     :malli/registry — local Malli registry used to validate named schemas."
+  ([cell-id meta-map]
+   (set-cell-meta! cell-id meta-map {}))
+  ([cell-id {:keys [schema requires] :as meta-map} opts]
+   (when-not (cell-spec cell-id)
+     (throw (ex-info (str "Cell " cell-id " not found in registry")
+                     {:id cell-id})))
+   (when schema
+     (when (:input schema)
+       (v/validate-malli-schema! (:input schema)
+                                 (str cell-id " :input")
+                                 opts))
+     (when (:output schema)
+       (v/validate-output-schema! (:output schema)
+                                  (str cell-id " :output")
+                                  opts)))
+   (let [overrides (cond-> {}
+                     schema   (assoc :schema schema)
+                     requires (assoc :requires requires))]
+     (swap! cell-overrides update cell-id merge overrides))
+   meta-map))
 
 (defn list-cells
   "Returns a seq of all registered cell IDs."

--- a/src/mycelium/cell.clj
+++ b/src/mycelium/cell.clj
@@ -1,7 +1,6 @@
 (ns mycelium.cell
   "Cell registry for Mycelium. Cells are registered via `defmethod cell-spec`."
-  (:require [mycelium.schema :as schema]
-            [mycelium.validation :as v]))
+  (:require [mycelium.validation :as v]))
 
 (defmulti cell-spec
   "Multimethod-backed cell registry. Dispatches on cell-id keyword,
@@ -48,7 +47,7 @@
    (when-not (cell-spec cell-id)
      (throw (ex-info (str "Cell " cell-id " not found in registry")
                      {:id cell-id})))
-   (let [schema-map (schema/normalize-cell-schema schema-map)]
+   (do
      (when (:input schema-map)
        (v/validate-malli-schema! (:input schema-map)
                                  (str cell-id " :input")
@@ -63,7 +62,8 @@
 (defn set-cell-meta!
   "Sets metadata overrides (schema, requires) on a registered cell.
    The manifest calls this to inject metadata into cells that were registered
-   without schemas/requires. Expects schemas to be pre-normalized.
+   without schemas/requires. Schemas are stored verbatim and compiled
+   at workflow boundaries.
    Validates schema is well-formed. Throws if the cell is not found.
    opts:
      :malli/registry — local Malli registry used to validate named schemas."
@@ -134,8 +134,7 @@
         opt-keys    #{:doc :requires :async?}
         raw-schema  (let [s (select-keys opts schema-keys)]
                       (when (seq s) s))
-        schema      (when raw-schema
-                      (schema/normalize-cell-schema raw-schema))
+        schema      raw-schema
         extra       (select-keys opts opt-keys)
         spec        (cond-> {:id cell-id :handler handler-fn :doc (:doc extra)}
                       schema (assoc :schema schema)

--- a/src/mycelium/compose.clj
+++ b/src/mycelium/compose.clj
@@ -82,8 +82,9 @@
       (schema/per-transition? output)
       output
 
-      ;; Caller provided a real schema — use it as :success, add :failure
-      (and (not (keyword? output)) (vector? output))
+      ;; Caller provided a real schema (Malli form or lite map) —
+      ;; use it as :success, add :failure
+      (and (not (keyword? output)) (or (vector? output) (map? output)))
       [:per-transition {:success output
                         :failure [:map [:mycelium/error :any]]}]
 
@@ -110,14 +111,13 @@
    `cell-id`  - the ID for the resulting cell
    `workflow`  - workflow definition map {:cells ... :edges ... :dispatches ...}
    `schema`    - {:input [...] :output [...]} for the cell.
-                 Lite map syntax is normalized automatically.
+                 Lite map schemas compile like any other form.
    opts:
      :malli/registry — local Malli registry captured during compilation."
   ([cell-id workflow schema-map]
    (workflow->cell cell-id workflow schema-map {}))
   ([cell-id workflow schema-map opts]
-   (let [schema-map (schema/normalize-cell-schema schema-map)
-         compiled (wf/compile-workflow
+   (let [compiled (wf/compile-workflow
                    workflow
                    (merge opts
                           {:on-error

--- a/src/mycelium/compose.clj
+++ b/src/mycelium/compose.clj
@@ -1,30 +1,27 @@
 (ns mycelium.compose
   "Hierarchical composition: wrapping workflows as cells for nesting."
-  (:require [mycelium.cell :as cell]
+  (:require [malli.core :as m]
+            [mycelium.cell :as cell]
             [mycelium.schema :as schema]
             [mycelium.workflow :as wf]
             [maestro.core :as fsm]
             [promesa.core :as p]))
 
 (defn- get-map-entries
-  "Extracts top-level entries from a Malli :map schema.
-   Handles both normalized [:map [:k v] ...] and lite syntax {:k v}.
-   Returns a vector of [key type] pairs, or nil if not a map schema."
+  "Extracts top-level entries from a resolved Malli :map schema.
+   Returns full entries with properties preserved, or nil if not a map schema."
   [schema]
-  (cond
-    ;; Standard Malli vector syntax: [:map [:k1 v1] [:k2 v2] ...]
-    (and (vector? schema) (= :map (first schema)))
-    (vec (keep (fn [entry]
-                 (when (vector? entry)
-                   [(first entry) (second entry)]))
-               (rest schema)))
-
-    ;; Lite map syntax: {:k1 v1 :k2 v2}
-    (map? schema)
-    (vec (map (fn [[k v]] [k v]) schema))))
+  (when schema
+    (let [schema (m/deref-all schema)]
+      (when (= :map (m/type schema))
+        (mapv (fn [[k properties child]]
+                (if properties
+                  [k properties child]
+                  [k child]))
+              (m/children schema))))))
 
 (defn- output-entries-for-edge
-  "Extracts [key type] entries from a cell's output schema for edges routing to :end."
+  "Extracts map entries from a cell's output schema for edges routing to :end."
   [output edge-def]
   (cond
     ;; Unconditional edge to :end
@@ -48,16 +45,24 @@
           (get-map-entries output))))))
 
 (defn- collect-end-reaching-output-entries
-  "Walks workflow edges to find cells routing to :end and collects their output entries.
-   Returns a vector of [key type] pairs representing the union of all outputs."
-  [edges cells]
+  "Walks workflow edges to find cells routing to :end and collects their resolved output entries.
+   Returns the union of full entries with properties preserved."
+  [edges cells opts]
   (->> edges
        (mapcat (fn [[cell-name edge-def]]
-                 (when-let [cell (some-> (get cells cell-name) cell/get-cell)]
-                   (some-> (get-in cell [:schema :output])
-                           (output-entries-for-edge edge-def)))))
-       (reduce (fn [m [k t]] (if (contains? m k) m (assoc m k t))) {})
-       vec))
+                 (let [cell-ref (get cells cell-name)
+                       cell-id  (if (map? cell-ref) (:id cell-ref) cell-ref)]
+                   (when-let [cell (some-> (cell/get-cell cell-id)
+                                           (schema/compile-cell-schemas opts))]
+                     (some-> (get-in cell [:schema :output])
+                             (output-entries-for-edge edge-def))))))
+       (reduce (fn [entries entry]
+                 (let [k (first entry)]
+                   (if (contains? entries k)
+                     entries
+                     (assoc entries k entry))))
+               {})
+       vals))
 
 (defn- infer-workflow-output-schema
   "Infers a per-transition output schema for a composed cell, wrapped
@@ -70,7 +75,7 @@
    :success schema. When the caller's schema is the bare :map keyword,
    we infer :success from the child workflow's end-reaching cells, and
    fall back to bare :map when there's nothing to infer."
-  [workflow schema]
+  [workflow schema opts]
   (let [output (:output schema)]
     (cond
       ;; Caller already passed an explicit per-transition wrapper — use it as-is.
@@ -83,7 +88,8 @@
                         :failure [:map [:mycelium/error :any]]}]
 
       :else
-      (let [entries (collect-end-reaching-output-entries (:edges workflow) (:cells workflow))]
+      (let [entries (collect-end-reaching-output-entries
+                     (:edges workflow) (:cells workflow) opts)]
         (if (seq entries)
           [:per-transition {:success (into [:map] entries)
                             :failure [:map [:mycelium/error :any]]}]
@@ -104,43 +110,54 @@
    `cell-id`  - the ID for the resulting cell
    `workflow`  - workflow definition map {:cells ... :edges ... :dispatches ...}
    `schema`    - {:input [...] :output [...]} for the cell.
-                 Lite map syntax is normalized automatically."
-  [cell-id workflow schema]
-  (let [schema (schema/normalize-cell-schema schema)
-        compiled (wf/compile-workflow workflow
-                                      {:on-error (fn [_ fsm-state]
-                                                   (-> (:data fsm-state)
-                                                       (assoc :mycelium/error
-                                                              (or (:error fsm-state)
-                                                                  (get-in fsm-state [:data :mycelium/schema-error])))
-                                                       (assoc :mycelium/child-trace
-                                                              (:trace fsm-state))))
-                                       :on-end (fn [_ fsm-state]
-                                                 (-> (:data fsm-state)
-                                                     (assoc :mycelium/child-trace
-                                                            (:trace fsm-state))))})
-        handler (fn [resources data]
-                  (try
-                    (let [result (fsm/run compiled resources {:data data})]
-                      (if (p/promise? result) @result result))
-                    (catch Exception e
-                      (-> data
-                          (assoc :mycelium/error (ex-message e))))))]
-    {:id                 cell-id
-     :handler            handler
-     ;; Infer per-transition output schema from child workflow's end-reaching cells.
-     ;; If the caller provided a proper [:map ...] vector, that takes precedence.
-     :schema             {:input (:input schema)
-                          :output (infer-workflow-output-schema workflow schema)}
-     :default-dispatches workflow-cell-dispatches}))
+                 Lite map syntax is normalized automatically.
+   opts:
+     :malli/registry — local Malli registry captured during compilation."
+  ([cell-id workflow schema-map]
+   (workflow->cell cell-id workflow schema-map {}))
+  ([cell-id workflow schema-map opts]
+   (let [schema-map (schema/normalize-cell-schema schema-map)
+         compiled (wf/compile-workflow
+                   workflow
+                   (merge opts
+                          {:on-error
+                           (fn [_ fsm-state]
+                             (-> (:data fsm-state)
+                                 (assoc :mycelium/error
+                                        (or (:error fsm-state)
+                                            (get-in fsm-state
+                                                    [:data :mycelium/schema-error])))
+                                 (assoc :mycelium/child-trace
+                                        (:trace fsm-state))))
+                           :on-end
+                           (fn [_ fsm-state]
+                             (-> (:data fsm-state)
+                                 (assoc :mycelium/child-trace
+                                        (:trace fsm-state))))}))
+         handler (fn [resources data]
+                   (try
+                     (let [result (fsm/run compiled resources {:data data})]
+                       (if (p/promise? result) @result result))
+                     (catch Exception e
+                       (assoc data :mycelium/error (ex-message e)))))]
+     {:id                 cell-id
+      :handler            handler
+      :schema             {:input (:input schema-map)
+                           :output (infer-workflow-output-schema
+                                    workflow schema-map opts)}
+      :default-dispatches workflow-cell-dispatches})))
 
 (defn register-workflow-cell!
   "Creates a workflow-as-cell and registers it in the cell registry.
 
    `cell-id`  - the ID for the resulting cell
    `workflow`  - workflow definition map {:cells ... :edges ... :dispatches ...}
-   `schema`    - {:input [...] :output [...]} for the cell"
-  [cell-id workflow schema]
-  (let [spec (workflow->cell cell-id workflow schema)]
-    (.addMethod cell/cell-spec cell-id (constantly spec))
-    spec))
+   `schema`    - {:input [...] :output [...]} for the cell
+   opts:
+     :malli/registry — local Malli registry captured during compilation."
+  ([cell-id workflow schema-map]
+   (register-workflow-cell! cell-id workflow schema-map {}))
+  ([cell-id workflow schema-map opts]
+   (let [spec (workflow->cell cell-id workflow schema-map opts)]
+     (.addMethod cell/cell-spec cell-id (constantly spec))
+     spec)))

--- a/src/mycelium/core.clj
+++ b/src/mycelium/core.clj
@@ -68,13 +68,13 @@
      :on-end   — custom end handler
      :coerce?  — auto-coerce numeric types (int↔double)
      :propagate-keys? — auto-merge input keys into handler output (default true)
-     :on-trace — callback (fn [trace-entry]) called after each cell completes"
+     :on-trace — callback (fn [trace-entry]) called after each cell completes
+     :malli/registry — local Malli registry captured during compilation"
   ([workflow-def] (pre-compile workflow-def {}))
   ([workflow-def opts]
    (let [compiled-fsm (compile-workflow workflow-def opts)
          input-schema-raw (:input-schema workflow-def)
-         input-schema-compiled (when input-schema-raw
-                                 (m/schema input-schema-raw))]
+         input-schema-compiled (schema/compile-schema input-schema-raw opts)]
      {:compiled-fsm         compiled-fsm
       :input-schema-raw     input-schema-raw
       :input-schema-compiled input-schema-compiled})))
@@ -167,7 +167,8 @@
      :on-end   — custom end handler
      :coerce?  — auto-coerce numeric types (int↔double)
      :propagate-keys? — auto-merge input keys into handler output (default true)
-     :on-trace — callback (fn [trace-entry]) called after each cell completes"
+     :on-trace — callback (fn [trace-entry]) called after each cell completes
+     :malli/registry — local Malli registry captured during compilation"
   ([workflow-def]
    (run-workflow workflow-def {} {} {}))
   ([workflow-def resources]
@@ -179,7 +180,8 @@
 
 (defn run-workflow-async
   "Like run-workflow but returns a future. Deref to get the final data map.
-   For repeated execution, use `pre-compile` + `run-compiled-async` instead."
+   For repeated execution, use `pre-compile` + `run-compiled-async` instead.
+   opts are passed to `run-workflow`."
   ([workflow-def]
    (run-workflow-async workflow-def {} {} {}))
   ([workflow-def resources]
@@ -221,16 +223,22 @@
                 :off skips :requires + schema checks; only the
                 cell-not-found check still fires (since the lookup is
                 needed to find the handler).
+    :malli/registry — local Malli registry used to compile cell schemas.
 
   Naming follows the rest of the Mycelium API (pre-compile, dev/test-cell)
   which uses plain `:validate` with keyword values rather than `:validate?`."
   ([cell-id resources data]
    (invoke-cell cell-id resources data {}))
-  ([cell-id resources data {:keys [validate] :or {validate :strict}}]
+  ([cell-id resources data {:keys [validate]
+                            :or {validate :strict}
+                            :as opts}]
    (let [cell (or (cell/get-cell cell-id)
                   (throw (ex-info (str "Cell not found in registry: " cell-id)
                                   {:type     :mycelium.invoke-cell/cell-not-found
-                                   :cell-id  cell-id})))]
+                                   :cell-id  cell-id})))
+         cell (if (= :strict validate)
+                (schema/compile-cell-schemas cell opts)
+                cell)]
      (when (= :strict validate)
        ;; :requires check
        (when-let [reqs (seq (:requires cell))]

--- a/src/mycelium/dev.clj
+++ b/src/mycelium/dev.clj
@@ -19,8 +19,11 @@
      :expected-dispatch   - if set, verifies the matched dispatch label
    Returns:
      {:pass? bool :errors [...] :output {...} :duration-ms n :matched-dispatch kw-or-nil}"
-  [cell-id {:keys [input resources dispatches expected-dispatch] :or {resources {}}}]
-  (let [cell       (cell/get-cell! cell-id)
+  [cell-id {:keys [input resources dispatches expected-dispatch]
+            :or {resources {}}
+            :as opts}]
+  (let [cell       (schema/compile-cell-schemas
+                    (cell/get-cell! cell-id) opts)
         start-time (System/nanoTime)
         ;; Validate input
         input-err  (schema/validate-input cell input)]
@@ -166,25 +169,34 @@
 
 (defn- generate-test-input
   "Generates test input data from a cell's input schema using Malli generators."
-  [cell]
+  [cell opts]
   (try
-    (mg/generate (m/schema (get-in cell [:schema :input])) {:size 3 :seed 42})
+    (mg/generate (schema/compile-schema
+                  (get-in cell [:schema :input]) opts)
+                 {:size 3 :seed 42})
     (catch Exception _
       {})))
 
 (defn workflow-status
   "Reports implementation status across all cells in a manifest.
-   Returns a map with :total, :implemented, :passing, :failing, :pending, :cells."
-  [{:keys [cells]}]
-  (let [cell-statuses
+   Returns a map with :total, :implemented, :passing, :failing, :pending, :cells.
+   opts:
+     :malli/registry — local Malli registry used to generate test data."
+  ([manifest]
+   (workflow-status manifest {}))
+  ([{:keys [cells]} opts]
+   (let [cell-statuses
         (mapv (fn [[cell-name cell-def]]
                 (let [cell-id (:id cell-def)
                       cell    (cell/get-cell cell-id)]
                   (if-not cell
                     {:id cell-id :name cell-name :status :pending}
                     (try
-                      (let [result (test-cell cell-id {:input     (generate-test-input cell)
-                                                       :resources {}})]
+                      (let [result (test-cell
+                                    cell-id
+                                    (assoc opts
+                                           :input (generate-test-input cell opts)
+                                           :resources {}))]
                         {:id     cell-id
                          :name   cell-name
                          :status (if (:pass? result) :passing :failing)
@@ -200,8 +212,8 @@
      :implemented (- (count cell-statuses) (get counts :pending 0))
      :passing     (get counts :passing 0)
      :failing     (get counts :failing 0)
-     :pending     (get counts :pending 0)
-     :cells       cell-statuses}))
+      :pending     (get counts :pending 0)
+      :cells       cell-statuses})))
 
 (defn analyze-workflow
   "Runs Maestro's static analysis on a workflow definition.
@@ -282,25 +294,21 @@
      :cycles         (mapv (fn [cycle] (mapv resolve-name cycle)) (:cycles analysis))}))
 
 (defn- get-map-keys
-  "Extracts top-level key names from a Malli schema. Returns #{} if not a map schema.
-   Handles both [:map [:k v] ...] and lite syntax {:k v}."
+  "Extracts top-level key names from a resolved Malli schema.
+   Returns #{} if the resolved schema is not a map schema."
   [schema]
-  (cond
-    (and (vector? schema) (= :map (first schema)))
-    (set (keep (fn [entry]
-                 (when (vector? entry)
-                   (first entry)))
-               (rest schema)))
-
-    (map? schema)
-    (set (keys schema))
-
-    :else #{}))
+  (if schema
+    (let [schema (m/deref-all schema)]
+      (if (= :map (m/type schema))
+        (into #{} (map first) (m/children schema))
+        #{}))
+    #{}))
 
 (defn- cell-output-keys
   "Returns the union of all output keys for a cell across all transitions."
-  [cell-id]
-  (let [cell   (cell/get-cell cell-id)
+  [cell-id opts]
+  (let [cell   (some-> (cell/get-cell cell-id)
+                       (schema/compile-cell-schemas opts))
         output (when cell (get-in cell [:schema :output]))]
     (cond
       (nil? output) #{}
@@ -314,17 +322,18 @@
 
 (defn- cell-input-keys
   "Returns the set of input keys for a cell."
-  [cell-id]
-  (let [cell (cell/get-cell cell-id)]
+  [cell-id opts]
+  (let [cell (some-> (cell/get-cell cell-id)
+                     (schema/compile-cell-schemas opts))]
     (when cell
       (get-map-keys (get-in cell [:schema :input])))))
 
 (defn- join-output-keys
   "Returns the union of output keys from all member cells of a join."
-  [join-def cells-map]
+  [join-def cells-map opts]
   (reduce (fn [acc member]
             (let [cell-id (get cells-map member)]
-              (set/union acc (cell-output-keys cell-id))))
+              (set/union acc (cell-output-keys cell-id opts))))
           #{}
           (:cells join-def)))
 
@@ -337,8 +346,10 @@
 
    Handles branching by taking the union of available keys from all incoming paths.
    Join nodes: union of all member output keys."
-  [{:keys [cells edges joins] :as _workflow-def}]
-  (let [joins-map (or joins {})
+  ([workflow]
+   (infer-workflow-schema workflow {}))
+  ([{:keys [cells edges joins]} opts]
+   (let [joins-map (or joins {})
         terminal? #{:end :error :halt}
         ;; Accumulate per-cell info via BFS
         result (atom {})
@@ -346,7 +357,7 @@
         available-before (atom {})
         ;; Start cell's input keys are the initial set
         start-cell-id (get cells :start)
-        start-input (or (cell-input-keys start-cell-id) #{})
+        start-input (or (cell-input-keys start-cell-id opts) #{})
         queue (atom [[:start start-input]])]
     (swap! available-before assoc :start start-input)
     (loop []
@@ -360,9 +371,9 @@
               (swap! available-before assoc cell-name merged-avail)
               ;; Compute output keys
               (let [adds (if-let [join-def (get joins-map cell-name)]
-                           (join-output-keys join-def cells)
+                           (join-output-keys join-def cells opts)
                            (let [cell-id (get cells cell-name)]
-                             (cell-output-keys cell-id)))
+                             (cell-output-keys cell-id opts)))
                     after (set/union merged-avail adds)]
                 ;; Record if first visit or if available-before expanded
                 (let [prev-record (get @result cell-name)]
@@ -380,7 +391,7 @@
                           (doseq [[_ target] edge-def]
                             (swap! queue conj [target after])))))))))))
         (recur)))
-    @result))
+     @result)))
 
 ;; ===== Stub generation =====
 

--- a/src/mycelium/fragment.clj
+++ b/src/mycelium/fragment.clj
@@ -6,17 +6,14 @@
             [clojure.set :as set]
             [mycelium.validation :as v]))
 
-;; ===== Fragment validation =====
-
-(defn- validate-cell-def!
-  "Validates a single cell definition within a fragment."
-  [cell-name cell-def]
-  (v/validate-cell-def! cell-name cell-def "Fragment cell"))
-
 (defn validate-fragment
   "Validates a fragment definition. Returns the fragment if valid, throws otherwise.
-   Checks: :entry, :exits, :cells, internal edge consistency."
-  [{:keys [id entry exits cells edges dispatches] :as fragment}]
+   Checks: :entry, :exits, :cells, internal edge consistency.
+   opts:
+     :malli/registry — local Malli registry used to validate cell schemas."
+  ([fragment]
+   (validate-fragment fragment {}))
+  ([{:keys [id entry exits cells edges dispatches] :as fragment} opts]
   (when-not entry
     (throw (ex-info (str "Fragment " (or id "unknown") " missing :entry")
                     {:fragment-id id})))
@@ -33,7 +30,7 @@
                     {:fragment-id id :entry entry})))
   ;; Validate each cell definition
   (doseq [[cell-name cell-def] cells]
-    (validate-cell-def! cell-name cell-def))
+    (v/validate-cell-def! cell-name cell-def "Fragment cell" opts))
   ;; Validate :on-error targets and edge targets
   (let [cell-names    (set (keys cells))
         exit-targets  (set (map #(keyword "_exit" (name %)) exits))
@@ -60,7 +57,7 @@
               (throw (ex-info (str "Fragment " (or id "unknown")
                                    " invalid edge target " target " from " from)
                               {:fragment-id id :from from :target target}))))))))
-  fragment)
+  fragment))
 
 ;; ===== Fragment expansion =====
 
@@ -68,9 +65,13 @@
   "Expands a single fragment into cells, edges, and dispatches.
    host-mapping: {:as :start, :exits {:success :render-dashboard, :failure :render-error}}
    host-cells: existing host cell names (set or map) to check for collisions.
-   Returns {:cells {...} :edges {...} :dispatches {...}}"
-  [fragment host-mapping host-cells]
-  (validate-fragment fragment)
+   Returns {:cells {...} :edges {...} :dispatches {...}}
+   opts:
+     :malli/registry — local Malli registry used to validate cell schemas."
+  ([fragment host-mapping host-cells]
+   (expand-fragment fragment host-mapping host-cells {}))
+  ([fragment host-mapping host-cells opts]
+  (validate-fragment fragment opts)
   (let [{:keys [entry exits cells edges dispatches]} fragment
         {:keys [as exits]} host-mapping
         ;; Validate all fragment exits are wired
@@ -131,7 +132,7 @@
                                   (or dispatches {}))]
     {:cells      expanded-cells
      :edges      expanded-edges
-     :dispatches expanded-dispatches}))
+     :dispatches expanded-dispatches})))
 
 (defn load-fragment
   "Loads a fragment from a resource path. Returns the parsed EDN."
@@ -152,8 +153,12 @@
 (defn expand-all-fragments
   "Expands all :fragments in a manifest, merging them into the manifest's cells/edges/dispatches.
    Each fragment mapping may specify :fragment (inline data) or :ref (resource path).
-   Returns the manifest with fragments expanded and :fragments key removed."
-  [{:keys [fragments cells edges dispatches] :as manifest}]
+   Returns the manifest with fragments expanded and :fragments key removed.
+   opts:
+     :malli/registry — local Malli registry used to validate cell schemas."
+  ([manifest]
+   (expand-all-fragments manifest {}))
+  ([{:keys [fragments cells edges dispatches] :as manifest} opts]
   (if (empty? fragments)
     manifest
     (let [result (reduce (fn [acc [_frag-name frag-mapping]]
@@ -161,7 +166,8 @@
                                  {:keys [as exits]} frag-mapping
                                  expansion (expand-fragment fragment
                                                            {:as as :exits exits}
-                                                           (:cells acc))]
+                                                           (:cells acc)
+                                                           opts)]
                              (-> acc
                                  (update :cells merge (:cells expansion))
                                  (update :edges merge (:edges expansion))
@@ -169,4 +175,4 @@
                          (-> manifest
                              (dissoc :fragments))
                          (sort-by first fragments))]
-      result)))
+     result))))

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -3,19 +3,11 @@
   (:require [clojure.edn :as edn]
             [clojure.set :as set]
             [clojure.string :as str]
-            [malli.core :as m]
             [malli.generator :as mg]
             [mycelium.cell :as cell]
             [mycelium.fragment :as fragment]
             [mycelium.schema :as schema]
             [mycelium.validation :as v]))
-
-;; ===== Cell definition validation =====
-
-(defn- validate-cell-def!
-  "Validates a single cell definition within a manifest."
-  [cell-name cell-def]
-  (v/validate-cell-def! cell-name cell-def "Cell"))
 
 (defn- resolve-inherit-schemas
   "Resolves :schema :inherit in cell definitions by looking up schemas from cell registry."
@@ -132,7 +124,8 @@
   "Validates a manifest structure. Returns the manifest if valid, throws otherwise.
    Optional opts map:
      :strict? — if true (default), requires :on-error on every cell.
-                Set to false to allow missing :on-error (legacy mode)."
+                Set to false to allow missing :on-error (legacy mode).
+     :malli/registry — local Malli registry used to validate schemas."
   ([manifest] (validate-manifest manifest {:strict? true}))
   ([manifest opts]
    (let [{:keys [id cells edges dispatches joins] :as manifest} (expand-pipeline manifest)]
@@ -156,7 +149,7 @@
            manifest (assoc manifest :cells cells)]
        ;; Validate each cell definition
        (doseq [[cell-name cell-def] cells]
-         (validate-cell-def! cell-name cell-def))
+         (v/validate-cell-def! cell-name cell-def "Cell" opts))
        ;; Validate :on-error declarations
        (validate-on-error! cells (:strict? opts))
        ;; Determine join members — cells consumed by joins don't need edges
@@ -196,7 +189,8 @@
          (v/validate-reachability! edges valid-names))
        ;; Validate :input-schema if present (normalize lite syntax first)
        (when-let [input-schema (:input-schema manifest)]
-         (v/validate-malli-schema! (schema/normalize-schema input-schema) "input-schema"))
+         (v/validate-malli-schema!
+          (schema/normalize-schema input-schema) "input-schema" opts))
        ;; Validate :regions if present
        (when-let [regions (:regions manifest)]
          (validate-regions! regions cells))
@@ -213,22 +207,28 @@
 
 (defn load-manifest
   "Loads and validates a manifest from an EDN file path.
-   If the manifest contains :fragments, expands them before validation."
-  [path]
-  (let [content (slurp path)
-        manifest (edn/read-string content)
-        expanded (if (:fragments manifest)
-                   (expand-fragments manifest)
-                   manifest)]
-    (validate-manifest expanded)))
+   If the manifest contains :fragments, expands them before validation.
+   opts:
+     :strict? — require :on-error on every cell.
+     :malli/registry — local Malli registry used to validate schemas."
+  ([path]
+   (load-manifest path {:strict? true}))
+  ([path opts]
+   (let [content  (slurp path)
+         manifest (edn/read-string content)
+         expanded (if (:fragments manifest)
+                    (expand-fragments manifest opts)
+                    manifest)]
+     (validate-manifest expanded opts))))
 
 ;; ===== Cell brief generation =====
 
 (defn- generate-example
   "Generates example data from a Malli schema."
-  [schema]
+  [schema-form opts]
   (try
-    (mg/generate (m/schema schema) {:size 3 :seed 42})
+    (mg/generate (schema/compile-schema schema-form opts)
+                 {:size 3 :seed 42})
     (catch Exception _
       {:example "could not generate"})))
 
@@ -246,19 +246,21 @@
 
 (defn- generate-output-examples
   "Generates output examples. For per-transition schemas, generates one per edge."
-  [output-schema edge-labels]
+  [output-schema edge-labels opts]
   (if-let [transitions (schema/transitions-map output-schema)]
     (into {}
           (map (fn [label]
-                 [label (generate-example (get transitions label))]))
+                 [label (generate-example (get transitions label) opts)]))
           (sort edge-labels))
-    (generate-example output-schema)))
+    (generate-example output-schema opts)))
 
 (defn cell-brief
   "Extracts a self-contained brief for a single cell from a manifest.
    Returns a map with :id, :doc, :schema, :requires, :examples, :prompt."
-  [manifest cell-name]
-  (let [cell-def    (get-in manifest [:cells cell-name])
+  ([manifest cell-name]
+   (cell-brief manifest cell-name {}))
+  ([manifest cell-name opts]
+   (let [cell-def    (get-in manifest [:cells cell-name])
         _           (when-not cell-def
                       (throw (ex-info (str "Cell " cell-name " not found in manifest")
                                       {:cell-name cell-name :manifest-id (:id manifest)})))
@@ -266,8 +268,9 @@
         edge-def    (get-in manifest [:edges cell-name])
         edge-labels (when (map? edge-def) (set (keys edge-def)))
         dispatches  (get-in manifest [:dispatches cell-name])
-        input-ex    (generate-example (:input schema))
-        output-ex   (generate-output-examples (:output schema) edge-labels)
+        input-ex    (generate-example (:input schema) opts)
+        output-ex   (generate-output-examples
+                     (:output schema) edge-labels opts)
         output-section (format-output-schema-section (:output schema) edge-labels)
         example-section (if (schema/per-transition? (:output schema))
                           (str/join "\n\n"
@@ -305,7 +308,7 @@
      :schema      schema
      :requires    (or requires [])
      :examples    {:input input-ex :output output-ex}
-     :prompt      prompt}))
+     :prompt      prompt})))
 
 ;; ===== Manifest → Workflow =====
 
@@ -316,14 +319,18 @@
    - If already registered, applies manifest metadata via `set-cell-meta!`.
    The manifest is the single source of truth for schemas and requires.
    Returns {:cells ... :edges ... :dispatches ...} suitable for `workflow/compile-workflow`."
-  [{:keys [cells edges dispatches] :as manifest}]
-  (let [cells    (resolve-inherit-schemas cells)
+  ([manifest]
+   (manifest->workflow manifest {}))
+  ([{:keys [cells edges dispatches] :as manifest} opts]
+   (let [cells    (resolve-inherit-schemas cells)
         cell-refs (into {}
                         (map (fn [[cell-name cell-def]]
                                (let [{:keys [id schema requires params]} cell-def]
                                  (if (cell/get-cell id)
-                                   (cell/set-cell-meta! id {:schema   schema
-                                                            :requires (or requires [])})
+                                   (cell/set-cell-meta! id
+                                                        {:schema   schema
+                                                         :requires (or requires [])}
+                                                        opts)
                                    (let [stub {:id      id
                                                :handler (fn [_ data] data)
                                                :schema  schema
@@ -343,4 +350,4 @@
       (:input-schema manifest) (assoc :input-schema (schema/normalize-schema (:input-schema manifest)))
       (:interceptors manifest) (assoc :interceptors (:interceptors manifest))
       (:resilience manifest) (assoc :resilience (:resilience manifest))
-      (:transforms manifest) (assoc :transforms (:transforms manifest)))))
+      (:transforms manifest) (assoc :transforms (:transforms manifest))))))

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -135,17 +135,8 @@
        (throw (ex-info "Manifest missing :cells" {:id id})))
      (when-not edges
        (throw (ex-info "Manifest missing :edges" {:id id})))
-     ;; Resolve :schema :inherit, then normalize lite syntax before validation
+     ;; Resolve :schema :inherit before validation
      (let [cells    (resolve-inherit-schemas cells)
-           cells    (into {}
-                          (map (fn [[cell-name cell-def]]
-                                 (if (or (= :inherit (:schema cell-def))
-                                         (nil? (:schema cell-def)))
-                                   [cell-name cell-def]
-                                   [cell-name (assoc cell-def :schema
-                                                     (schema/normalize-cell-schema
-                                                       (:schema cell-def)))])))
-                          cells)
            manifest (assoc manifest :cells cells)]
        ;; Validate each cell definition
        (doseq [[cell-name cell-def] cells]
@@ -187,10 +178,9 @@
                effective-dispatches (merge join-dispatches (or dispatches {}))]
            (v/validate-dispatch-coverage! edges effective-dispatches))
          (v/validate-reachability! edges valid-names))
-       ;; Validate :input-schema if present (normalize lite syntax first)
+       ;; Validate :input-schema if present
        (when-let [input-schema (:input-schema manifest)]
-         (v/validate-malli-schema!
-          (schema/normalize-schema input-schema) "input-schema" opts))
+         (v/validate-malli-schema! input-schema "input-schema" opts))
        ;; Validate :regions if present
        (when-let [regions (:regions manifest)]
          (validate-regions! regions cells))
@@ -347,7 +337,7 @@
              :edges edges}
       dispatches (assoc :dispatches dispatches)
       (:joins manifest) (assoc :joins (:joins manifest))
-      (:input-schema manifest) (assoc :input-schema (schema/normalize-schema (:input-schema manifest)))
+      (:input-schema manifest) (assoc :input-schema (:input-schema manifest))
       (:interceptors manifest) (assoc :interceptors (:interceptors manifest))
       (:resilience manifest) (assoc :resilience (:resilience manifest))
       (:transforms manifest) (assoc :transforms (:transforms manifest))))))

--- a/src/mycelium/orchestrate.clj
+++ b/src/mycelium/orchestrate.clj
@@ -6,24 +6,28 @@
 
 (defn cell-briefs
   "Returns a map of cell-name → brief for every cell in the manifest."
-  [manifest-data]
-  (into {}
-        (map (fn [[cell-name _]]
-               [cell-name (manifest/cell-brief manifest-data cell-name)]))
-        (:cells manifest-data)))
+  ([manifest-data]
+   (cell-briefs manifest-data {}))
+  ([manifest-data opts]
+   (into {}
+         (map (fn [[cell-name _]]
+                [cell-name (manifest/cell-brief manifest-data cell-name opts)]))
+         (:cells manifest-data))))
 
 (defn reassignment-brief
   "Generates a targeted brief that includes failure context.
    `error-context` should be {:error \"...\", :input {...}, :output {...}}"
-  [manifest-data cell-name {:keys [error input output]}]
-  (let [base-brief (manifest/cell-brief manifest-data cell-name)
-        error-section (str "\n\n## Previous Implementation Failed\n\n"
-                          "Error: " error "\n\n"
-                          "Given input: " (pr-str input) "\n\n"
-                          "Your handler returned: " (pr-str output) "\n\n"
-                          "Fix the handler to satisfy the output schema.\n")]
-    (assoc base-brief
-           :prompt (str (:prompt base-brief) error-section))))
+  ([manifest-data cell-name error-context]
+   (reassignment-brief manifest-data cell-name error-context {}))
+  ([manifest-data cell-name {:keys [error input output]} opts]
+   (let [base-brief (manifest/cell-brief manifest-data cell-name opts)
+         error-section (str "\n\n## Previous Implementation Failed\n\n"
+                            "Error: " error "\n\n"
+                            "Given input: " (pr-str input) "\n\n"
+                            "Your handler returned: " (pr-str output) "\n\n"
+                            "Fix the handler to satisfy the output schema.\n")]
+     (assoc base-brief
+            :prompt (str (:prompt base-brief) error-section)))))
 
 (defn region-brief
   "Generates a scoped brief for a named region in a manifest.
@@ -137,21 +141,23 @@
 
 (defn progress
   "Generates a human-readable progress report string."
-  [{:keys [id] :as manifest-data}]
-  (let [status (dev/workflow-status manifest-data)
-        {:keys [total implemented passing failing pending cells]} status]
-    (str "Workflow: " id "\n"
-         "Status: " passing "/" total " cells passing"
+  ([manifest-data]
+   (progress manifest-data {}))
+  ([{:keys [id] :as manifest-data} opts]
+   (let [status (dev/workflow-status manifest-data opts)
+         {:keys [total implemented passing failing pending cells]} status]
+     (str "Workflow: " id "\n"
+          "Status: " passing "/" total " cells passing"
          " | " total " total | " implemented " implemented | " pending " pending\n\n"
-         (str/join "\n"
-                   (map (fn [{:keys [id name status error errors]}]
-                          (let [tag (case status
-                                     :passing "[PASS]"
-                                     :failing "[FAIL]"
-                                     :pending "[    ]")]
-                            (str tag " " name " (" id ")"
-                                 (when (= status :failing)
-                                   (str " — " (or error
-                                                  (some-> errors first :detail :errors str)))))))
-                        cells))
-         "\n")))
+          (str/join "\n"
+                    (map (fn [{:keys [id name status error errors]}]
+                           (let [tag (case status
+                                      :passing "[PASS]"
+                                      :failing "[FAIL]"
+                                      :pending "[    ]")]
+                             (str tag " " name " (" id ")"
+                                  (when (= status :failing)
+                                    (str " — " (or error
+                                                   (some-> errors first :detail :errors str)))))))
+                         cells))
+          "\n"))))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -123,14 +123,15 @@
 (defn- schema-expected-keys
   "Extracts the set of required (non-optional) top-level keys from a :map schema."
   [schema]
-  (when (and schema (= :map (m/type schema)))
-    (into #{}
-          (keep (fn [child]
-                  (let [k    (first child)
-                        opts (when (= 3 (count child)) (second child))]
-                    (when-not (:optional opts)
-                      k))))
-          (m/children schema))))
+  (let [schema (some-> schema m/deref-all)]
+    (when (and schema (= :map (m/type schema)))
+      (into #{}
+            (keep (fn [child]
+                    (let [k    (first child)
+                          opts (when (= 3 (count child)) (second child))]
+                      (when-not (:optional opts)
+                        k))))
+            (m/children schema)))))
 
 (defn- compute-key-diff
   "Computes the difference between schema-expected keys and actual data keys.
@@ -328,39 +329,50 @@
            {:error (build-error-map (:id cell) :output explanation data)}
            {:data coerced}))))))
 
-(defn- compile-schema-value
-  "Compiles a single schema value to a Malli schema object if it's a raw form.
-   Returns the value unchanged if it's already compiled or nil."
-  [schema-val]
-  (cond
-    (nil? schema-val) nil
-    (m/schema? schema-val) schema-val
-    :else (m/schema schema-val)))
+(defn compile-schema
+  "Compiles a Malli schema form, resolving named refs against an optional
+   :malli/registry in opts. Already-compiled schemas and nil pass through."
+  ([schema-val]
+   (compile-schema schema-val {}))
+  ([schema-val opts]
+   (cond
+     (nil? schema-val)      nil
+     (m/schema? schema-val) schema-val
+     :else                  (m/schema
+                             schema-val
+                             (cond-> {}
+                               (:malli/registry opts)
+                               (assoc :registry (:malli/registry opts)))))))
+
+(defn ^:no-doc compile-cell-schemas
+  "Compiles the input and output schemas of one cell spec. Handles nil,
+   single schemas, and per-transition output schemas. Idempotent."
+  [cell opts]
+  (let [input  (get-in cell [:schema :input])
+        output (get-in cell [:schema :output])
+        compiled-output
+        (cond
+          (nil? output)            nil
+          (per-transition? output) [:per-transition
+                                    (update-vals (transitions-map output)
+                                                 #(compile-schema % opts))]
+          :else                    (compile-schema output opts))]
+    (cond-> cell
+      (some? input)           (assoc-in [:schema :input]
+                                        (compile-schema input opts))
+      (some? compiled-output) (assoc-in [:schema :output] compiled-output))))
 
 (defn pre-compile-schemas
   "Pre-compiles all Malli schemas in a state->cell map.
    Converts raw schema forms (vectors, keywords) into compiled Malli schema objects
    so that validate-input/validate-output don't re-parse them on every call.
-   Returns an updated state->cell map with compiled schemas."
-  [state->cell]
-  (into {}
-        (map (fn [[state-id cell]]
-               (let [input  (get-in cell [:schema :input])
-                     output (get-in cell [:schema :output])
-                     compiled-input  (compile-schema-value input)
-                     compiled-output (cond
-                                      (nil? output)            nil
-                                      (per-transition? output) [:per-transition
-                                                                (into {}
-                                                                      (map (fn [[k v]]
-                                                                             [k (compile-schema-value v)]))
-                                                                      (transitions-map output))]
-                                      :else                    (compile-schema-value output))
-                     updated-cell (cond-> cell
-                                    compiled-input  (assoc-in [:schema :input] compiled-input)
-                                    (some? compiled-output) (assoc-in [:schema :output] compiled-output))]
-                 [state-id updated-cell])))
-        state->cell))
+   Returns an updated state->cell map with compiled schemas.
+   opts:
+     :malli/registry — local Malli registry used to resolve named schemas."
+  ([state->cell]
+   (pre-compile-schemas state->cell {}))
+  ([state->cell opts]
+   (update-vals state->cell #(compile-cell-schemas % opts))))
 
 (defn- extract-cell-path
   "Extracts a vector of cell names from the :mycelium/trace in data."
@@ -547,10 +559,16 @@
   "Wraps an async cell's callback to validate output before forwarding.
    If validation fails, calls error-callback with an ex-info.
    For per-transition output schemas, falls back to 'any schema matches' validation
-   since the transition target is not known until dispatch."
-  [cell original-callback error-callback]
-  (fn [data]
-    (if-let [error (validate-output cell data)]
-      (error-callback (ex-info (str "Output validation failed for " (:id cell))
-                               error))
-      (original-callback data))))
+   since the transition target is not known until dispatch.
+   opts:
+     :malli/registry — local Malli registry used to compile cell schemas."
+  ([cell original-callback error-callback]
+   (wrap-async-callback cell original-callback error-callback {}))
+  ([cell original-callback error-callback opts]
+   (let [cell (compile-cell-schemas cell opts)]
+     (fn [data]
+       (if-let [error (validate-output cell data)]
+         (error-callback
+          (ex-info (str "Output validation failed for " (:id cell))
+                   error))
+         (original-callback data))))))

--- a/src/mycelium/schema.clj
+++ b/src/mycelium/schema.clj
@@ -6,6 +6,7 @@
             [clojure.string :as str]
             [malli.core :as m]
             [malli.error :as me]
+            [malli.experimental.lite :as l]
             [malli.transform :as mt]
             [maestro.core :as fsm]))
 
@@ -41,79 +42,6 @@
   [output]
   (when (per-transition? output)
     (second output)))
-
-;; ===== Lite schema normalization =====
-
-(defn normalize-schema
-  "Normalizes a schema that may be in lite syntax to standard Malli.
-   - Plain maps become [:map [:k1 v1] [:k2 v2] ...] with values recursively normalized
-   - Vectors are recursed into so nested lite maps inside [:vector {...}] etc. are normalized
-   - Keywords and nil pass through unchanged
-   Examples:
-     {:subtotal :double}             → [:map [:subtotal :double]]
-     {:address {:street :string}}    → [:map [:address [:map [:street :string]]]]
-     [:vector {:x :int :y :string}]  → [:vector [:map [:x :int] [:y :string]]]
-     [:map [:x :int]]                → [:map [:x :int]]
-     :int                            → :int"
-  [schema]
-  (cond
-    (nil? schema) nil
-    (map? schema) (into [:map] (map (fn [[k v]] [k (normalize-schema v)])) schema)
-    (vector? schema) (mapv (fn [element]
-                             (if (and (vector? element)
-                                      (keyword? (first element)))
-                               ;; This is a [:key type] entry — normalize the type
-                               (if (= 2 (count element))
-                                 [(first element) (normalize-schema (second element))]
-                                 ;; 3-element entry: [:key opts type]
-                                 (if (= 3 (count element))
-                                   [(first element) (second element) (normalize-schema (nth element 2))]
-                                   element))
-                               ;; Non-entry element (type tag, property map, or nested schema)
-                               (normalize-schema element)))
-                           schema)
-    :else schema))
-
-(defn normalize-output-schema
-  "Normalizes an output schema:
-    * `[:per-transition {tx schema, ...}]` — each transition's
-      schema is normalized in place; the wrapper is preserved.
-    * `[:map ...]` and other Malli vector schemas — pass through.
-    * `{:k schema, :k2 schema, ...}` — lite map syntax, normalized
-      to `[:map [:k schema] [:k2 schema] ...]`.
-
-  Throws on a malformed `[:per-transition ...]` wrapper (anything
-  other than `[:per-transition {...}]`)."
-  [schema]
-  (cond
-    (nil? schema) nil
-
-    (per-transition? schema)
-    [:per-transition (into {} (map (fn [[k v]] [k (normalize-schema v)]))
-                           (transitions-map schema))]
-
-    (and (vector? schema) (= :per-transition (first schema)))
-    (throw (ex-info
-             (str "Malformed [:per-transition ...] output schema. "
-                  "Expected [:per-transition {transition-label schema, ...}], got: "
-                  (pr-str schema))
-             {:schema schema}))
-
-    (vector? schema) schema
-
-    (map? schema) (normalize-schema schema)
-
-    :else schema))
-
-(defn normalize-cell-schema
-  "Normalizes a cell's :schema map, converting lite syntax to Malli."
-  [schema]
-  (when schema
-    (let [input  (:input schema)
-          output (:output schema)]
-      (cond-> schema
-        input  (assoc :input (normalize-schema input))
-        output (assoc :output (normalize-output-schema output))))))
 
 (def ^:private terminal-states
   #{::fsm/end ::fsm/error ::fsm/halt})
@@ -331,18 +259,19 @@
 
 (defn compile-schema
   "Compiles a Malli schema form, resolving named refs against an optional
-   :malli/registry in opts. Already-compiled schemas and nil pass through."
+   :malli/registry in opts. Already-compiled schemas and nil pass through.
+   Plain maps are malli.experimental.lite syntax and compile through
+   l/schema, so a lite map anywhere a schema is expected just works."
   ([schema-val]
    (compile-schema schema-val {}))
   ([schema-val opts]
    (cond
      (nil? schema-val)      nil
      (m/schema? schema-val) schema-val
-     :else                  (m/schema
-                             schema-val
-                             (cond-> {}
-                               (:malli/registry opts)
-                               (assoc :registry (:malli/registry opts)))))))
+     :else                  (binding [l/*options*
+                                      (when-let [registry (:malli/registry opts)]
+                                        {:registry registry})]
+                              (l/schema schema-val)))))
 
 (defn ^:no-doc compile-cell-schemas
   "Compiles the input and output schemas of one cell spec. Handles nil,
@@ -356,6 +285,12 @@
           (per-transition? output) [:per-transition
                                     (update-vals (transitions-map output)
                                                  #(compile-schema % opts))]
+          (and (vector? output) (= :per-transition (first output)))
+          (throw (ex-info
+                  (str "Malformed [:per-transition ...] output schema. "
+                       "Expected [:per-transition {transition-label schema, ...}], got: "
+                       (pr-str output))
+                  {:schema output}))
           :else                    (compile-schema output opts))]
     (cond-> cell
       (some? input)           (assoc-in [:schema :input]

--- a/src/mycelium/validation.clj
+++ b/src/mycelium/validation.clj
@@ -54,7 +54,6 @@
 (defn validate-cell-def!
   "Validates a single cell definition (manifest or fragment).
    Checks :id, :doc, and :schema presence, validates Malli schemas.
-   Expects schemas to be pre-normalized (lite syntax already converted).
    Skips schema validation for :schema :inherit (resolved separately).
    `context` is a string prefix for error messages (e.g. \"Cell\" or \"Fragment cell\").
    opts:

--- a/src/mycelium/validation.clj
+++ b/src/mycelium/validation.clj
@@ -3,22 +3,27 @@
    Provides schema well-formedness checks, edge target validation,
    BFS reachability, and dispatch coverage verification."
   (:require [clojure.set :as set]
-            [malli.core :as m]))
+            [mycelium.schema :as schema]))
 
 ;; ===== Schema well-formedness =====
 
 (defn validate-malli-schema!
   "Validates that a Malli schema definition is well-formed.
    Returns nil on success, throws on invalid schema.
-   `label` is included in the error message for diagnostics."
-  [schema label]
-  (try
-    (m/schema schema)
-    nil
-    (catch Exception e
-      (throw (ex-info (str "Invalid Malli schema for " label ": " (ex-message e))
-                      {:label label :schema schema}
-                      e)))))
+   `label` is included in the error message for diagnostics.
+   opts:
+     :malli/registry — local Malli registry used to resolve named schemas."
+  ([schema-form label]
+   (validate-malli-schema! schema-form label {}))
+  ([schema-form label opts]
+   (try
+     (schema/compile-schema schema-form opts)
+     nil
+     (catch Exception e
+       (throw (ex-info (str "Invalid Malli schema for " label ": "
+                            (ex-message e))
+                       {:label label :schema schema-form}
+                       e))))))
 
 (defn- per-transition-output?
   "True when `output-schema` is in explicit per-transition form.
@@ -33,12 +38,16 @@
 (defn validate-output-schema!
   "Validates an output schema: either a single Malli schema, or an
    explicit per-transition wrapper [:per-transition {tx schema, ...}]
-   whose inner values are each Malli schemas."
-  [output-schema label]
-  (if (per-transition-output? output-schema)
-    (doseq [[k v] (second output-schema)]
-      (validate-malli-schema! v (str label " transition " k)))
-    (validate-malli-schema! output-schema label)))
+   whose inner values are each Malli schemas.
+   opts:
+     :malli/registry — local Malli registry used to resolve named schemas."
+  ([output-schema label]
+   (validate-output-schema! output-schema label {}))
+  ([output-schema label opts]
+   (if (per-transition-output? output-schema)
+     (doseq [[k v] (second output-schema)]
+       (validate-malli-schema! v (str label " transition " k) opts))
+     (validate-malli-schema! output-schema label opts))))
 
 ;; ===== Cell definition validation =====
 
@@ -47,25 +56,36 @@
    Checks :id, :doc, and :schema presence, validates Malli schemas.
    Expects schemas to be pre-normalized (lite syntax already converted).
    Skips schema validation for :schema :inherit (resolved separately).
-   `context` is a string prefix for error messages (e.g. \"Cell\" or \"Fragment cell\")."
-  [cell-name cell-def context]
-  (when-not (:id cell-def)
-    (throw (ex-info (str context " " cell-name " missing :id") {:cell-name cell-name})))
-  (when-not (and (string? (:doc cell-def)) (seq (:doc cell-def)))
-    (throw (ex-info (str context " " cell-name " missing :doc — provide a non-empty string "
-                         "describing the cell's purpose and semantics")
-                    {:cell-name cell-name})))
-  (when-not (:schema cell-def)
-    (throw (ex-info (str context " " cell-name " missing :schema") {:cell-name cell-name})))
-  (when-not (= :inherit (:schema cell-def))
-    (let [input  (get-in cell-def [:schema :input])
-          output (get-in cell-def [:schema :output])]
-      (when-not input
-        (throw (ex-info (str context " " cell-name " missing :schema :input") {:cell-name cell-name})))
-      (when-not output
-        (throw (ex-info (str context " " cell-name " missing :schema :output") {:cell-name cell-name})))
-      (validate-malli-schema! input (str cell-name " :input"))
-      (validate-output-schema! output (str cell-name " :output")))))
+   `context` is a string prefix for error messages (e.g. \"Cell\" or \"Fragment cell\").
+   opts:
+     :malli/registry — local Malli registry used to resolve named schemas."
+  ([cell-name cell-def context]
+   (validate-cell-def! cell-name cell-def context {}))
+  ([cell-name cell-def context opts]
+   (when-not (:id cell-def)
+     (throw (ex-info (str context " " cell-name " missing :id")
+                     {:cell-name cell-name})))
+   (when-not (and (string? (:doc cell-def)) (seq (:doc cell-def)))
+     (throw (ex-info (str context " " cell-name
+                          " missing :doc — provide a non-empty string "
+                          "describing the cell's purpose and semantics")
+                     {:cell-name cell-name})))
+   (when-not (:schema cell-def)
+     (throw (ex-info (str context " " cell-name " missing :schema")
+                     {:cell-name cell-name})))
+   (when-not (= :inherit (:schema cell-def))
+     (let [input  (get-in cell-def [:schema :input])
+           output (get-in cell-def [:schema :output])]
+       (when-not input
+         (throw (ex-info (str context " " cell-name
+                              " missing :schema :input")
+                         {:cell-name cell-name})))
+       (when-not output
+         (throw (ex-info (str context " " cell-name
+                              " missing :schema :output")
+                         {:cell-name cell-name})))
+       (validate-malli-schema! input (str cell-name " :input") opts)
+       (validate-output-schema! output (str cell-name " :output") opts)))))
 
 ;; ===== Edge target validation =====
 

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -2,6 +2,7 @@
   "Workflow DSL compiler: transforms workflow definitions into Maestro FSM specs."
   (:require [clojure.set :as set]
             [clojure.string :as str]
+            [malli.core :as m]
             [mycelium.cell :as cell]
             [mycelium.resilience :as resilience]
             [mycelium.schema :as schema]
@@ -35,6 +36,21 @@
   (into {} (map (fn [[cell-name cell-ref]]
                   [cell-name (:id (normalize-cell-ref cell-name cell-ref))]))
         cells))
+
+(defn- resolve-cells
+  "Looks up each cell once and compiles its schemas with `opts`."
+  [cell-ids opts]
+  (update-vals
+   cell-ids
+   (fn [cell-id]
+     (let [cell (cell/get-cell! cell-id)]
+       (try
+         (schema/compile-cell-schemas cell opts)
+         (catch Exception e
+           (throw (ex-info (str "Invalid schema for cell " cell-id ": "
+                                (ex-message e))
+                           {:cell-id cell-id}
+                           e))))))))
 
 (defn- cells->params
   "Extracts a {cell-name → params} map from cells, only for cells with params."
@@ -85,10 +101,10 @@
 ;; ===== Schema key utilities =====
 
 (defn- get-map-keys
-  "Extracts top-level keys from a Malli :map schema. Returns nil if
+  "Extracts top-level keys from a resolved Malli :map schema. Returns nil if
   not a map schema.
 
-  Handles both normalized `[:map [:k v] ...]` and lite syntax `{:k v}`.
+  Dereferences named schemas before reading their map entries.
   Skips Malli property maps (e.g. `{:closed true}` in
   `[:map {:closed true} [:x :int]]`).
 
@@ -97,32 +113,24 @@
   validator uses :include-optional? false when collecting a cell's
   REQUIRED inputs, so that upstream cells aren't forced to produce
   keys the downstream cell has declared optional."
-  ([schema] (get-map-keys schema {}))
+  ([schema]
+   (get-map-keys schema {}))
   ([schema {:keys [include-optional?] :or {include-optional? true}}]
-   (cond
-     ;; Standard Malli vector syntax: [:map [:k1 v1] [:k1 opts v1] ...]
-     (and (vector? schema) (= :map (first schema)))
-     (set (keep (fn [entry]
-                  (when (vector? entry)
-                    (let [k    (first entry)
-                          opts (when (and (= 3 (count entry))
-                                          (map? (second entry)))
-                                 (second entry))]
-                      (when (or include-optional? (not (:optional opts)))
-                        k))))
-                (rest schema)))
-
-     ;; Lite map syntax: {:k1 v1 :k2 v2}. Lite syntax has no
-     ;; per-key optional modifier — every key is required.
-     (map? schema)
-     (set (keys schema)))))
+   (when schema
+     (let [schema (m/deref-all schema)]
+       (when (= :map (m/type schema))
+         (into #{}
+               (keep (fn [[k properties _]]
+                       (when (or include-optional?
+                                 (not (:optional properties)))
+                         k)))
+               (m/children schema)))))))
 
 (defn- get-required-input-keys
   "Required (non-optional) input keys for a cell."
-  [cell-id]
-  (let [cell   (cell/get-cell! cell-id)
-        schema (get-in cell [:schema :input])]
-    (get-map-keys schema {:include-optional? false})))
+  [cell]
+  (get-map-keys (get-in cell [:schema :input])
+                {:include-optional? false}))
 
 (defn- per-transition-output? [output]
   (schema/per-transition? output))
@@ -137,17 +145,16 @@
    transition (or the union across transitions when the transition
    isn't present — handles composed cells where the parent workflow's
    edge labels don't match the composed cell's transitions)."
-  [cell-id transition]
-  (let [cell   (cell/get-cell! cell-id)
-        output (get-in cell [:schema :output])]
+  [cell transition]
+  (let [output (get-in cell [:schema :output])]
     (cond
       (nil? output) nil
 
       (per-transition-output? output)
-      (if-let [schema (get (transitions output) transition)]
-        (get-map-keys schema)
-        (reduce (fn [acc [_ schema]]
-                  (into acc (get-map-keys schema)))
+      (if-let [output-schema (get (transitions output) transition)]
+        (get-map-keys output-schema)
+        (reduce (fn [acc [_ output-schema]]
+                  (into acc (get-map-keys output-schema)))
                 #{}
                 (transitions output)))
 
@@ -156,15 +163,14 @@
 (defn- get-all-output-keys
   "Gets the union of all output keys across all transitions.
    Used for unconditional edges where all transitions route to the same target."
-  [cell-id]
-  (let [cell   (cell/get-cell! cell-id)
-        output (get-in cell [:schema :output])]
+  [cell]
+  (let [output (get-in cell [:schema :output])]
     (cond
       (nil? output) nil
 
       (per-transition-output? output)
-      (reduce (fn [acc [_ schema]]
-                (into acc (get-map-keys schema)))
+      (reduce (fn [acc [_ output-schema]]
+                (into acc (get-map-keys output-schema)))
               #{}
               (transitions output))
 
@@ -172,19 +178,8 @@
 
 (defn- get-join-member-output-keys
   "Gets the union of all output keys from a single join member cell."
-  [cell-id]
-  (let [cell   (cell/get-cell! cell-id)
-        output (get-in cell [:schema :output])]
-    (cond
-      (nil? output) #{}
-
-      (per-transition-output? output)
-      (reduce (fn [acc [_ schema]]
-                (into acc (or (get-map-keys schema) #{})))
-              #{}
-              (transitions output))
-
-      :else (or (get-map-keys output) #{}))))
+  [cell]
+  (or (get-all-output-keys cell) #{}))
 
 ;; ===== Join validation =====
 
@@ -248,8 +243,9 @@
     (when-not (:merge-fn join-def)
       (let [member-cells (:cells join-def)
             cell-key-pairs (mapv (fn [member]
-                                   (let [cell-id (get cells member)]
-                                     [member (get-join-member-output-keys cell-id)]))
+                                   [member
+                                    (get-join-member-output-keys
+                                     (get cells member))])
                                  member-cells)]
         ;; Check for overlapping keys between any pair
         (doseq [i (range (count cell-key-pairs))
@@ -301,7 +297,8 @@
         strategy     (:strategy join-def :parallel)
         merge-fn     (:merge-fn join-def)
         timeout-ms   (:timeout-ms join-def default-async-timeout-ms)
-        member-cells (mapv (fn [m] {:name m :cell (cell/get-cell! (get cells-map m))})
+        member-cells (mapv (fn [member]
+                             {:name member :cell (get cells-map member)})
                            member-names)]
     (fn [resources data]
       (let [snapshot data ;; each branch gets the same snapshot
@@ -346,43 +343,47 @@
         (assoc merged-data :mycelium/join-traces join-traces)))))
 
 (defn- get-map-entries
-  "Extracts top-level entries from a Malli :map schema as a map of {key -> type-schema}.
-   Returns {} if not a :map schema."
+  "Extracts top-level entries from a resolved Malli :map schema.
+   Returns full entries with properties preserved, or [] if not a :map schema."
   [schema]
-  (if (and (vector? schema) (= :map (first schema)))
-    (into {}
-          (keep (fn [entry]
-                  (when (and (vector? entry) (>= (count entry) 2))
-                    [(first entry) (second entry)])))
-          (rest schema))
-    {}))
+  (if schema
+    (let [schema (m/deref-all schema)]
+      (if (= :map (m/type schema))
+        (mapv (fn [[k properties child]]
+                (if properties
+                  [k properties child]
+                  [k child]))
+              (m/children schema))
+        []))
+    []))
 
 (defn- build-join-input-schema
   "Builds a synthesized input schema for a join node.
-   Union of all member cells' input keys with their actual types preserved.
+   Union of all member cells' input entries with their actual types and properties preserved.
    When the same key appears in multiple members with different types,
    the first type encountered wins (they must be compatible for the
    workflow to function correctly)."
   [join-def cells-map]
-  (let [member-names (:cells join-def)
-        all-entries (reduce (fn [acc member]
-                              (let [cell (cell/get-cell! (get cells-map member))
-                                    schema (get-in cell [:schema :input])
-                                    entries (get-map-entries schema)]
-                                ;; merge — first type wins for duplicate keys
-                                (merge entries acc)))
-                            {}
-                            member-names)]
+  (let [all-entries
+        (reduce (fn [acc member]
+                  (let [entries (get-map-entries
+                                 (get-in cells-map
+                                         [member :schema :input]))
+                        entries-by-key (into {}
+                                             (map (juxt first identity))
+                                             entries)]
+                    (merge entries-by-key acc)))
+                {}
+                (:cells join-def))]
     (if (empty? all-entries)
       [:map]
-      (into [:map] (mapv (fn [[k t]] [k t]) all-entries)))))
+      (into [:map] (vals all-entries)))))
 
 (defn- build-join-output-keys
   "Gets the union of all output keys from all join member cells."
   [join-def cells-map]
   (reduce (fn [acc member]
-            (let [cell-id (get cells-map member)]
-              (into acc (get-join-member-output-keys cell-id))))
+            (into acc (get-join-member-output-keys (get cells-map member))))
           #{}
           (:cells join-def)))
 
@@ -486,19 +487,56 @@
           (or dispatches-map {})
           edges-map))
 
+(defn- resolve-schema-form
+  "Normalizes top-level lite syntax and compiles one transform schema."
+  [form opts]
+  (some-> (if (map? form) (schema/normalize-schema form) form)
+          (schema/compile-schema opts)))
+
+(defn- resolve-transform-spec [spec opts]
+  (if-let [schemas (:schema spec)]
+    (assoc spec :schema
+           (reduce (fn [resolved k]
+                     (if (contains? resolved k)
+                       (update resolved k resolve-schema-form opts)
+                       resolved))
+                   schemas
+                   [:input :output]))
+    spec))
+
+(defn- resolve-transforms
+  "Compiles every transform input and output schema once."
+  [transforms opts]
+  (update-vals
+   transforms
+   (fn [transform-def]
+     (update-vals
+      transform-def
+      (fn [entry]
+        (cond
+          (and (map? entry) (contains? entry :fn))
+          (resolve-transform-spec entry opts)
+
+          (map? entry)
+          (update-vals entry #(resolve-transform-spec % opts))
+
+          :else entry))))))
+
 (defn- get-transform-output-keys
   "Extracts output keys from a transform spec's :schema :output, if present."
   [transform-spec]
-  (when-let [schema (get-in transform-spec [:schema :output])]
-    (get-map-keys schema)))
+  (some-> transform-spec
+          (get-in [:schema :output])
+          get-map-keys))
 
 (defn- get-transform-input-keys
   "Extracts required input keys from a transform spec's :schema :input,
    if present. Optional keys are filtered out so the schema-chain
    validator doesn't demand them from upstream producers."
   [transform-spec]
-  (when-let [schema (get-in transform-spec [:schema :input])]
-    (get-map-keys schema {:include-optional? false})))
+  (some-> transform-spec
+          (get-in [:schema :input])
+          (get-map-keys {:include-optional? false})))
 
 (defn- validate-schema-chain!
   "Walks all paths from :start, accumulating output keys.
@@ -513,8 +551,7 @@
    (let [;; Required (non-optional) input keys only. A downstream
          ;; cell that declares `[:k {:optional true} ...]` doesn't
          ;; force upstream cells to produce :k.
-         get-input-keys  (fn [cell-id]
-                           (get-required-input-keys cell-id))
+         get-input-keys get-required-input-keys
          errors (atom [])
          visit  (fn visit [cell-name available-keys visited]
                   (when-not (or (contains? visited cell-name)
@@ -524,14 +561,14 @@
                       (let [member-names (:cells join-def)]
                         ;; Validate each member's input keys against available
                         (doseq [member member-names]
-                          (let [cell-id    (get cells-map member)
-                                input-keys (get-input-keys cell-id)
+                          (let [cell       (get cells-map member)
+                                input-keys (get-input-keys cell)
                                 missing    (when input-keys
                                              (set/difference input-keys available-keys))]
                             (when (seq missing)
                               (swap! errors conj
                                      {:cell-name     member
-                                      :cell-id       cell-id
+                                      :cell-id       (:id cell)
                                       :missing-keys  missing
                                       :available-keys available-keys}))))
                         ;; Accumulate union of all member output keys
@@ -543,7 +580,7 @@
                             (doseq [[_transition target] edge-def]
                               (visit target new-keys (conj visited cell-name))))))
                       ;; Regular cell
-                      (let [cell-id     (get cells-map cell-name)
+                      (let [cell        (get cells-map cell-name)
                             ;; If cell has an input transform, check transform's input keys instead
                             xf-def      (get transforms cell-name)
                             input-xf    (when xf-def
@@ -552,20 +589,20 @@
                                               nil))
                             effective-input-keys (if input-xf
                                                    (get-transform-input-keys input-xf)
-                                                   (get-input-keys cell-id))
+                                                   (get-input-keys cell))
                             missing     (when effective-input-keys
                                           (set/difference effective-input-keys available-keys))]
                         (when (seq missing)
                           (swap! errors conj
                                  {:cell-name     cell-name
-                                  :cell-id       cell-id
+                                  :cell-id       (:id cell)
                                   :missing-keys  missing
                                   :available-keys available-keys}))
                         ;; Traverse edges, using per-transition output keys
                         (let [edge-def (get edges-map cell-name)]
                           (if (keyword? edge-def)
                             ;; Unconditional edge — use union of all output keys
-                            (let [out-keys (get-all-output-keys cell-id)
+                            (let [out-keys (get-all-output-keys cell)
                                   ;; Add output transform keys if present
                                   xf-out-keys (when-let [xf (:output xf-def)]
                                                 (get-transform-output-keys xf))
@@ -575,7 +612,7 @@
                               (visit edge-def new-keys (conj visited cell-name)))
                             ;; Map edges — per-transition output keys
                             (doseq [[transition target] edge-def]
-                              (let [out-keys (get-output-keys-for-transition cell-id transition)
+                              (let [out-keys (get-output-keys-for-transition cell transition)
                                     ;; Add per-edge output transform keys if present
                                     xf-out-keys (when-let [edge-xf (get xf-def transition)]
                                                   (get-transform-output-keys (:output edge-xf)))
@@ -584,13 +621,13 @@
                                                            (or xf-out-keys #{})))]
                                 (visit target new-keys (conj visited cell-name))))))))))]
      ;; Start with :start cell
-     (let [start-cell-id    (get cells-map :start)
-           start-input-keys (when start-cell-id (get-input-keys start-cell-id))
+     (let [start-cell       (get cells-map :start)
+           start-input-keys (when start-cell (get-input-keys start-cell))
            initial-keys     (or start-input-keys #{})
            edge-def         (get edges-map :start)
            xf-def           (get transforms :start)]
        (if (keyword? edge-def)
-         (let [out-keys (get-all-output-keys start-cell-id)
+         (let [out-keys (get-all-output-keys start-cell)
                xf-out-keys (when-let [xf (:output xf-def)]
                              (get-transform-output-keys xf))
                new-keys (into initial-keys
@@ -598,7 +635,7 @@
                                       (or xf-out-keys #{})))]
            (visit edge-def new-keys #{:start}))
          (doseq [[transition target] edge-def]
-           (let [out-keys (get-output-keys-for-transition start-cell-id transition)
+           (let [out-keys (get-output-keys-for-transition start-cell transition)
                  xf-out-keys (when-let [edge-xf (get xf-def transition)]
                                (get-transform-output-keys (:output edge-xf)))
                  new-keys (into initial-keys
@@ -952,83 +989,88 @@
 
 (defn validate-workflow
   "Runs all validations on a workflow definition.
-   Merges :default-dispatches from cell specs as fallback for cells without explicit dispatches."
-  [{:keys [cells edges dispatches joins input-schema pipeline] :as raw-workflow}]
-  (let [{:keys [cells edges dispatches joins input-schema]} (expand-pipeline raw-workflow)]
-    (validate-cells-exist! cells)
-    ;; Validate and expand error groups (must happen before edge/dispatch validation)
-    (let [error-groups (or (:error-groups raw-workflow) {})
-          _            (when (seq error-groups)
-                         (validate-error-groups! error-groups cells))
-          edges        (if (seq error-groups)
-                         (expand-error-group-edges edges error-groups)
-                         edges)
-          dispatches   (if (seq error-groups)
-                         (inject-error-group-dispatches dispatches error-groups edges)
-                         dispatches)]
-      ;; Validate :default edge usage (must not be sole edge)
-      (validate-default-edges! edges)
-      ;; Normalize to {name → cell-id} for all downstream validation
-      (let [cell-ids (cells->ids cells)]
-        ;; Validate :input-schema well-formedness if present
-        (when input-schema
-          (v/validate-malli-schema! input-schema "input-schema"))
-        ;; Validate :resilience policies if present
-        (when-let [resilience (:resilience raw-workflow)]
-          (resilience/validate-resilience! resilience cell-ids))
-        ;; Validate join definitions
-        (let [joins-map (or joins {})]
-          (when (seq joins-map)
-            (validate-join-defs! joins-map cell-ids edges)
-            (validate-join-output-conflicts! joins-map cell-ids))
-          ;; For edge-target and reachability validation, include join names as valid targets
-          (let [cell-names     (set (keys cell-ids))
-                join-names     (set (keys joins-map))
-                join-members   (set (mapcat :cells (vals joins-map)))
-                edge-cell-names (set/difference cell-names join-members)
-                valid-names    (set/union edge-cell-names join-names)]
-            (v/validate-edge-targets! edges valid-names)
-            (v/validate-reachability! edges valid-names))
-          ;; Merge default dispatches — include join default dispatches (filtered to match edge keys)
-          ;; Also auto-inject :default catch-all predicates
-          ;; Join dispatches take priority (merged last) since joins compute their own dispatches
-          (let [timeouts-map        (or (:timeouts raw-workflow) {})
-                with-timeouts      (inject-timeout-dispatches dispatches timeouts-map edges)
-                with-defaults      (inject-default-dispatches with-timeouts edges)
-                join-dispatches    (compute-join-dispatches joins-map edges)
-                effective-dispatches (merge (merge-default-dispatches with-defaults edges cell-ids)
-                                            join-dispatches)]
-            (v/validate-dispatch-coverage! edges effective-dispatches))
-          ;; Validate transforms before schema chain (transforms affect key availability)
-          (when-let [transforms (:transforms raw-workflow)]
-            (validate-transforms! transforms cells edges))
-          (validate-schema-chain! edges cell-ids joins-map (:transforms raw-workflow))
-          ;; Validate graph-level timeouts
-          (when-let [timeouts (:timeouts raw-workflow)]
-            (validate-timeouts! timeouts cells edges))
-          ;; Validate constraints (after all structural validations pass)
-          (when-let [constraints (:constraints raw-workflow)]
-            (validate-constraints! constraints edges)))))))
+   Merges :default-dispatches from cell specs as fallback for cells without explicit dispatches.
+   Returns resolved cell specs keyed by workflow cell name for reuse during compilation.
+   opts:
+     :malli/registry — local Malli registry used to resolve named schemas."
+  ([raw-workflow]
+   (validate-workflow raw-workflow {}))
+  ([raw-workflow opts]
+   (let [{:keys [cells edges dispatches joins input-schema]}
+         (expand-pipeline raw-workflow)]
+     (validate-cells-exist! cells)
+     (let [error-groups (or (:error-groups raw-workflow) {})
+           _            (when (seq error-groups)
+                          (validate-error-groups! error-groups cells))
+           edges        (if (seq error-groups)
+                          (expand-error-group-edges edges error-groups)
+                          edges)
+           dispatches   (if (seq error-groups)
+                          (inject-error-group-dispatches
+                           dispatches error-groups edges)
+                          dispatches)]
+       (validate-default-edges! edges)
+       (let [cell-ids        (cells->ids cells)
+             resolved        (resolve-cells cell-ids opts)
+             joins-map       (or joins {})
+             cell-names      (set (keys cell-ids))
+             join-names      (set (keys joins-map))
+             join-members    (set (mapcat :cells (vals joins-map)))
+             edge-cell-names (set/difference cell-names join-members)
+             valid-names     (set/union edge-cell-names join-names)]
+         (when input-schema
+           (v/validate-malli-schema! input-schema "input-schema" opts))
+         (when-let [resilience (:resilience raw-workflow)]
+           (resilience/validate-resilience! resilience cell-ids))
+         (when (seq joins-map)
+           (validate-join-defs! joins-map cell-ids edges)
+           (validate-join-output-conflicts! joins-map resolved))
+         (v/validate-edge-targets! edges valid-names)
+         (v/validate-reachability! edges valid-names)
+         (let [timeouts-map (or (:timeouts raw-workflow) {})
+               with-timeouts (inject-timeout-dispatches
+                              dispatches timeouts-map edges)
+               with-defaults (inject-default-dispatches with-timeouts edges)
+               join-dispatches (compute-join-dispatches joins-map edges)
+               effective-dispatches
+               (merge (merge-default-dispatches
+                       with-defaults edges cell-ids)
+                      join-dispatches)]
+           (v/validate-dispatch-coverage! edges effective-dispatches))
+         (when-let [transforms (:transforms raw-workflow)]
+           (validate-transforms! transforms cells edges opts))
+         (let [resolved-transforms
+               (some-> (:transforms raw-workflow)
+                       (resolve-transforms opts))]
+           (validate-schema-chain!
+            edges resolved joins-map resolved-transforms))
+         (when-let [timeouts (:timeouts raw-workflow)]
+           (validate-timeouts! timeouts cells edges))
+         (when-let [constraints (:constraints raw-workflow)]
+           (validate-constraints! constraints edges))
+         resolved)))))
 
 ;; ===== Edge transform validation & compilation =====
 
 (defn- validate-transform-spec!
   "Validates a single transform spec {:fn f, :schema {:input [...] :output [...]}}."
-  [cell-name label spec]
+  [cell-name label spec opts]
   (when-not (and (map? spec) (ifn? (:fn spec)))
     (throw (ex-info (str "Transform " label " on cell " cell-name " must be a function (:fn key required)")
                     {:cell-name cell-name :label label :spec spec})))
   (when-let [schema (:schema spec)]
     (when (:input schema)
-      (v/validate-malli-schema! (:input schema) (str "Transform " label " on " cell-name " :input")))
+      (v/validate-malli-schema!
+       (:input schema) (str "Transform " label " on " cell-name " :input") opts))
     (when (:output schema)
-      (v/validate-malli-schema! (:output schema) (str "Transform " label " on " cell-name " :output")))))
+      (v/validate-malli-schema!
+       (:output schema) (str "Transform " label " on " cell-name " :output") opts))))
 
 (defn- validate-transforms!
   "Validates the :transforms map at compile time.
    Each key must be a valid cell name, edge labels must match the cell's edges,
    and transform specs must have :fn (function) and optional :schema."
-  [transforms cells edges]
+  [transforms cells edges opts]
   (let [cell-names (set (keys cells))]
     (doseq [[cell-name transform-def] transforms]
       (when-not (contains? cell-names cell-name)
@@ -1040,7 +1082,7 @@
           (doseq [[k v] transform-def]
             (cond
               (= k :input)
-              (validate-transform-spec! cell-name :input v)
+              (validate-transform-spec! cell-name :input v opts)
 
               (contains? edge-def k)
               (do
@@ -1048,8 +1090,12 @@
                   (throw (ex-info (str "Transform edge " k " on cell " cell-name
                                        " must be a map with :input/:output keys")
                                   {:cell-name cell-name :label k :value v})))
-                (when (:input v) (validate-transform-spec! cell-name (str k " :input") (:input v)))
-                (when (:output v) (validate-transform-spec! cell-name (str k " :output") (:output v))))
+                (when (:input v)
+                  (validate-transform-spec!
+                   cell-name (str k " :input") (:input v) opts))
+                (when (:output v)
+                  (validate-transform-spec!
+                   cell-name (str k " :output") (:output v) opts)))
 
               :else
               (throw (ex-info (str "Transform on cell " cell-name " has invalid edge label " k
@@ -1062,9 +1108,11 @@
                                    ". Unconditional cells only support :input and :output")
                               {:cell-name cell-name :invalid-keys invalid-keys})))
             (when (:input transform-def)
-              (validate-transform-spec! cell-name :input (:input transform-def)))
+              (validate-transform-spec!
+               cell-name :input (:input transform-def) opts))
             (when (:output transform-def)
-              (validate-transform-spec! cell-name :output (:output transform-def)))))))))
+              (validate-transform-spec!
+               cell-name :output (:output transform-def) opts))))))))
 
 (defn- build-transform-maps
   "Builds input and output transform lookup maps from the :transforms workflow key.
@@ -1232,11 +1280,11 @@
    Returns the compiled (ready-to-run) FSM."
   ([workflow] (compile-workflow workflow {}))
   ([raw-workflow opts]
-   (let [{:keys [cells edges dispatches joins] :as workflow} (expand-pipeline raw-workflow)]
-     ;; Validate
-     (validate-workflow workflow)
-     (let [;; Expand error groups (edges + dispatches) before other processing
-           error-groups (or (:error-groups workflow) {})
+   (let [{:keys [cells edges dispatches joins] :as workflow}
+         (expand-pipeline raw-workflow)
+         resolved (validate-workflow workflow opts)
+         ;; Expand error groups before other processing.
+         error-groups (or (:error-groups workflow) {})
            edges        (if (seq error-groups)
                           (expand-error-group-edges edges error-groups)
                           edges)
@@ -1258,16 +1306,18 @@
                                      join-dispatches)
          ;; Build state->cell map for non-join-member cells
          state->cell (into {}
-                           (keep (fn [[cell-name cell-id]]
+                           (keep (fn [[cell-name _]]
                                    (when-not (contains? join-members cell-name)
                                      [(resolve-state-id cell-name)
-                                      (cell/get-cell! cell-id)])))
+                                      (get resolved cell-name)])))
                            cell-ids)
          ;; Build synthetic join cell specs for state->cell
          join-cell-specs (into {}
                                (map (fn [[join-name join-def]]
-                                      (let [handler   (build-join-handler join-name join-def cell-ids)
-                                            in-schema (build-join-input-schema join-def cell-ids)]
+                                      (let [handler (build-join-handler
+                                                     join-name join-def resolved)
+                                            in-schema (build-join-input-schema
+                                                       join-def resolved)]
                                         [(resolve-state-id join-name)
                                          {:id       (keyword "mycelium.join" (name join-name))
                                           :handler  handler
@@ -1277,7 +1327,7 @@
                                joins-map)
          state->cell (merge state->cell join-cell-specs)
          ;; Pre-compile all Malli schemas so interceptors use compiled objects
-         state->cell (schema/pre-compile-schemas state->cell)
+         state->cell (schema/pre-compile-schemas state->cell opts)
          ;; Apply params wrapping for parameterized cells
          state->cell (reduce (fn [acc [cell-name params]]
                                (let [state-id (resolve-state-id cell-name)]
@@ -1330,7 +1380,7 @@
                              joins-map))
          ;; Build Maestro FSM states — non-join-member cells only
          fsm-cell-states (into {}
-                               (keep (fn [[cell-name cell-id]]
+                               (keep (fn [[cell-name _]]
                                        (when-not (contains? join-members cell-name)
                                          (let [state-id  (resolve-state-id cell-name)
                                                cell      (get state->cell state-id)
@@ -1390,4 +1440,4 @@
        (let [names (mapv #(get state->names % %) (:no-path-to-end analysis))]
          (throw (ex-info (str "States with no path to end: " names)
                          {:no-path-to-end names :analysis analysis}))))
-     (fsm/compile spec)))))
+     (fsm/compile spec))))

--- a/src/mycelium/workflow.clj
+++ b/src/mycelium/workflow.clj
@@ -488,10 +488,9 @@
           edges-map))
 
 (defn- resolve-schema-form
-  "Normalizes top-level lite syntax and compiles one transform schema."
+  "Compiles one transform schema; lite maps compile like any other form."
   [form opts]
-  (some-> (if (map? form) (schema/normalize-schema form) form)
-          (schema/compile-schema opts)))
+  (schema/compile-schema form opts))
 
 (defn- resolve-transform-spec [spec opts]
   (if-let [schemas (:schema spec)]

--- a/test/mycelium/lite_schema_test.clj
+++ b/test/mycelium/lite_schema_test.clj
@@ -1,5 +1,7 @@
 (ns mycelium.lite-schema-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [malli.registry :as mr]
             [mycelium.cell :as cell]
             [mycelium.core :as myc]
             [mycelium.manifest :as manifest]
@@ -7,105 +9,64 @@
 
 (use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
 
-;; ===== 1. normalize-schema: basic lite map conversion =====
+;; ===== 1. compile-schema: lite maps compile via malli's lite syntax =====
 
-(deftest normalize-schema-basic-test
-  (testing "Converts {key type} map to [:map [key type] ...]"
+(deftest compile-schema-lite-test
+  (testing "Plain maps compile as [:map ...] via malli.experimental.lite"
     (is (= [:map [:subtotal :double] [:state :string]]
-           (schema/normalize-schema {:subtotal :double :state :string}))))
+           (m/form (schema/compile-schema {:subtotal :double :state :string})))))
 
-  (testing "Nested maps are recursively converted"
+  (testing "Nested maps compile recursively"
     (is (= [:map [:address [:map [:street :string] [:city :string]]]]
-           (schema/normalize-schema {:address {:street :string :city :string}}))))
+           (m/form (schema/compile-schema {:address {:street :string :city :string}})))))
 
-  (testing "Vector schemas pass through unchanged"
+  (testing "Vector values inside lite maps are Malli and compile as-is"
+    (is (= [:map [:items [:vector :string]] [:count :int]]
+           (m/form (schema/compile-schema {:items [:vector :string] :count :int})))))
+
+  (testing "Malli forms compile unchanged"
     (is (= [:map [:x :int]]
-           (schema/normalize-schema [:map [:x :int]]))))
-
-  (testing "Keyword schemas pass through unchanged"
-    (is (= :int (schema/normalize-schema :int))))
+           (m/form (schema/compile-schema [:map [:x :int]])))))
 
   (testing "nil passes through"
-    (is (nil? (schema/normalize-schema nil))))
+    (is (nil? (schema/compile-schema nil))))
 
-  (testing "Compound type values (vectors) pass through as values"
-    (is (= [:map [:items [:vector :string]] [:count :int]]
-           (schema/normalize-schema {:items [:vector :string] :count :int})))))
+  (testing "Already-compiled schemas pass through identically"
+    (let [c (schema/compile-schema {:x :int})]
+      (is (identical? c (schema/compile-schema c)))))
 
-;; ===== 2. normalize-output-schema: dispatched vs single =====
+  (testing "Lite maps resolve values against a local registry"
+    (let [reg (mr/composite-registry (m/default-schemas) {:test/id :uuid})
+          c   (schema/compile-schema {:id :test/id} {:malli/registry reg})]
+      (is (true? (m/validate c {:id (random-uuid)})))
+      (is (false? (m/validate c {:id "not-a-uuid"}))))))
 
-(deftest normalize-output-schema-test
-  (testing "Map output is normalized as lite syntax"
-    (is (= [:map [:tax :double]]
-           (schema/normalize-output-schema {:tax :double}))))
+;; ===== 2. Registration stores schemas verbatim =====
 
-  (testing "Explicit per-transition wrapper normalizes each transition value"
-    (is (= [:per-transition {:success [:map [:result :string]]
-                             :failure [:map [:error :string]]}]
-           (schema/normalize-output-schema
-            [:per-transition {:success {:result :string}
-                              :failure {:error  :string}}]))))
-
-  (testing "Per-transition wrapper with already-normalized Malli vectors passes through"
-    (is (= [:per-transition {:high [:map [:result [:= :high]]]
-                             :low  [:map [:result [:= :low]]]}]
-           (schema/normalize-output-schema
-            [:per-transition {:high [:map [:result [:= :high]]]
-                              :low  [:map [:result [:= :low]]]}]))))
-
-  (testing "Plain map output is always lite syntax, even when values are vectors"
-    (is (= [:map
-            [:high [:map [:result [:= :high]]]]
-            [:low  [:map [:result [:= :low]]]]]
-           (schema/normalize-output-schema
-            {:high [:map [:result [:= :high]]]
-             :low  [:map [:result [:= :low]]]}))))
-
-  (testing "Malformed [:per-transition ...] wrapper is rejected"
-    (is (thrown-with-msg? Exception #"Malformed \[:per-transition"
-          (schema/normalize-output-schema [:per-transition]))))
-
-  (testing "Vector output passes through"
-    (is (= [:map [:x :int]]
-           (schema/normalize-output-schema [:map [:x :int]]))))
-
-  (testing "nil output passes through"
-    (is (nil? (schema/normalize-output-schema nil)))))
-
-;; ===== 3. defcell with lite syntax =====
-
-(deftest defcell-lite-schema-test
-  (testing "defcell normalizes lite input schema"
-    (cell/defcell :test/lite-input
-      {:doc    "Sums x and y"
-       :input {:x :int :y :int}
-       :output [:map [:sum :int]]}
-      (fn [_ data] {:sum (+ (:x data) (:y data))}))
-    (let [spec (cell/get-cell :test/lite-input)]
-      (is (= [:map [:x :int] [:y :int]]
-             (get-in spec [:schema :input])))))
-
-  (testing "defcell normalizes lite output schema"
-    (cell/defcell :test/lite-output
-      {:doc    "Doubles x"
-       :input [:map [:x :int]]
-       :output {:doubled :int}}
-      (fn [_ data] {:doubled (* 2 (:x data))}))
-    (let [spec (cell/get-cell :test/lite-output)]
-      (is (= [:map [:doubled :int]]
-             (get-in spec [:schema :output])))))
-
-  (testing "defcell normalizes both input and output lite schemas"
+(deftest defcell-stores-schemas-verbatim-test
+  (testing "Lite input and output schemas are stored as written"
     (cell/defcell :test/lite-both
       {:doc    "Increments x into y"
        :input  {:x :int}
        :output {:y :int}}
       (fn [_ data] {:y (inc (:x data))}))
     (let [spec (cell/get-cell :test/lite-both)]
-      (is (= [:map [:x :int]] (get-in spec [:schema :input])))
-      (is (= [:map [:y :int]] (get-in spec [:schema :output])))))
+      (is (= {:x :int} (get-in spec [:schema :input])))
+      (is (= {:y :int} (get-in spec [:schema :output])))))
 
-  (testing "defcell with explicit per-transition output is preserved"
+  (testing "Malli property maps are stored as written"
+    (cell/defcell :test/bounded-email
+      {:doc    "Validates a bounded email"
+       :input  [:map [:email [:string {:min 5}]]]
+       :output [:map {:closed true} [:ok :boolean]]}
+      (fn [_ _] {:ok true}))
+    (let [spec (cell/get-cell :test/bounded-email)]
+      (is (= [:map [:email [:string {:min 5}]]]
+             (get-in spec [:schema :input])))
+      (is (= [:map {:closed true} [:ok :boolean]]
+             (get-in spec [:schema :output])))))
+
+  (testing "Explicit per-transition output is stored as written"
     (cell/defcell :test/per-transition
       {:doc    "Classifies x as high or low"
        :input  {:x :int}
@@ -115,37 +76,28 @@
         {:result (if (> (:x data) 10) :high :low)}))
     (let [output (get-in (cell/get-cell :test/per-transition) [:schema :output])]
       (is (= :per-transition (first output)))
-      (is (= #{:high :low} (set (keys (second output))))))))
+      (is (= #{:high :low} (set (keys (second output)))))))
 
-;; ===== 4. set-cell-schema! with lite syntax =====
-
-(deftest set-cell-schema-lite-test
-  (testing "set-cell-schema! normalizes lite schemas"
+  (testing "set-cell-schema! stores lite schemas as written"
     (cell/defcell :test/schema-override
       {:doc "Increments x into y"}
       (fn [_ data] {:y (inc (:x data))}))
     (cell/set-cell-schema! :test/schema-override
                            {:input {:x :int} :output {:y :int}})
     (let [spec (cell/get-cell :test/schema-override)]
-      (is (= [:map [:x :int]] (get-in spec [:schema :input])))
-      (is (= [:map [:y :int]] (get-in spec [:schema :output]))))))
+      (is (= {:x :int} (get-in spec [:schema :input])))
+      (is (= {:y :int} (get-in spec [:schema :output]))))))
 
-;; ===== 5. set-cell-meta! receives pre-normalized schemas from manifest =====
+;; ===== 3. Malformed per-transition wrapper is rejected at compile =====
 
-(deftest set-cell-meta-normalized-test
-  (testing "set-cell-meta! works with pre-normalized lite schemas"
-    (cell/defcell :test/meta-override
-      {:doc "Passthrough cell for meta override testing"}
-      (fn [_ data] data))
-    ;; Simulate what manifest->workflow does: normalize first, then set-cell-meta!
-    (let [normalized (schema/normalize-cell-schema
-                       {:input {:name :string} :output {:greeting :string}})]
-      (cell/set-cell-meta! :test/meta-override {:schema normalized})
-      (let [spec (cell/get-cell :test/meta-override)]
-        (is (= [:map [:name :string]] (get-in spec [:schema :input])))
-        (is (= [:map [:greeting :string]] (get-in spec [:schema :output])))))))
+(deftest malformed-per-transition-test
+  (testing "A bad [:per-transition ...] wrapper throws with a helpful message"
+    (is (thrown-with-msg? Exception #"Malformed \[:per-transition"
+          (schema/compile-cell-schemas
+           {:id :test/bad :schema {:output [:per-transition]}}
+           {})))))
 
-;; ===== 6. End-to-end: workflow with lite schemas runs correctly =====
+;; ===== 4. End-to-end: workflows with lite schemas =====
 
 (deftest lite-schema-workflow-e2e-test
   (testing "Workflow runs with lite schemas in defcell"
@@ -187,7 +139,36 @@
                      {} {:x "not-an-int" :y 5} {:on-error on-error})]
       (is (some? (myc/workflow-error result))))))
 
-;; ===== 7. Manifest loading with lite schemas =====
+;; ===== 5. End-to-end: Malli property maps =====
+
+(deftest property-map-workflow-e2e-test
+  (testing "Workflow runs with a property-carrying input schema"
+    (cell/defcell :test/min-length
+      {:doc    "Echoes a name at least three characters long"
+       :input  [:map [:name [:string {:min 3}]]]
+       :output {:seen :string}}
+      (fn [_ data] {:seen (:name data)}))
+    (let [workflow {:cells {:start :test/min-length}
+                    :edges {:start :end}}
+          ok        (myc/run-workflow workflow {} {:name "Alice"})
+          too-short (myc/run-workflow workflow {} {:name "Al"}
+                                      {:on-error (fn [_ fsm-state] (:data fsm-state))})]
+      (is (nil? (myc/workflow-error ok)))
+      (is (= "Alice" (:seen ok)))
+      (is (some? (myc/workflow-error too-short)))))
+
+  (testing "Lite maps inside Malli vector forms are rejected by Malli at compile"
+    ;; The two dialects cannot be mixed; every mixed form is invalid Malli.
+    (cell/defcell :test/mixed
+      {:doc    "Mixes dialects illegally"
+       :input  :map
+       :output [:vector {:x :int}]}
+      (fn [_ data] data))
+    (is (thrown? Exception
+          (myc/pre-compile {:cells {:start :test/mixed}
+                            :edges {:start :end}})))))
+
+;; ===== 6. Manifest loading with lite schemas =====
 
 (deftest manifest-lite-schema-test
   (testing "Manifest with lite schemas validates via manifest->workflow"
@@ -202,15 +183,13 @@
                               :on-error nil}}
              :edges {:start :end}
              :input-schema {:x :int}}
-          ;; validate-manifest normalizes lite schemas
           validated (manifest/validate-manifest m {:strict? true})
-          ;; manifest->workflow injects schemas into cells
           wf-def   (manifest/manifest->workflow validated)
           result   (myc/run-workflow wf-def {} {:x 5})]
       (is (nil? (myc/workflow-error result)))
       (is (= 10 (:result result)))))
 
-  (testing "Manifest with per-transition lite schemas normalizes correctly"
+  (testing "Manifest with per-transition lite schemas works end to end"
     (cell/defcell :test/branch
       {:doc "Classifies x as positive or negative"}
       (fn [_ data]
@@ -230,7 +209,6 @@
                                   [:negative (fn [d] (= :negative (:sign d)))]]}}
           validated (manifest/validate-manifest m {:strict? true})
           wf-def   (manifest/manifest->workflow validated)]
-      ;; Per-transition output with lite values should work
       (let [result (myc/run-workflow wf-def {} {:x 5})]
         (is (nil? (myc/workflow-error result)))
         (is (= :positive (:sign result)))))))

--- a/test/mycelium/registry_test.clj
+++ b/test/mycelium/registry_test.clj
@@ -1,0 +1,263 @@
+(ns mycelium.registry-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [malli.registry :as mr]
+            [mycelium.cell :as cell]
+            [mycelium.compose :as compose]
+            [mycelium.core :as myc]
+            [mycelium.dev :as dev]
+            [mycelium.manifest :as manifest]
+            [mycelium.orchestrate :as orchestrate]
+            [mycelium.workflow :as wf]))
+
+(use-fixtures :each (fn [f] (cell/clear-registry!) (f)))
+
+(def custom-schemas
+  {:test/id             :uuid
+   :test/request        [:map [:id :test/id]]
+   :test/response       [:map [:id :test/id] [:status [:= :loaded]]]
+   :test/audit-input    [:map [:id :test/id] [:status [:= :loaded]] [:actor :string]]
+   :test/optional-input [:map [:optional-value {:optional true} :string]]
+   :test/done-output    [:map [:done :boolean]]})
+
+(def registry-opts {:malli/registry (mr/composite-registry (m/default-schemas) custom-schemas)})
+
+(defn- capture-error [f]
+  (try
+    (f)
+    nil
+    (catch Exception e
+      e)))
+
+(deftest cell-schema-setter-uses-local-registry-test
+  (defmethod cell/cell-spec :test/set-schema [_] {:id :test/set-schema :handler (fn [_ data] data)})
+  (let [schema-map {:input :test/request :output :test/response}]
+    (is (= schema-map (cell/set-cell-schema! :test/set-schema schema-map registry-opts)))))
+
+(defn- register-load-cell! []
+  (defmethod cell/cell-spec :test/load [_]
+    {:id      :test/load
+     :doc     "Loads a test record."
+     :handler (fn [_ data] (assoc data :status (if (:bad-output data) "loaded" :loaded)))
+     :schema  {:input [:ref :test/request] :output [:ref :test/response]}}))
+
+(defn- manifest-cell [id doc input output]
+  {:id id :doc doc :schema {:input input :output output} :on-error nil})
+
+(def custom-manifest
+  {:id           :test/manifest
+   :input-schema :test/request
+   :cells        {:start (manifest-cell :test/load "Loads." :test/request :test/response)}
+   :edges        {:start :end}})
+
+(def custom-fragment
+  {:id    :test/fragment
+   :entry :part
+   :exits [:done]
+   :cells {:part (manifest-cell :test/load "Loads." :test/request :test/response)}
+   :edges {:part :_exit/done}})
+
+(def custom-fragment-manifest
+  {:id        :test/fragment-host
+   :cells     {:finish (manifest-cell :test/finish "Finishes." :test/response :test/response)}
+   :edges     {:finish :end}
+   :fragments {:loader {:fragment custom-fragment :as :start :exits {:done :finish}}}})
+
+(deftest pre-compile-propagates-local-registry-test
+  (testing "one registry compiles workflow input, cell, and transform schemas"
+    (register-load-cell!)
+    (let [workflow  {:input-schema :test/request
+                     :cells        {:start :test/load}
+                     :edges        {:start :end}
+                     :transforms   {:start
+                                    {:input
+                                     {:fn     identity
+                                      :schema {:input  :test/request
+                                               :output :test/request}}
+                                     :output
+                                     {:fn     identity
+                                      :schema {:input  :test/response
+                                               :output :test/response}}}}}
+          compiled  (myc/pre-compile
+                     workflow
+                     (assoc registry-opts
+                            :on-error (fn [_ fsm-state]
+                                        (:data fsm-state))))
+          id        (random-uuid)
+          valid     (myc/run-compiled compiled {} {:id id})
+          bad-input (myc/run-compiled compiled {} {:id "invalid"})
+          bad-output (myc/run-compiled compiled
+                                       {}
+                                       {:id id :bad-output true})]
+      (is (= {:id id :status :loaded}
+             (select-keys valid [:id :status])))
+      (is (some? (:mycelium/input-error bad-input)))
+      (is (= :output
+             (get-in bad-output [:mycelium/schema-error :phase])))
+      (is (thrown? Exception (m/schema :test/request))))))
+
+(deftest schema-chain-resolves-local-registry-test
+  (testing "schema-chain errors include keys hidden behind registry references"
+    (register-load-cell!)
+    (defmethod cell/cell-spec :test/audit [_]
+      {:id      :test/audit
+       :handler (fn [_ data] data)
+       :schema  {:input  [:ref :test/audit-input]
+                 :output :map}})
+    (let [error (capture-error
+                 #(myc/pre-compile
+                   {:cells {:start :test/load
+                            :audit :test/audit}
+                    :edges {:start :audit
+                            :audit :end}}
+                   registry-opts))]
+      (is (= #{:actor}
+             (-> error ex-data :errors first :missing-keys))))))
+
+(deftest inline-local-registry-schema-runs-test
+  (testing "schema key extraction dereferences Malli's inline registry form"
+    (defmethod cell/cell-spec :test/inline-producer [_]
+      {:id      :test/inline-producer
+       :handler (fn [_ data] (assoc data :status :loaded))
+       :schema  {:input  :test/request
+                 :output [:schema
+                          {:registry custom-schemas}
+                          :test/response]}})
+    (defmethod cell/cell-spec :test/inline-consumer [_]
+      {:id      :test/inline-consumer
+       :handler (fn [_ data] data)
+       :schema  {:input  :test/response
+                 :output :test/response}})
+    (let [id     (random-uuid)
+          result (myc/run-workflow
+                  {:cells {:start :test/inline-producer
+                           :next  :test/inline-consumer}
+                   :edges {:start :next
+                           :next  :end}}
+                  {}
+                  {:id id}
+                  registry-opts)]
+      (is (= {:id id :status :loaded}
+             (select-keys result [:id :status]))))))
+
+(deftest invoke-cell-uses-local-registry-test
+  (register-load-cell!)
+  (defmethod cell/cell-spec :test/unchecked [_]
+    {:id      :test/unchecked
+     :handler (fn [_ data] (assoc data :invoked true))
+     :schema  {:input :test/unresolvable :output :test/unresolvable}})
+  (let [id           (random-uuid)
+        result       (myc/invoke-cell :test/load {} {:id id} registry-opts)
+        input-error  (capture-error #(myc/invoke-cell :test/load {}
+                                                      {:id "invalid"} registry-opts))
+        output-error (capture-error #(myc/invoke-cell :test/load {}
+                                                      {:id id :bad-output true} registry-opts))]
+    (is (= {:id id :status :loaded} (select-keys result [:id :status])))
+    (is (= :mycelium.invoke-cell/input-error (:type (ex-data input-error))))
+    (is (= :mycelium.invoke-cell/output-error (:type (ex-data output-error))))
+    (is (= {:invoked true} (myc/invoke-cell :test/unchecked {} {} {:validate :off})))))
+
+(deftest workflow-composition-uses-local-registry-test
+  (register-load-cell!)
+  (let [child          {:cells {:start :test/load} :edges {:start :end}}
+        spec           (compose/workflow->cell :test/composed child
+                                               {:input :test/request :output :map}
+                                               registry-opts)
+        success-schema (get-in spec [:schema :output 1 :success])
+        id             (random-uuid)]
+    (is (true? (m/validate success-schema {:id id :status :loaded})))
+    ;; Maps are open — this fails only if :status was inferred as required.
+    (is (false? (m/validate success-schema {:id id})))
+    (compose/register-workflow-cell!
+     :test/composed child {:input :test/request :output :map} registry-opts)
+    (let [result (myc/run-workflow
+                  {:cells {:start :test/composed}
+                   :edges {:start {:success :end :failure :error}}}
+                  {} {:id id} registry-opts)]
+      (is (= {:id id :status :loaded} (select-keys result [:id :status]))))))
+
+(deftest manifest-and-fragment-paths-use-local-registry-test
+  (register-load-cell!)
+  (is (= custom-manifest (manifest/validate-manifest custom-manifest registry-opts)))
+  (let [file (java.io.File/createTempFile "mycelium-registry-" ".edn")]
+    (try
+      (spit file (pr-str custom-fragment-manifest))
+      (is (= #{:start :finish}
+             (-> (manifest/load-manifest (.getPath file) registry-opts)
+                 :cells keys set)))
+      (finally
+        (.delete file))))
+  (let [workflow (manifest/manifest->workflow custom-manifest registry-opts)
+        id       (random-uuid)
+        result   (myc/run-workflow workflow {} {:id id} registry-opts)]
+    (is (= {:id id :status :loaded} (select-keys result [:id :status])))))
+
+(deftest generators-and-orchestration-use-local-registry-test
+  (register-load-cell!)
+  (let [brief    (manifest/cell-brief custom-manifest :start registry-opts)
+        status   (dev/workflow-status custom-manifest registry-opts)
+        progress (orchestrate/progress custom-manifest registry-opts)
+        inferred (dev/infer-workflow-schema
+                  {:cells {:start :test/load} :edges {:start :end}} registry-opts)]
+    (is (uuid? (get-in brief [:examples :input :id])))
+    (is (= [1 1] ((juxt :passing :total) status)))
+    (is (re-find #"\[PASS\]" progress))
+    (is (= #{:id :status} (get-in inferred [:start :available-after])))))
+
+(deftest join-input-preserves-optional-registry-entry-test
+  (testing "join synthesis does not make optional registry keys required"
+    (defmethod cell/cell-spec :test/join-start [_]
+      {:id      :test/join-start
+       :handler (fn [_ data] data)
+       :schema  {:input :map :output :map}})
+    (defmethod cell/cell-spec :test/optional-member [_]
+      {:id      :test/optional-member
+       :handler (fn [_ data] (assoc data :done true))
+       :schema  {:input  :test/optional-input
+                 :output :test/done-output}})
+    (let [result (myc/run-workflow
+                  {:cells {:start  :test/join-start
+                           :member :test/optional-member}
+                   :joins {:joined {:cells [:member]}}
+                   :edges {:start  :joined
+                           :joined :end}}
+                  {}
+                  {}
+                  registry-opts)]
+      (is (true? (:done result)))
+      (is (nil? (:mycelium/schema-error result))))))
+
+(deftest per-transition-schemas-use-local-registry-test
+  (testing "per-transition cell outputs compile against the local registry"
+    (defmethod cell/cell-spec :test/per-transition [_]
+      {:id      :test/per-transition
+       :handler (fn [_ data] (assoc data :status :loaded))
+       :schema  {:input  :test/request
+                 :output [:per-transition {:done :test/response}]}})
+    (let [id     (random-uuid)
+          result (myc/run-workflow
+                  {:cells      {:start :test/per-transition}
+                   :edges      {:start {:done :end}}
+                   :dispatches {:start [[:done (constantly true)]]}}
+                  {}
+                  {:id id}
+                  registry-opts)]
+      (is (= {:id id :status :loaded}
+             (select-keys result [:id :status]))))))
+
+(deftest invalid-cell-schema-error-is-labelled-test
+  (testing "boundary compilation names the cell with an unresolved reference"
+    (defmethod cell/cell-spec :test/invalid-schema [_]
+      {:id      :test/invalid-schema
+       :handler (fn [_ data] data)
+       :schema  {:input  :test/missing
+                 :output :map}})
+    (let [error (capture-error
+                 #(wf/validate-workflow
+                   {:cells {:start :test/invalid-schema}
+                    :edges {:start :end}}
+                   registry-opts))]
+      (is (re-find #"Invalid schema for cell :test/invalid-schema"
+                   (ex-message error)))
+      (is (= {:cell-id :test/invalid-schema}
+             (select-keys (ex-data error) [:cell-id]))))))


### PR DESCRIPTION
As discussed in #46, this PR allows users to use a non-global malli registry.

I considered two approaches when working on this.

The first threaded the registry option through every internal function that
reads a schema. It worked, but each new schema consumer would have to remember
to forward the option, and during review we found three places that already
forgot.

The second (this patch) resolves each cell's schemas once at the public entry
points and passes compiled schema objects inward, since a compiled Malli schema
carries its own registry. This way internal code never holds a schema it can't
interpret, so there is no option to forget.

FWIW this is technical a breaking change.. but I don't think it will affect anyone (it doesn't affect the examples, nor codeberg.org/yogthos/apparat)

1. Three public functions are deleted (`normalize-schema`, `normalize-output-schema`,
`normalize-cell-schema`). 
2. Stored schemas change shape: `(cell/get-cell :x)` now returns the lite map as written, not `[:map ...]`. This ripples into cell-brief prompts and generated stubs (they print what you wrote)
3. Mixed dialect forms that used to be silently rewritten now fail at compile, but they would have failed at runtime anyway. 


fixes #46
fixes #48