### PR TITLE
default validate-manifest to strict for all arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ filters out optional keys when computing a cell's required inputs.
    :output [:map [:done :boolean]]}
   ...)
 ```
+### Fix: `validate-manifest` is strict for every arity
+
+The docstring said `:strict?` (require `:on-error` on every cell) defaults to
+true, but the default only applied to the one-argument call. Passing any opts
+map without `:strict?` silently ran in lenient mode, so
+`(validate-manifest m {})` skipped the `:on-error` check entirely. The default
+now applies whenever `:strict?` is absent. If you were relying on the lenient
+behavior, pass `{:strict? false}` explicitly.
 
 ## 2026-03-07
 

--- a/src/mycelium/manifest.clj
+++ b/src/mycelium/manifest.clj
@@ -158,7 +158,7 @@
        (doseq [[cell-name cell-def] cells]
          (validate-cell-def! cell-name cell-def))
        ;; Validate :on-error declarations
-       (validate-on-error! cells (:strict? opts))
+       (validate-on-error! cells (:strict? opts true))
        ;; Determine join members — cells consumed by joins don't need edges
        (let [joins-map    (or joins {})
              join-members (set (mapcat :cells (vals joins-map)))

--- a/test/mycelium/manifest_test.clj
+++ b/test/mycelium/manifest_test.clj
@@ -527,3 +527,27 @@
           wf-def   (manifest/manifest->workflow validated)
           result   (myc/run-workflow wf-def {} {:x 21})]
       (is (= "val=42" (:result result))))))
+
+;; ===== Strict :on-error default applies to every arity =====
+
+(deftest validate-manifest-strict-default-test
+  (let [lenient-manifest {:id    :test/no-on-error
+                          :cells {:start {:id     :test/loose
+                                          :doc    "A cell without :on-error"
+                                          :schema {:input  [:map [:x :int]]
+                                                   :output [:map [:y :int]]}}}
+                          :edges {:start :end}}]
+    (testing "One-arity call is strict"
+      (is (thrown-with-msg? Exception #"missing :on-error"
+            (manifest/validate-manifest lenient-manifest))))
+
+    (testing "An opts map without :strict? is also strict, as documented"
+      (is (thrown-with-msg? Exception #"missing :on-error"
+            (manifest/validate-manifest lenient-manifest {})))
+      (is (thrown-with-msg? Exception #"missing :on-error"
+            (manifest/validate-manifest lenient-manifest {:unrelated :option}))))
+
+    (testing "Lenient mode still available with an explicit :strict? false"
+      (is (= :test/no-on-error
+             (:id (manifest/validate-manifest lenient-manifest
+                                              {:strict? false})))))))


### PR DESCRIPTION
The docstring promised :strict? defaults to true, but the default only existed
in the 1-arity delegation. Any opts map without :strict? read nil and silently
ran lenient, so (validate-manifest m {}) skipped the :on-error check. The
default now applies whenever the key is absent; lenient mode requires an
explicit {:strict? false}.

fixes #49
