### PR TITLE
docs: add Breaking changelog note for normalize-* removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ per-transition. The migration error message includes the exact
 rewrite for each cell that needs updating. EDN manifest files
 follow the same form.
 
+### Breaking: schemas stored verbatim; `normalize-*` functions removed
+
+Registration no longer rewrites schemas. `(cell/get-cell :id)` returns
+the schema exactly as written — a lite map like `{:name :string}` stays
+a map and is not converted to `[:map [:name :string]]`. Compilation runs
+lite maps through `malli.experimental.lite` itself, so the two dialects
+can no longer be mixed: a lite map nested inside a Malli vector form is
+invalid Malli and is rejected at compile time.
+
+The custom normalization layer is removed. Three previously public
+functions are gone: `normalize-schema`, `normalize-output-schema`, and
+`normalize-cell-schema`. Compile raw schema forms with
+`compile-schema` / `compile-cell-schemas` instead — both accept a
+`:malli/registry` and pass already-compiled schemas through untouched.
+
 ### Feature: custom Malli registries
 
 Compilation takes a `:malli/registry` option. Named schemas resolve against


### PR DESCRIPTION
Follow-up to #47 (merged) which closed #48.

That merge introduced two breaking changes that were documented only as a Fix/Feature entry, with no "Breaking" callout:

- Three public functions removed: `normalize-schema`, `normalize-output-schema`, `normalize-cell-schema`.
- Stored schemas change shape — `(cell/get-cell :id)` now returns the schema verbatim (lite maps stay maps) instead of the rewritten `[:map ...]` form.

This adds an explicit `### Breaking` section under `## Unreleased` so the migration is visible. It points users at `compile-schema` / `compile-cell-schemas`, which accept a `:malli/registry` and pass already-compiled schemas through.

Also filed #52 for the pre-existing `loan_processing` example compile failure (schema-chain rejects carried-through keys) — unrelated to this change but surfaced during the #48 review; left out of this docs PR since fixing the example is a separate design decision.