### PR TITLE
loan_processing: fix schema-chain compile failure

### DIFF
--- a/examples/loan_processing/src/loan/cells.clj
+++ b/examples/loan_processing/src/loan/cells.clj
@@ -30,10 +30,14 @@
                        [:applicant-name {:optional true} [:maybe :string]]
                        [:income {:optional true} [:maybe number?]]
                        [:loan-amount {:optional true} [:maybe number?]]]
-             :output [:per-transition {:valid   [:map [:validation-status [:= :valid]]]
-                      :invalid [:map
-                                [:validation-status [:= :invalid]]
-                                [:validation-errors [:vector :string]]]}]}})
+              :output [:per-transition {:valid   [:map
+                                     [:applicant-name :string]
+                                     [:income number?]
+                                     [:loan-amount number?]
+                                     [:validation-status [:= :valid]]]
+                       :invalid [:map
+                                 [:validation-status [:= :invalid]]
+                                 [:validation-errors [:vector :string]]]}]}})
 
 ;; ===== Credit Assessment (subworkflow cells) =====
 


### PR DESCRIPTION
The `loan_application` workflow failed to compile, throwing a schema-chain error at `pre-compile`:

```
Schema chain error: :loan/credit-assessment at :credit-assessment requires keys
#{:applicant-name} but only #{:validation-status} available; ...
```

Downstream cells (`credit-assessment`, `eligibility-decision`, `queue-for-review`, `audit-log`, `send-notification`) require `:applicant-name` and `:loan-amount`, but no cell declared them in its output.

These are workflow inputs. The `validate-application` start cell reads them from input and passes them through via `assoc`, but its `:valid` output schema only declared `:validation-status`. The schema-chain validator accumulates available keys from declared outputs, so `:applicant-name` and `:loan-amount` were never in scope downstream.

Fix: declare the carried-through keys (`:applicant-name`, `:income`, `:loan-amount`) in the `:valid` output transition. The `:invalid` branch routes to `:end`, so it is unchanged.

Verified: `clojure -M:test` in `examples/loan_processing` now passes (36 tests, 108 assertions, 0 failures) — previously 1 error, 0 failures.

This example was never run by CI (the workflow only tests `user_onboarding`), so the failure went unnoticed.

Closes #52